### PR TITLE
Add SearchFilter struct + SourceToMap function for Document content

### DIFF
--- a/types/kuzzle_request.go
+++ b/types/kuzzle_request.go
@@ -34,3 +34,9 @@ type Policy struct {
 type Policies struct {
 	Policies []Policy `json:"policies"`
 }
+
+type SearchFilters struct {
+	Query        interface{}   `json:"query,omitempty"`
+	Sort         []interface{} `json:"sort,omitempty"`
+	Aggregations interface{}   `json:"aggregations,omitempty"`
+}

--- a/types/kuzzle_response.go
+++ b/types/kuzzle_response.go
@@ -26,6 +26,10 @@ type (
 		Error     MessageError `json:"error"`
 	}
 
+	IKuzzleResult interface {
+		SourceToMap()
+	}
+
 	KuzzleResult struct {
 		Id      string          `json:"_id"`
 		Meta    KuzzleMeta      `json:"_meta"`
@@ -262,4 +266,13 @@ func (role Role) Controllers() map[string]struct {
 	json.Unmarshal(role.Source, &controllers)
 
 	return controllers.Controllers
+}
+
+func (sr KuzzleResult) SourceToMap() map[string]interface{} {
+	type SourceMap map[string]interface{}
+	sourceMap := SourceMap{}
+
+	json.Unmarshal(sr.Source, &sourceMap)
+
+	return sourceMap
 }


### PR DESCRIPTION
## SearchFilters usage:
```
var sort = make([]interface{}, 0)
sort = append(sort, map[string]interface{}{"price": "asc"})

type ExistsFilter struct {
	Field string `json:"field"`
}
type QueryFilters struct {
	Exists ExistsFilter `json:"exists"`
}

filters := types.SearchFilters{
	Query: QueryFilters{Exists: ExistsFilter{Field: "title"}},
	Sort: sort,
}

qo.SetSize(2)
qo.SetScroll("1m")

res, err := c.Search(filters, qo)
```
## SourceToMap usage:
```
fmt.Println(document.SourceToMap()["title"])
```

Open to suggestions