### PR TITLE
Merge types.Document and collection.CollectionDocument

### DIFF
--- a/collection/collection.go
+++ b/collection/collection.go
@@ -24,6 +24,6 @@ func NewCollection(kuzzle *kuzzle.Kuzzle, collection, index string) *Collection 
 func (dc Collection) CollectionDocument() CollectionDocument {
 	return CollectionDocument{
 		Collection: dc,
-		Document:   types.Document{Source: []byte(`{}`)},
+		Document:   types.Document{Content: []byte(`{}`)},
 	}
 }

--- a/collection/collection.go
+++ b/collection/collection.go
@@ -22,7 +22,7 @@ func NewCollection(kuzzle *kuzzle.Kuzzle, collection, index string) *Collection 
 
 func (dc Collection) Document() Document {
 	return Document{
-		Content: []byte(`{}`),
+		Content:    []byte(`{}`),
 		collection: dc,
 	}
 }

--- a/collection/collection.go
+++ b/collection/collection.go
@@ -2,7 +2,6 @@ package collection
 
 import (
 	"github.com/kuzzleio/sdk-go/kuzzle"
-	"github.com/kuzzleio/sdk-go/types"
 )
 
 type Collection struct {
@@ -21,9 +20,9 @@ func NewCollection(kuzzle *kuzzle.Kuzzle, collection, index string) *Collection 
 	}
 }
 
-func (dc Collection) CollectionDocument() CollectionDocument {
-	return CollectionDocument{
-		Collection: dc,
-		Document:   types.Document{Content: []byte(`{}`)},
+func (dc Collection) Document() Document {
+	return Document{
+		Content: []byte(`{}`),
+		collection: dc,
 	}
 }

--- a/collection/create_document.go
+++ b/collection/create_document.go
@@ -35,7 +35,7 @@ func (dc Collection) CreateDocument(id string, document types.Document, options 
 		Index:      dc.index,
 		Controller: "document",
 		Action:     action,
-		Body:       document.Source,
+		Body:       document.Content,
 		Id:         id,
 	}
 	go dc.Kuzzle.Query(query, options, ch)
@@ -82,7 +82,7 @@ func performMultipleCreate(dc Collection, documents []types.Document, action str
 	for _, doc := range documents {
 		docs = append(docs, CreationDocument{
 			Id:   doc.Id,
-			Body: doc.Source,
+			Body: doc.Content,
 		})
 	}
 

--- a/collection/create_document.go
+++ b/collection/create_document.go
@@ -17,7 +17,7 @@ import (
            - resolves with an error if set to "error".
            - replaces the existing document if set to "replace"
 */
-func (dc Collection) CreateDocument(id string, document types.Document, options types.QueryOptions) (types.Document, error) {
+func (dc Collection) CreateDocument(id string, document Document, options types.QueryOptions) (Document, error) {
 	ch := make(chan types.KuzzleResponse)
 
 	action := "create"
@@ -26,7 +26,7 @@ func (dc Collection) CreateDocument(id string, document types.Document, options 
 		if options.GetIfExist() == "replace" {
 			action = "createOrReplace"
 		} else if options.GetIfExist() != "error" {
-			return types.Document{}, errors.New(fmt.Sprintf("Invalid value for the 'ifExist' option: '%s'", options.GetIfExist()))
+			return Document{}, errors.New(fmt.Sprintf("Invalid value for the 'ifExist' option: '%s'", options.GetIfExist()))
 		}
 	}
 
@@ -43,10 +43,10 @@ func (dc Collection) CreateDocument(id string, document types.Document, options 
 	res := <-ch
 
 	if res.Error.Message != "" {
-		return types.Document{}, errors.New(res.Error.Message)
+		return Document{}, errors.New(res.Error.Message)
 	}
 
-	documentResponse := types.Document{}
+	documentResponse := Document{collection: dc}
 	json.Unmarshal(res.Result, &documentResponse)
 
 	return documentResponse, nil
@@ -55,18 +55,18 @@ func (dc Collection) CreateDocument(id string, document types.Document, options 
 /*
   Creates the provided documents.
 */
-func (dc Collection) MCreateDocument(documents []types.Document, options types.QueryOptions) (types.KuzzleSearchResult, error) {
+func (dc Collection) MCreateDocument(documents []Document, options types.QueryOptions) (KuzzleSearchResult, error) {
 	return performMultipleCreate(dc, documents, "mCreate", options)
 }
 
 /*
   Creates or replaces the provided documents.
 */
-func (dc Collection) MCreateOrReplaceDocument(documents []types.Document, options types.QueryOptions) (types.KuzzleSearchResult, error) {
+func (dc Collection) MCreateOrReplaceDocument(documents []Document, options types.QueryOptions) (KuzzleSearchResult, error) {
 	return performMultipleCreate(dc, documents, "mCreateOrReplace", options)
 }
 
-func performMultipleCreate(dc Collection, documents []types.Document, action string, options types.QueryOptions) (types.KuzzleSearchResult, error) {
+func performMultipleCreate(dc Collection, documents []Document, action string, options types.QueryOptions) (KuzzleSearchResult, error) {
 	ch := make(chan types.KuzzleResponse)
 
 	type CreationDocument struct {
@@ -98,11 +98,15 @@ func performMultipleCreate(dc Collection, documents []types.Document, action str
 	res := <-ch
 
 	if res.Error.Message != "" {
-		return types.KuzzleSearchResult{}, errors.New(res.Error.Message)
+		return KuzzleSearchResult{}, errors.New(res.Error.Message)
 	}
 
-	result := types.KuzzleSearchResult{}
+	result := KuzzleSearchResult{}
 	json.Unmarshal(res.Result, &result)
+
+	for _, d := range result.Hits {
+		d.collection = dc
+	}
 
 	return result, nil
 }

--- a/collection/create_document_test.go
+++ b/collection/create_document_test.go
@@ -19,7 +19,7 @@ func TestCreateDocumentError(t *testing.T) {
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)
 
-	_, err := collection.NewCollection(k, "collection", "index").CreateDocument("id", types.Document{Content: []byte(`{"title":"yolo"}`)}, nil)
+	_, err := collection.NewCollection(k, "collection", "index").CreateDocument("id", collection.Document{Content: []byte(`{"title":"yolo"}`)}, nil)
 	assert.NotNil(t, err)
 }
 
@@ -34,7 +34,7 @@ func TestCreateDocumentWrongOptionError(t *testing.T) {
 	opts := types.NewQueryOptions()
 	opts.SetIfExist("unknown")
 
-	_, err := newCollection.CreateDocument("id", types.Document{Content: []byte(`{"title":"yolo"}`)}, opts)
+	_, err := newCollection.CreateDocument("id", collection.Document{Content: []byte(`{"title":"yolo"}`)}, opts)
 	assert.Equal(t, "Invalid value for the 'ifExist' option: 'unknown'", fmt.Sprint(err))
 }
 
@@ -57,14 +57,14 @@ func TestCreateDocument(t *testing.T) {
 
 			assert.Equal(t, body, parsedQuery.Body)
 
-			res := types.Document{Id: id, Content: []byte(`{"title":"yolo"}`)}
+			res := collection.Document{Id: id, Content: []byte(`{"title":"yolo"}`)}
 			r, _ := json.Marshal(res)
 			return types.KuzzleResponse{Result: r}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)
 
-	res, _ := collection.NewCollection(k, "collection", "index").CreateDocument(id, types.Document{Content: []byte(`{"title":"yolo"}`)}, nil)
+	res, _ := collection.NewCollection(k, "collection", "index").CreateDocument(id, collection.Document{Content: []byte(`{"title":"yolo"}`)}, nil)
 	assert.Equal(t, id, res.Id)
 }
 
@@ -76,7 +76,7 @@ func TestCreateDocumentReplace(t *testing.T) {
 
 			assert.Equal(t, "createOrReplace", parsedQuery.Action)
 
-			res := types.Document{Id: "id", Content: []byte(`{"Title":"yolo"}`)}
+			res := collection.Document{Id: "id", Content: []byte(`{"Title":"yolo"}`)}
 			r, _ := json.Marshal(res)
 			return types.KuzzleResponse{Result: r}
 		},
@@ -86,7 +86,7 @@ func TestCreateDocumentReplace(t *testing.T) {
 	newCollection := collection.NewCollection(k, "collection", "index")
 	opts := types.NewQueryOptions()
 	opts.SetIfExist("replace")
-	newCollection.CreateDocument("id", types.Document{Content: []byte(`{"Title":"yolo"}`)}, opts)
+	newCollection.CreateDocument("id", collection.Document{Content: []byte(`{"Title":"yolo"}`)}, opts)
 }
 
 func TestCreateDocumentCreate(t *testing.T) {
@@ -97,7 +97,7 @@ func TestCreateDocumentCreate(t *testing.T) {
 
 			assert.Equal(t, "create", parsedQuery.Action)
 
-			res := types.Document{Id: "id", Content: []byte(`{"Title":"yolo"}`)}
+			res := collection.Document{Id: "id", Content: []byte(`{"Title":"yolo"}`)}
 			r, _ := json.Marshal(res)
 			return types.KuzzleResponse{Result: r}
 		},
@@ -108,11 +108,11 @@ func TestCreateDocumentCreate(t *testing.T) {
 	opts := types.NewQueryOptions()
 	opts.SetIfExist("error")
 
-	newCollection.CreateDocument("id", types.Document{Content: []byte(`{"Title":"yolo"}`)}, opts)
+	newCollection.CreateDocument("id", collection.Document{Content: []byte(`{"Title":"yolo"}`)}, opts)
 }
 
 func TestMCreateDocumentError(t *testing.T) {
-	documents := []types.Document{
+	documents := []collection.Document{
 		{Id: "foo", Content: []byte(`{"title":"Foo"}`)},
 		{Id: "bar", Content: []byte(`{"title":"Bar"}`)},
 	}
@@ -129,7 +129,7 @@ func TestMCreateDocumentError(t *testing.T) {
 }
 
 func TestMCreateDocument(t *testing.T) {
-	documents := []types.Document{
+	documents := []collection.Document{
 		{Id: "foo", Content: []byte(`{"title":"Foo"}`)},
 		{Id: "bar", Content: []byte(`{"title":"Bar"}`)},
 	}
@@ -144,12 +144,12 @@ func TestMCreateDocument(t *testing.T) {
 			assert.Equal(t, "index", parsedQuery.Index)
 			assert.Equal(t, "collection", parsedQuery.Collection)
 
-			results := []types.KuzzleResult{
+			results := []collection.Document{
 				{Id: "foo", Content: []byte(`{"title":"Foo"}`)},
 				{Id: "bar", Content: []byte(`{"title":"Bar"}`)},
 			}
 
-			res := types.KuzzleSearchResult{
+			res := collection.KuzzleSearchResult{
 				Total: 2,
 				Hits:  results,
 			}
@@ -169,7 +169,7 @@ func TestMCreateDocument(t *testing.T) {
 }
 
 func TestMCreateOrReplaceDocumentError(t *testing.T) {
-	documents := []types.Document{
+	documents := []collection.Document{
 		{Id: "foo", Content: []byte(`{"title":"Foo"}`)},
 		{Id: "bar", Content: []byte(`{"title":"Bar"}`)},
 	}
@@ -186,7 +186,7 @@ func TestMCreateOrReplaceDocumentError(t *testing.T) {
 }
 
 func TestMCreateOrReplaceDocument(t *testing.T) {
-	documents := []types.Document{
+	documents := []collection.Document{
 		{Id: "foo", Content: []byte(`{"title":"Foo"}`)},
 		{Id: "bar", Content: []byte(`{"title":"Bar"}`)},
 	}
@@ -201,12 +201,12 @@ func TestMCreateOrReplaceDocument(t *testing.T) {
 			assert.Equal(t, "index", parsedQuery.Index)
 			assert.Equal(t, "collection", parsedQuery.Collection)
 
-			results := []types.KuzzleResult{
+			results := []collection.Document{
 				{Id: "foo", Content: []byte(`{"title":"Foo"}`)},
 				{Id: "bar", Content: []byte(`{"title":"Bar"}`)},
 			}
 
-			res := types.KuzzleSearchResult{
+			res := collection.KuzzleSearchResult{
 				Total: 2,
 				Hits:  results,
 			}

--- a/collection/create_document_test.go
+++ b/collection/create_document_test.go
@@ -19,7 +19,7 @@ func TestCreateDocumentError(t *testing.T) {
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)
 
-	_, err := collection.NewCollection(k, "collection", "index").CreateDocument("id", types.Document{Source: []byte(`{"title":"yolo"}`)}, nil)
+	_, err := collection.NewCollection(k, "collection", "index").CreateDocument("id", types.Document{Content: []byte(`{"title":"yolo"}`)}, nil)
 	assert.NotNil(t, err)
 }
 
@@ -34,7 +34,7 @@ func TestCreateDocumentWrongOptionError(t *testing.T) {
 	opts := types.NewQueryOptions()
 	opts.SetIfExist("unknown")
 
-	_, err := newCollection.CreateDocument("id", types.Document{Source: []byte(`{"title":"yolo"}`)}, opts)
+	_, err := newCollection.CreateDocument("id", types.Document{Content: []byte(`{"title":"yolo"}`)}, opts)
 	assert.Equal(t, "Invalid value for the 'ifExist' option: 'unknown'", fmt.Sprint(err))
 }
 
@@ -57,14 +57,14 @@ func TestCreateDocument(t *testing.T) {
 
 			assert.Equal(t, body, parsedQuery.Body)
 
-			res := types.Document{Id: id, Source: []byte(`{"title":"yolo"}`)}
+			res := types.Document{Id: id, Content: []byte(`{"title":"yolo"}`)}
 			r, _ := json.Marshal(res)
 			return types.KuzzleResponse{Result: r}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)
 
-	res, _ := collection.NewCollection(k, "collection", "index").CreateDocument(id, types.Document{Source: []byte(`{"title":"yolo"}`)}, nil)
+	res, _ := collection.NewCollection(k, "collection", "index").CreateDocument(id, types.Document{Content: []byte(`{"title":"yolo"}`)}, nil)
 	assert.Equal(t, id, res.Id)
 }
 
@@ -76,7 +76,7 @@ func TestCreateDocumentReplace(t *testing.T) {
 
 			assert.Equal(t, "createOrReplace", parsedQuery.Action)
 
-			res := types.Document{Id: "id", Source: []byte(`{"Title":"yolo"}`)}
+			res := types.Document{Id: "id", Content: []byte(`{"Title":"yolo"}`)}
 			r, _ := json.Marshal(res)
 			return types.KuzzleResponse{Result: r}
 		},
@@ -86,7 +86,7 @@ func TestCreateDocumentReplace(t *testing.T) {
 	newCollection := collection.NewCollection(k, "collection", "index")
 	opts := types.NewQueryOptions()
 	opts.SetIfExist("replace")
-	newCollection.CreateDocument("id", types.Document{Source: []byte(`{"Title":"yolo"}`)}, opts)
+	newCollection.CreateDocument("id", types.Document{Content: []byte(`{"Title":"yolo"}`)}, opts)
 }
 
 func TestCreateDocumentCreate(t *testing.T) {
@@ -97,7 +97,7 @@ func TestCreateDocumentCreate(t *testing.T) {
 
 			assert.Equal(t, "create", parsedQuery.Action)
 
-			res := types.Document{Id: "id", Source: []byte(`{"Title":"yolo"}`)}
+			res := types.Document{Id: "id", Content: []byte(`{"Title":"yolo"}`)}
 			r, _ := json.Marshal(res)
 			return types.KuzzleResponse{Result: r}
 		},
@@ -108,13 +108,13 @@ func TestCreateDocumentCreate(t *testing.T) {
 	opts := types.NewQueryOptions()
 	opts.SetIfExist("error")
 
-	newCollection.CreateDocument("id", types.Document{Source: []byte(`{"Title":"yolo"}`)}, opts)
+	newCollection.CreateDocument("id", types.Document{Content: []byte(`{"Title":"yolo"}`)}, opts)
 }
 
 func TestMCreateDocumentError(t *testing.T) {
 	documents := []types.Document{
-		{Id: "foo", Source: []byte(`{"title":"Foo"}`)},
-		{Id: "bar", Source: []byte(`{"title":"Bar"}`)},
+		{Id: "foo", Content: []byte(`{"title":"Foo"}`)},
+		{Id: "bar", Content: []byte(`{"title":"Bar"}`)},
 	}
 
 	c := &internal.MockedConnection{
@@ -130,8 +130,8 @@ func TestMCreateDocumentError(t *testing.T) {
 
 func TestMCreateDocument(t *testing.T) {
 	documents := []types.Document{
-		{Id: "foo", Source: []byte(`{"title":"Foo"}`)},
-		{Id: "bar", Source: []byte(`{"title":"Bar"}`)},
+		{Id: "foo", Content: []byte(`{"title":"Foo"}`)},
+		{Id: "bar", Content: []byte(`{"title":"Bar"}`)},
 	}
 
 	c := &internal.MockedConnection{
@@ -145,8 +145,8 @@ func TestMCreateDocument(t *testing.T) {
 			assert.Equal(t, "collection", parsedQuery.Collection)
 
 			results := []types.KuzzleResult{
-				{Id: "foo", Source: []byte(`{"title":"Foo"}`)},
-				{Id: "bar", Source: []byte(`{"title":"Bar"}`)},
+				{Id: "foo", Content: []byte(`{"title":"Foo"}`)},
+				{Id: "bar", Content: []byte(`{"title":"Bar"}`)},
 			}
 
 			res := types.KuzzleSearchResult{
@@ -164,14 +164,14 @@ func TestMCreateDocument(t *testing.T) {
 
 	for index, doc := range res.Hits {
 		assert.Equal(t, documents[index].Id, doc.Id)
-		assert.Equal(t, documents[index].Source, doc.Source)
+		assert.Equal(t, documents[index].Content, doc.Content)
 	}
 }
 
 func TestMCreateOrReplaceDocumentError(t *testing.T) {
 	documents := []types.Document{
-		{Id: "foo", Source: []byte(`{"title":"Foo"}`)},
-		{Id: "bar", Source: []byte(`{"title":"Bar"}`)},
+		{Id: "foo", Content: []byte(`{"title":"Foo"}`)},
+		{Id: "bar", Content: []byte(`{"title":"Bar"}`)},
 	}
 
 	c := &internal.MockedConnection{
@@ -187,8 +187,8 @@ func TestMCreateOrReplaceDocumentError(t *testing.T) {
 
 func TestMCreateOrReplaceDocument(t *testing.T) {
 	documents := []types.Document{
-		{Id: "foo", Source: []byte(`{"title":"Foo"}`)},
-		{Id: "bar", Source: []byte(`{"title":"Bar"}`)},
+		{Id: "foo", Content: []byte(`{"title":"Foo"}`)},
+		{Id: "bar", Content: []byte(`{"title":"Bar"}`)},
 	}
 
 	c := &internal.MockedConnection{
@@ -202,8 +202,8 @@ func TestMCreateOrReplaceDocument(t *testing.T) {
 			assert.Equal(t, "collection", parsedQuery.Collection)
 
 			results := []types.KuzzleResult{
-				{Id: "foo", Source: []byte(`{"title":"Foo"}`)},
-				{Id: "bar", Source: []byte(`{"title":"Bar"}`)},
+				{Id: "foo", Content: []byte(`{"title":"Foo"}`)},
+				{Id: "bar", Content: []byte(`{"title":"Bar"}`)},
 			}
 
 			res := types.KuzzleSearchResult{
@@ -221,6 +221,6 @@ func TestMCreateOrReplaceDocument(t *testing.T) {
 
 	for index, doc := range res.Hits {
 		assert.Equal(t, documents[index].Id, doc.Id)
-		assert.Equal(t, documents[index].Source, doc.Source)
+		assert.Equal(t, documents[index].Content, doc.Content)
 	}
 }

--- a/collection/delete_document.go
+++ b/collection/delete_document.go
@@ -31,7 +31,7 @@ func (dc Collection) DeleteDocument(id string, options types.QueryOptions) (stri
 		return "", errors.New(res.Error.Message)
 	}
 
-	document := types.Document{}
+	document := Document{collection: dc}
 	json.Unmarshal(res.Result, &document)
 
 	return document.Id, nil

--- a/collection/delete_document_test.go
+++ b/collection/delete_document_test.go
@@ -52,7 +52,7 @@ func TestDeleteDocument(t *testing.T) {
 			assert.Equal(t, "collection", parsedQuery.Collection)
 			assert.Equal(t, id, parsedQuery.Id)
 
-			res := types.Document{Id: id}
+			res := collection.Document{Id: id}
 			r, _ := json.Marshal(res)
 			return types.KuzzleResponse{Result: r}
 		},

--- a/collection/document.go
+++ b/collection/document.go
@@ -43,7 +43,6 @@ func (d Document) SourceToMap() map[string]interface{} {
 	return sourceMap
 }
 
-
 /*
   Saves the document into Kuzzle.
 

--- a/collection/document.go
+++ b/collection/document.go
@@ -58,7 +58,7 @@ func (d Document) Fetch(id string) (Document, error) {
 		return d, errors.New("Document.Fetch: an error occurred: " + fmt.Sprint(err))
 	}
 
-	d.Id = doc.Id
+	d.Id = id
 	d.Meta = doc.Meta
 	d.Content = doc.Content
 	d.Version = doc.Version

--- a/collection/document.go
+++ b/collection/document.go
@@ -49,7 +49,7 @@ func (cd CollectionDocument) Save(options types.QueryOptions) (CollectionDocumen
 		Controller: "document",
 		Action:     "createOrReplace",
 		Id:         cd.Document.Id,
-		Body:       cd.Document.Source,
+		Body:       cd.Document.Content,
 	}
 
 	go cd.Collection.Kuzzle.Query(query, options, ch)
@@ -114,16 +114,16 @@ func (cd CollectionDocument) SetDocumentId(id string) CollectionDocument {
 */
 func (cd CollectionDocument) SetContent(content DocumentContent, replace bool) CollectionDocument {
 	if replace {
-		cd.Document.Source, _ = json.Marshal(content)
+		cd.Document.Content, _ = json.Marshal(content)
 	} else {
 		source := DocumentContent{}
-		json.Unmarshal(cd.Document.Source, &source)
+		json.Unmarshal(cd.Document.Content, &source)
 
 		for attr, value := range content {
 			source[attr] = value
 		}
 
-		cd.Document.Source, _ = json.Marshal(source)
+		cd.Document.Content, _ = json.Marshal(source)
 	}
 
 	return cd
@@ -160,7 +160,7 @@ func (cd CollectionDocument) Publish(options types.QueryOptions) (bool, error) {
 		Body: message{
 			Id:      cd.Document.Id,
 			Version: cd.Document.Version,
-			Body:    cd.Document.Source,
+			Body:    cd.Document.Content,
 			Meta:    cd.Document.Meta,
 		},
 	}

--- a/collection/document_test.go
+++ b/collection/document_test.go
@@ -16,9 +16,9 @@ func TestDocumentSetContent(t *testing.T) {
 	dc := collection.NewCollection(k, "collection", "index")
 
 	cd := dc.CollectionDocument()
-	cd.Document.Source = []byte(`{"foo":"bar","subfield":{"john":"smith"}}`)
+	cd.Document.Content = []byte(`{"foo":"bar","subfield":{"john":"smith"}}`)
 
-	assert.Equal(t, json.RawMessage([]byte(`{"foo":"bar","subfield":{"john":"smith"}}`)), cd.Document.Source)
+	assert.Equal(t, json.RawMessage([]byte(`{"foo":"bar","subfield":{"john":"smith"}}`)), cd.Document.Content)
 
 	cd = cd.SetContent(collection.DocumentContent{
 		"subfield": collection.DocumentContent{
@@ -26,7 +26,7 @@ func TestDocumentSetContent(t *testing.T) {
 		},
 	}, false)
 
-	assert.Equal(t, string(json.RawMessage([]byte(`{"foo":"bar","subfield":{"john":"cena"}}`))), string(cd.Document.Source))
+	assert.Equal(t, string(json.RawMessage([]byte(`{"foo":"bar","subfield":{"john":"cena"}}`))), string(cd.Document.Content))
 }
 
 func TestDocumentSetContentReplace(t *testing.T) {
@@ -34,9 +34,9 @@ func TestDocumentSetContentReplace(t *testing.T) {
 	dc := collection.NewCollection(k, "collection", "index")
 
 	cd := dc.CollectionDocument()
-	cd.Document.Source = []byte(`{"foo":"bar","subfield":{"john":"smith"}}`)
+	cd.Document.Content = []byte(`{"foo":"bar","subfield":{"john":"smith"}}`)
 
-	assert.Equal(t, json.RawMessage([]byte(`{"foo":"bar","subfield":{"john":"smith"}}`)), cd.Document.Source)
+	assert.Equal(t, json.RawMessage([]byte(`{"foo":"bar","subfield":{"john":"smith"}}`)), cd.Document.Content)
 
 	cd = cd.SetContent(collection.DocumentContent{
 		"subfield": collection.DocumentContent{
@@ -47,7 +47,7 @@ func TestDocumentSetContentReplace(t *testing.T) {
 		},
 	}, true)
 
-	assert.Equal(t, string(json.RawMessage([]byte(`{"subfield":{"john":"cena","subsubfield":{"hi":"there"}}}`))), string(cd.Document.Source))
+	assert.Equal(t, string(json.RawMessage([]byte(`{"subfield":{"john":"cena","subsubfield":{"hi":"there"}}}`))), string(cd.Document.Content))
 }
 
 func TestDocumentSetHeaders(t *testing.T) {
@@ -134,7 +134,7 @@ func TestDocumentSave(t *testing.T) {
 			assert.Equal(t, "collection", parsedQuery.Collection)
 			assert.Equal(t, id, parsedQuery.Id)
 
-			res := types.Document{Id: id, Source: []byte(`{"foo":"bar"}`)}
+			res := types.Document{Id: id, Content: []byte(`{"foo":"bar"}`)}
 			r, _ := json.Marshal(res)
 			return types.KuzzleResponse{Result: r}
 		},
@@ -142,13 +142,13 @@ func TestDocumentSave(t *testing.T) {
 	k, _ := kuzzle.NewKuzzle(c, nil)
 	dc := collection.NewCollection(k, "collection", "index")
 
-	documentSource := collection.DocumentContent{"foo": "bar"}
+	documentContent := collection.DocumentContent{"foo": "bar"}
 
-	cd, _ := dc.CollectionDocument().SetDocumentId(id).SetContent(documentSource, true).Save(nil)
+	cd, _ := dc.CollectionDocument().SetDocumentId(id).SetContent(documentContent, true).Save(nil)
 
 	assert.Equal(t, id, cd.Document.Id)
 	assert.Equal(t, dc, &cd.Collection)
-	assert.Equal(t, documentSource.ToString(), string(cd.Document.Source))
+	assert.Equal(t, documentContent.ToString(), string(cd.Document.Content))
 }
 
 func TestDocumentRefreshEmptyId(t *testing.T) {
@@ -187,7 +187,7 @@ func TestDocumentRefresh(t *testing.T) {
 			assert.Equal(t, "collection", parsedQuery.Collection)
 			assert.Equal(t, id, parsedQuery.Id)
 
-			res := types.Document{Id: id, Source: []byte(`{"name":"Anakin","function":"Jedi"}`)}
+			res := types.Document{Id: id, Content: []byte(`{"name":"Anakin","function":"Jedi"}`)}
 			r, _ := json.Marshal(res)
 			return types.KuzzleResponse{Result: r}
 		},
@@ -195,24 +195,24 @@ func TestDocumentRefresh(t *testing.T) {
 	k, _ := kuzzle.NewKuzzle(c, nil)
 	dc := collection.NewCollection(k, "collection", "index")
 
-	documentSource := collection.DocumentContent{
+	documentContent := collection.DocumentContent{
 		"name":     "Anakin",
 		"function": "Padawan",
 	}
 
-	cd, _ := dc.CollectionDocument().SetDocumentId(id).SetContent(documentSource, true).Refresh(nil)
+	cd, _ := dc.CollectionDocument().SetDocumentId(id).SetContent(documentContent, true).Refresh(nil)
 
 	result := types.Document{}
-	json.Unmarshal(cd.Document.Source, &result.Source)
+	json.Unmarshal(cd.Document.Content, &result.Content)
 
 	ic := collection.DocumentContent{}
-	json.Unmarshal(result.Source, &ic)
+	json.Unmarshal(result.Content, &ic)
 
 	assert.Equal(t, id, cd.Document.Id)
 	assert.Equal(t, dc, &cd.Collection)
-	assert.Equal(t, "Padawan", documentSource["function"])
+	assert.Equal(t, "Padawan", documentContent["function"])
 	assert.Equal(t, "Jedi", ic["function"])
-	assert.NotEqual(t, documentSource["function"], ic["function"])
+	assert.NotEqual(t, documentContent["function"], ic["function"])
 }
 
 func TestDocumentPublishError(t *testing.T) {

--- a/collection/document_test.go
+++ b/collection/document_test.go
@@ -15,30 +15,30 @@ func TestDocumentSetContent(t *testing.T) {
 	k, _ := kuzzle.NewKuzzle(&internal.MockedConnection{}, nil)
 	dc := collection.NewCollection(k, "collection", "index")
 
-	cd := dc.CollectionDocument()
-	cd.Document.Content = []byte(`{"foo":"bar","subfield":{"john":"smith"}}`)
+	d := dc.Document()
+	d.Content = []byte(`{"foo":"bar","subfield":{"john":"smith"}}`)
 
-	assert.Equal(t, json.RawMessage([]byte(`{"foo":"bar","subfield":{"john":"smith"}}`)), cd.Document.Content)
+	assert.Equal(t, json.RawMessage([]byte(`{"foo":"bar","subfield":{"john":"smith"}}`)), d.Content)
 
-	cd = cd.SetContent(collection.DocumentContent{
+	d = d.SetContent(collection.DocumentContent{
 		"subfield": collection.DocumentContent{
 			"john": "cena",
 		},
 	}, false)
 
-	assert.Equal(t, string(json.RawMessage([]byte(`{"foo":"bar","subfield":{"john":"cena"}}`))), string(cd.Document.Content))
+	assert.Equal(t, string(json.RawMessage([]byte(`{"foo":"bar","subfield":{"john":"cena"}}`))), string(d.Content))
 }
 
 func TestDocumentSetContentReplace(t *testing.T) {
 	k, _ := kuzzle.NewKuzzle(&internal.MockedConnection{}, nil)
 	dc := collection.NewCollection(k, "collection", "index")
 
-	cd := dc.CollectionDocument()
-	cd.Document.Content = []byte(`{"foo":"bar","subfield":{"john":"smith"}}`)
+	d := dc.Document()
+	d.Content = []byte(`{"foo":"bar","subfield":{"john":"smith"}}`)
 
-	assert.Equal(t, json.RawMessage([]byte(`{"foo":"bar","subfield":{"john":"smith"}}`)), cd.Document.Content)
+	assert.Equal(t, json.RawMessage([]byte(`{"foo":"bar","subfield":{"john":"smith"}}`)), d.Content)
 
-	cd = cd.SetContent(collection.DocumentContent{
+	d = d.SetContent(collection.DocumentContent{
 		"subfield": collection.DocumentContent{
 			"john": "cena",
 			"subsubfield": collection.DocumentContent{
@@ -47,12 +47,12 @@ func TestDocumentSetContentReplace(t *testing.T) {
 		},
 	}, true)
 
-	assert.Equal(t, string(json.RawMessage([]byte(`{"subfield":{"john":"cena","subsubfield":{"hi":"there"}}}`))), string(cd.Document.Content))
+	assert.Equal(t, string(json.RawMessage([]byte(`{"subfield":{"john":"cena","subsubfield":{"hi":"there"}}}`))), string(d.Content))
 }
 
 func TestDocumentSetHeaders(t *testing.T) {
 	k, _ := kuzzle.NewKuzzle(&internal.MockedConnection{}, nil)
-	cd := collection.NewCollection(k, "collection", "index").CollectionDocument()
+	d := collection.NewCollection(k, "collection", "index").Document()
 
 	var headers = make(map[string]interface{}, 0)
 
@@ -61,12 +61,12 @@ func TestDocumentSetHeaders(t *testing.T) {
 	headers["foo"] = "bar"
 	headers["bar"] = "foo"
 
-	cd.SetHeaders(headers, false)
+	d.SetHeaders(headers, false)
 
 	var newHeaders = make(map[string]interface{}, 0)
 	newHeaders["foo"] = "rab"
 
-	cd.SetHeaders(newHeaders, false)
+	d.SetHeaders(newHeaders, false)
 
 	headers["foo"] = "rab"
 
@@ -76,7 +76,7 @@ func TestDocumentSetHeaders(t *testing.T) {
 
 func TestDocumentSetHeadersReplace(t *testing.T) {
 	k, _ := kuzzle.NewKuzzle(&internal.MockedConnection{}, nil)
-	cd := collection.NewCollection(k, "collection", "index").CollectionDocument()
+	d := collection.NewCollection(k, "collection", "index").Document()
 
 	var headers = make(map[string]interface{}, 0)
 
@@ -85,12 +85,12 @@ func TestDocumentSetHeadersReplace(t *testing.T) {
 	headers["foo"] = "bar"
 	headers["bar"] = "foo"
 
-	cd.SetHeaders(headers, false)
+	d.SetHeaders(headers, false)
 
 	var newHeaders = make(map[string]interface{}, 0)
 	newHeaders["foo"] = "rab"
 
-	cd.SetHeaders(newHeaders, true)
+	d.SetHeaders(newHeaders, true)
 
 	headers["foo"] = "rab"
 
@@ -101,10 +101,10 @@ func TestDocumentSetHeadersReplace(t *testing.T) {
 func TestDocumentSaveEmptyId(t *testing.T) {
 	k, _ := kuzzle.NewKuzzle(&internal.MockedConnection{}, nil)
 	dc := collection.NewCollection(k, "collection", "index")
-	_, err := dc.CollectionDocument().Save(nil)
+	_, err := dc.Document().Save(nil)
 
 	assert.NotNil(t, err)
-	assert.Equal(t, "CollectionDocument.Save: missing document id", fmt.Sprint(err))
+	assert.Equal(t, "Document.Save: missing document id", fmt.Sprint(err))
 }
 
 func TestDocumentSaveError(t *testing.T) {
@@ -115,7 +115,7 @@ func TestDocumentSaveError(t *testing.T) {
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)
 	dc := collection.NewCollection(k, "collection", "index")
-	_, err := dc.CollectionDocument().SetDocumentId("myId").Save(nil)
+	_, err := dc.Document().SetDocumentId("myId").Save(nil)
 
 	assert.NotNil(t, err)
 }
@@ -134,7 +134,7 @@ func TestDocumentSave(t *testing.T) {
 			assert.Equal(t, "collection", parsedQuery.Collection)
 			assert.Equal(t, id, parsedQuery.Id)
 
-			res := types.Document{Id: id, Content: []byte(`{"foo":"bar"}`)}
+			res := collection.Document{Id: id, Content: []byte(`{"foo":"bar"}`)}
 			r, _ := json.Marshal(res)
 			return types.KuzzleResponse{Result: r}
 		},
@@ -144,20 +144,19 @@ func TestDocumentSave(t *testing.T) {
 
 	documentContent := collection.DocumentContent{"foo": "bar"}
 
-	cd, _ := dc.CollectionDocument().SetDocumentId(id).SetContent(documentContent, true).Save(nil)
+	d, _ := dc.Document().SetDocumentId(id).SetContent(documentContent, true).Save(nil)
 
-	assert.Equal(t, id, cd.Document.Id)
-	assert.Equal(t, dc, &cd.Collection)
-	assert.Equal(t, documentContent.ToString(), string(cd.Document.Content))
+	assert.Equal(t, id, d.Id)
+	assert.Equal(t, documentContent.ToString(), string(d.Content))
 }
 
 func TestDocumentRefreshEmptyId(t *testing.T) {
 	k, _ := kuzzle.NewKuzzle(&internal.MockedConnection{}, nil)
 	dc := collection.NewCollection(k, "collection", "index")
-	_, err := dc.CollectionDocument().Refresh(nil)
+	_, err := dc.Document().Refresh(nil)
 
 	assert.NotNil(t, err)
-	assert.Equal(t, "CollectionDocument.Refresh: missing document id", fmt.Sprint(err))
+	assert.Equal(t, "Document.Refresh: missing document id", fmt.Sprint(err))
 }
 
 func TestDocumentRefreshError(t *testing.T) {
@@ -168,7 +167,7 @@ func TestDocumentRefreshError(t *testing.T) {
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)
 	dc := collection.NewCollection(k, "collection", "index")
-	_, err := dc.CollectionDocument().SetDocumentId("myId").Refresh(nil)
+	_, err := dc.Document().SetDocumentId("myId").Refresh(nil)
 
 	assert.NotNil(t, err)
 }
@@ -187,7 +186,7 @@ func TestDocumentRefresh(t *testing.T) {
 			assert.Equal(t, "collection", parsedQuery.Collection)
 			assert.Equal(t, id, parsedQuery.Id)
 
-			res := types.Document{Id: id, Content: []byte(`{"name":"Anakin","function":"Jedi"}`)}
+			res := collection.Document{Id: id, Content: []byte(`{"name":"Anakin","function":"Jedi"}`)}
 			r, _ := json.Marshal(res)
 			return types.KuzzleResponse{Result: r}
 		},
@@ -200,16 +199,15 @@ func TestDocumentRefresh(t *testing.T) {
 		"function": "Padawan",
 	}
 
-	cd, _ := dc.CollectionDocument().SetDocumentId(id).SetContent(documentContent, true).Refresh(nil)
+	d, _ := dc.Document().SetDocumentId(id).SetContent(documentContent, true).Refresh(nil)
 
-	result := types.Document{}
-	json.Unmarshal(cd.Document.Content, &result.Content)
+	result := collection.Document{}
+	json.Unmarshal(d.Content, &result.Content)
 
 	ic := collection.DocumentContent{}
 	json.Unmarshal(result.Content, &ic)
 
-	assert.Equal(t, id, cd.Document.Id)
-	assert.Equal(t, dc, &cd.Collection)
+	assert.Equal(t, id, d.Id)
 	assert.Equal(t, "Padawan", documentContent["function"])
 	assert.Equal(t, "Jedi", ic["function"])
 	assert.NotEqual(t, documentContent["function"], ic["function"])
@@ -223,7 +221,7 @@ func TestDocumentPublishError(t *testing.T) {
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)
 	dc := collection.NewCollection(k, "realtime", "publish")
-	_, err := dc.CollectionDocument().SetDocumentId("myId").Publish(nil)
+	_, err := dc.Document().SetDocumentId("myId").Publish(nil)
 
 	assert.NotNil(t, err)
 }
@@ -245,7 +243,7 @@ func TestDocumentPublish(t *testing.T) {
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)
 	dc := collection.NewCollection(k, "collection", "index")
-	result, _ := dc.CollectionDocument().SetDocumentId("myId").Publish(nil)
+	result, _ := dc.Document().SetDocumentId("myId").Publish(nil)
 
 	assert.Equal(t, true, result)
 }
@@ -253,10 +251,10 @@ func TestDocumentPublish(t *testing.T) {
 func TestDocumentDeleteEmptyId(t *testing.T) {
 	k, _ := kuzzle.NewKuzzle(&internal.MockedConnection{}, nil)
 	dc := collection.NewCollection(k, "collection", "index")
-	_, err := dc.CollectionDocument().Delete(nil)
+	_, err := dc.Document().Delete(nil)
 
 	assert.NotNil(t, err)
-	assert.Equal(t, "CollectionDocument.Delete: missing document id", fmt.Sprint(err))
+	assert.Equal(t, "Document.Delete: missing document id", fmt.Sprint(err))
 }
 
 func TestDocumentDeleteError(t *testing.T) {
@@ -267,7 +265,7 @@ func TestDocumentDeleteError(t *testing.T) {
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)
 	dc := collection.NewCollection(k, "collection", "index")
-	_, err := dc.CollectionDocument().SetDocumentId("myId").Delete(nil)
+	_, err := dc.Document().SetDocumentId("myId").Delete(nil)
 
 	assert.NotNil(t, err)
 }
@@ -286,13 +284,13 @@ func TestDocumentDelete(t *testing.T) {
 			assert.Equal(t, "collection", parsedQuery.Collection)
 			assert.Equal(t, id, parsedQuery.Id)
 
-			r, _ := json.Marshal(types.Document{Id: id})
+			r, _ := json.Marshal(collection.Document{Id: id})
 			return types.KuzzleResponse{Result: r}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)
 	dc := collection.NewCollection(k, "collection", "index")
-	result, _ := dc.CollectionDocument().SetDocumentId("myId").Delete(nil)
+	result, _ := dc.Document().SetDocumentId("myId").Delete(nil)
 
 	assert.Equal(t, id, result)
 }

--- a/collection/document_test.go
+++ b/collection/document_test.go
@@ -143,9 +143,10 @@ func TestDocumentFetch(t *testing.T) {
 	k, _ := kuzzle.NewKuzzle(c, nil)
 	dc := collection.NewCollection(k, "collection", "index")
 	d, _ := dc.Document().Fetch(id)
+	r := collection.Document{Id: id, Content: []byte(`{"foo":"bar"}`)}
 
-	assert.Equal(t, id, d.Id)
-	assert.Equal(t, []byte(`{"foo":"bar"}`), d.Content)
+	assert.Equal(t, r.Id, d.Id)
+	assert.Equal(t, r.Content, d.Content)
 }
 
 func TestDocumentSubscribeEmptyId(t *testing.T) {
@@ -199,10 +200,10 @@ func TestDocumentSubscribe(t *testing.T) {
 	k, _ = kuzzle.NewKuzzle(c, nil)
 	*k.State = state.Connected
 	dc := collection.NewCollection(k, "collection", "index")
-	cd, _ := dc.Document().Fetch(id)
+	d, _ := dc.Document().Fetch(id)
 
 	ch := make(chan types.KuzzleNotification)
-	subRes := cd.Subscribe(types.NewRoomOptions(), ch)
+	subRes := d.Subscribe(types.NewRoomOptions(), ch)
 	r := <-subRes
 
 	assert.Nil(t, r.Error)

--- a/collection/fetch_document.go
+++ b/collection/fetch_document.go
@@ -9,9 +9,9 @@ import (
 /*
   Retrieves a Document using its provided unique id.
 */
-func (dc Collection) FetchDocument(id string, options types.QueryOptions) (types.Document, error) {
+func (dc Collection) FetchDocument(id string, options types.QueryOptions) (Document, error) {
 	if id == "" {
-		return types.Document{}, errors.New("Collection.FetchDocument: document id required")
+		return Document{}, errors.New("Collection.FetchDocument: document id required")
 	}
 
 	ch := make(chan types.KuzzleResponse)
@@ -28,10 +28,10 @@ func (dc Collection) FetchDocument(id string, options types.QueryOptions) (types
 	res := <-ch
 
 	if res.Error.Message != "" {
-		return types.Document{}, errors.New(res.Error.Message)
+		return Document{}, errors.New(res.Error.Message)
 	}
 
-	document := types.Document{}
+	document := Document{}
 	json.Unmarshal(res.Result, &document)
 
 	return document, nil
@@ -40,9 +40,9 @@ func (dc Collection) FetchDocument(id string, options types.QueryOptions) (types
 /*
   Get specific documents according to given IDs.
 */
-func (dc Collection) MGetDocument(ids []string, options types.QueryOptions) (types.KuzzleSearchResult, error) {
+func (dc Collection) MGetDocument(ids []string, options types.QueryOptions) (KuzzleSearchResult, error) {
 	if len(ids) == 0 {
-		return types.KuzzleSearchResult{}, errors.New("Collection.MGetDocument: please provide at least one id of document to retrieve")
+		return KuzzleSearchResult{}, errors.New("Collection.MGetDocument: please provide at least one id of document to retrieve")
 	}
 
 	ch := make(chan types.KuzzleResponse)
@@ -63,11 +63,15 @@ func (dc Collection) MGetDocument(ids []string, options types.QueryOptions) (typ
 	res := <-ch
 
 	if res.Error.Message != "" {
-		return types.KuzzleSearchResult{}, errors.New(res.Error.Message)
+		return KuzzleSearchResult{}, errors.New(res.Error.Message)
 	}
 
-	result := types.KuzzleSearchResult{}
+	result := KuzzleSearchResult{}
 	json.Unmarshal(res.Result, &result)
+
+	for _, d := range result.Hits {
+		d.collection = dc
+	}
 
 	return result, nil
 }

--- a/collection/fetch_document.go
+++ b/collection/fetch_document.go
@@ -31,7 +31,7 @@ func (dc Collection) FetchDocument(id string, options types.QueryOptions) (Docum
 		return Document{}, errors.New(res.Error.Message)
 	}
 
-	document := Document{}
+	document := Document{collection: dc}
 	json.Unmarshal(res.Result, &document)
 
 	return document, nil

--- a/collection/fetch_document_test.go
+++ b/collection/fetch_document_test.go
@@ -52,7 +52,7 @@ func TestFetchDocument(t *testing.T) {
 			assert.Equal(t, "collection", parsedQuery.Collection)
 			assert.Equal(t, id, parsedQuery.Id)
 
-			res := types.Document{Id: id, Content: []byte(`{"foo": "bar"}`)}
+			res := collection.Document{Id: id, Content: []byte(`{"foo": "bar"}`)}
 			r, _ := json.Marshal(res)
 			return types.KuzzleResponse{Result: r}
 		},
@@ -88,10 +88,10 @@ func TestMGetDocumentError(t *testing.T) {
 }
 
 func TestMGetDocument(t *testing.T) {
-	hits := make([]types.KuzzleResult, 2)
-	hits[0] = types.KuzzleResult{Id: "foo", Content: json.RawMessage(`{"title":"foo"}`)}
-	hits[1] = types.KuzzleResult{Id: "bar", Content: json.RawMessage(`{"title":"bar"}`)}
-	var results = types.KuzzleSearchResult{Total: 2, Hits: hits}
+	hits := make([]collection.Document, 2)
+	hits[0] = collection.Document{Id: "foo", Content: json.RawMessage(`{"title":"foo"}`)}
+	hits[1] = collection.Document{Id: "bar", Content: json.RawMessage(`{"title":"bar"}`)}
+	var results = collection.KuzzleSearchResult{Total: 2, Hits: hits}
 
 	ids := []string{"foo", "bar"}
 
@@ -106,7 +106,7 @@ func TestMGetDocument(t *testing.T) {
 			assert.Equal(t, "collection", parsedQuery.Collection)
 			assert.Equal(t, []interface{}{"foo", "bar"}, parsedQuery.Body.(map[string]interface{})["ids"])
 
-			res := types.KuzzleSearchResult{Total: results.Total, Hits: results.Hits}
+			res := collection.KuzzleSearchResult{Total: results.Total, Hits: results.Hits}
 			r, _ := json.Marshal(res)
 			return types.KuzzleResponse{Result: r}
 		},

--- a/collection/fetch_document_test.go
+++ b/collection/fetch_document_test.go
@@ -52,7 +52,7 @@ func TestFetchDocument(t *testing.T) {
 			assert.Equal(t, "collection", parsedQuery.Collection)
 			assert.Equal(t, id, parsedQuery.Id)
 
-			res := types.Document{Id: id, Source: []byte(`{"foo": "bar"}`)}
+			res := types.Document{Id: id, Content: []byte(`{"foo": "bar"}`)}
 			r, _ := json.Marshal(res)
 			return types.KuzzleResponse{Result: r}
 		},
@@ -89,8 +89,8 @@ func TestMGetDocumentError(t *testing.T) {
 
 func TestMGetDocument(t *testing.T) {
 	hits := make([]types.KuzzleResult, 2)
-	hits[0] = types.KuzzleResult{Id: "foo", Source: json.RawMessage(`{"title":"foo"}`)}
-	hits[1] = types.KuzzleResult{Id: "bar", Source: json.RawMessage(`{"title":"bar"}`)}
+	hits[0] = types.KuzzleResult{Id: "foo", Content: json.RawMessage(`{"title":"foo"}`)}
+	hits[1] = types.KuzzleResult{Id: "bar", Content: json.RawMessage(`{"title":"bar"}`)}
 	var results = types.KuzzleSearchResult{Total: 2, Hits: hits}
 
 	ids := []string{"foo", "bar"}

--- a/collection/replace_document.go
+++ b/collection/replace_document.go
@@ -61,7 +61,7 @@ func (dc Collection) MReplaceDocument(documents []types.Document, options types.
 	for _, doc := range documents {
 		docs = append(docs, CreationDocument{
 			Id:   doc.Id,
-			Body: doc.Source,
+			Body: doc.Content,
 		})
 	}
 

--- a/collection/replace_document.go
+++ b/collection/replace_document.go
@@ -9,9 +9,9 @@ import (
 /*
   Replaces a document in Kuzzle.
 */
-func (dc Collection) ReplaceDocument(id string, document interface{}, options types.QueryOptions) (types.Document, error) {
+func (dc Collection) ReplaceDocument(id string, document interface{}, options types.QueryOptions) (Document, error) {
 	if id == "" {
-		return types.Document{}, errors.New("Collection.ReplaceDocument: document id required")
+		return Document{}, errors.New("Collection.ReplaceDocument: document id required")
 	}
 
 	ch := make(chan types.KuzzleResponse)
@@ -29,21 +29,21 @@ func (dc Collection) ReplaceDocument(id string, document interface{}, options ty
 	res := <-ch
 
 	if res.Error.Message != "" {
-		return types.Document{}, errors.New(res.Error.Message)
+		return Document{}, errors.New(res.Error.Message)
 	}
 
-	documentResponse := types.Document{}
-	json.Unmarshal(res.Result, &documentResponse)
+	d := Document{collection: dc}
+	json.Unmarshal(res.Result, &d)
 
-	return documentResponse, nil
+	return d, nil
 }
 
 /*
   Replace the provided documents.
 */
-func (dc Collection) MReplaceDocument(documents []types.Document, options types.QueryOptions) (types.KuzzleSearchResult, error) {
+func (dc Collection) MReplaceDocument(documents []Document, options types.QueryOptions) (KuzzleSearchResult, error) {
 	if len(documents) == 0 {
-		return types.KuzzleSearchResult{}, errors.New("Collection.MReplaceDocument: please provide at least one document to replace")
+		return KuzzleSearchResult{}, errors.New("Collection.MReplaceDocument: please provide at least one document to replace")
 	}
 
 	ch := make(chan types.KuzzleResponse)
@@ -77,11 +77,15 @@ func (dc Collection) MReplaceDocument(documents []types.Document, options types.
 	res := <-ch
 
 	if res.Error.Message != "" {
-		return types.KuzzleSearchResult{}, errors.New(res.Error.Message)
+		return KuzzleSearchResult{}, errors.New(res.Error.Message)
 	}
 
-	result := types.KuzzleSearchResult{}
+	result := KuzzleSearchResult{}
 	json.Unmarshal(res.Result, &result)
+
+	for _, d := range result.Hits {
+		d.collection = dc
+	}
 
 	return result, nil
 }

--- a/collection/replace_document_test.go
+++ b/collection/replace_document_test.go
@@ -62,7 +62,7 @@ func TestReplaceDocument(t *testing.T) {
 
 			assert.Equal(t, "jonathan", parsedQuery.Body.(map[string]interface{})["Title"])
 
-			res := types.Document{Id: id, Content: []byte(`{"title": "jonathan"}`)}
+			res := collection.Document{Id: id, Content: []byte(`{"title": "jonathan"}`)}
 			r, _ := json.Marshal(res)
 			return types.KuzzleResponse{Result: r}
 		},
@@ -74,7 +74,7 @@ func TestReplaceDocument(t *testing.T) {
 }
 
 func TestMReplaceDocumentEmptyDocuments(t *testing.T) {
-	documents := []types.Document{}
+	documents := []collection.Document{}
 
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) types.KuzzleResponse {
@@ -88,7 +88,7 @@ func TestMReplaceDocumentEmptyDocuments(t *testing.T) {
 }
 
 func TestMReplaceDocumentError(t *testing.T) {
-	documents := []types.Document{
+	documents := []collection.Document{
 		{Id: "foo", Content: []byte(`{"title":"Foo"}`)},
 		{Id: "bar", Content: []byte(`{"title":"Bar"}`)},
 	}
@@ -105,7 +105,7 @@ func TestMReplaceDocumentError(t *testing.T) {
 }
 
 func TestMReplaceDocument(t *testing.T) {
-	documents := []types.Document{
+	documents := []collection.Document{
 		{Id: "foo", Content: []byte(`{"title":"Foo"}`)},
 		{Id: "bar", Content: []byte(`{"title":"Bar"}`)},
 	}
@@ -120,12 +120,12 @@ func TestMReplaceDocument(t *testing.T) {
 			assert.Equal(t, "index", parsedQuery.Index)
 			assert.Equal(t, "collection", parsedQuery.Collection)
 
-			results := []types.KuzzleResult{
+			results := []collection.Document{
 				{Id: "foo", Content: []byte(`{"title":"Foo"}`)},
 				{Id: "bar", Content: []byte(`{"title":"Bar"}`)},
 			}
 
-			res := types.KuzzleSearchResult{
+			res := collection.KuzzleSearchResult{
 				Total: 2,
 				Hits:  results,
 			}

--- a/collection/replace_document_test.go
+++ b/collection/replace_document_test.go
@@ -62,7 +62,7 @@ func TestReplaceDocument(t *testing.T) {
 
 			assert.Equal(t, "jonathan", parsedQuery.Body.(map[string]interface{})["Title"])
 
-			res := types.Document{Id: id, Source: []byte(`{"title": "jonathan"}`)}
+			res := types.Document{Id: id, Content: []byte(`{"title": "jonathan"}`)}
 			r, _ := json.Marshal(res)
 			return types.KuzzleResponse{Result: r}
 		},
@@ -89,8 +89,8 @@ func TestMReplaceDocumentEmptyDocuments(t *testing.T) {
 
 func TestMReplaceDocumentError(t *testing.T) {
 	documents := []types.Document{
-		{Id: "foo", Source: []byte(`{"title":"Foo"}`)},
-		{Id: "bar", Source: []byte(`{"title":"Bar"}`)},
+		{Id: "foo", Content: []byte(`{"title":"Foo"}`)},
+		{Id: "bar", Content: []byte(`{"title":"Bar"}`)},
 	}
 
 	c := &internal.MockedConnection{
@@ -106,8 +106,8 @@ func TestMReplaceDocumentError(t *testing.T) {
 
 func TestMReplaceDocument(t *testing.T) {
 	documents := []types.Document{
-		{Id: "foo", Source: []byte(`{"title":"Foo"}`)},
-		{Id: "bar", Source: []byte(`{"title":"Bar"}`)},
+		{Id: "foo", Content: []byte(`{"title":"Foo"}`)},
+		{Id: "bar", Content: []byte(`{"title":"Bar"}`)},
 	}
 
 	c := &internal.MockedConnection{
@@ -121,8 +121,8 @@ func TestMReplaceDocument(t *testing.T) {
 			assert.Equal(t, "collection", parsedQuery.Collection)
 
 			results := []types.KuzzleResult{
-				{Id: "foo", Source: []byte(`{"title":"Foo"}`)},
-				{Id: "bar", Source: []byte(`{"title":"Bar"}`)},
+				{Id: "foo", Content: []byte(`{"title":"Foo"}`)},
+				{Id: "bar", Content: []byte(`{"title":"Bar"}`)},
 			}
 
 			res := types.KuzzleSearchResult{
@@ -140,6 +140,6 @@ func TestMReplaceDocument(t *testing.T) {
 
 	for index, doc := range res.Hits {
 		assert.Equal(t, documents[index].Id, doc.Id)
-		assert.Equal(t, documents[index].Source, doc.Source)
+		assert.Equal(t, documents[index].Content, doc.Content)
 	}
 }

--- a/collection/scroll.go
+++ b/collection/scroll.go
@@ -9,9 +9,9 @@ import (
 /*
   A "scroll" option can be passed to search queries, creating persistent paginated results.
 */
-func (dc Collection) Scroll(scrollId string, options types.QueryOptions) (types.KuzzleSearchResult, error) {
+func (dc Collection) Scroll(scrollId string, options types.QueryOptions) (KuzzleSearchResult, error) {
 	if scrollId == "" {
-		return types.KuzzleSearchResult{}, errors.New("Collection.Scroll: scroll id required")
+		return KuzzleSearchResult{}, errors.New("Collection.Scroll: scroll id required")
 	}
 
 	ch := make(chan types.KuzzleResponse)
@@ -26,11 +26,15 @@ func (dc Collection) Scroll(scrollId string, options types.QueryOptions) (types.
 	res := <-ch
 
 	if res.Error.Message != "" {
-		return types.KuzzleSearchResult{}, errors.New(res.Error.Message)
+		return KuzzleSearchResult{}, errors.New(res.Error.Message)
 	}
 
-	searchResult := types.KuzzleSearchResult{}
-	json.Unmarshal(res.Result, &searchResult)
+	result := KuzzleSearchResult{}
+	json.Unmarshal(res.Result, &result)
 
-	return searchResult, nil
+	for _, d := range result.Hits {
+		d.collection = dc
+	}
+
+	return result, nil
 }

--- a/collection/scroll_test.go
+++ b/collection/scroll_test.go
@@ -41,7 +41,7 @@ func TestScroll(t *testing.T) {
 	}
 
 	hits := make([]types.KuzzleResult, 1)
-	hits[0] = types.KuzzleResult{Id: "doc42", Source: json.RawMessage(`{"foo":"bar"}`)}
+	hits[0] = types.KuzzleResult{Id: "doc42", Content: json.RawMessage(`{"foo":"bar"}`)}
 	var results = types.KuzzleSearchResult{Total: 42, Hits: hits}
 
 	c := &internal.MockedConnection{
@@ -63,5 +63,5 @@ func TestScroll(t *testing.T) {
 	assert.Equal(t, results.Total, res.Total)
 	assert.Equal(t, hits, res.Hits)
 	assert.Equal(t, res.Hits[0].Id, "doc42")
-	assert.Equal(t, res.Hits[0].Source, json.RawMessage(`{"foo":"bar"}`))
+	assert.Equal(t, res.Hits[0].Content, json.RawMessage(`{"foo":"bar"}`))
 }

--- a/collection/scroll_test.go
+++ b/collection/scroll_test.go
@@ -36,13 +36,13 @@ func TestScrollError(t *testing.T) {
 
 func TestScroll(t *testing.T) {
 	type response struct {
-		Total int                  `json:"total"`
-		Hits  []types.KuzzleResult `json:"hits"`
+		Total int                   `json:"total"`
+		Hits  []collection.Document `json:"hits"`
 	}
 
-	hits := make([]types.KuzzleResult, 1)
-	hits[0] = types.KuzzleResult{Id: "doc42", Content: json.RawMessage(`{"foo":"bar"}`)}
-	var results = types.KuzzleSearchResult{Total: 42, Hits: hits}
+	hits := make([]collection.Document, 1)
+	hits[0] = collection.Document{Id: "doc42", Content: json.RawMessage(`{"foo":"bar"}`)}
+	var results = collection.KuzzleSearchResult{Total: 42, Hits: hits}
 
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) types.KuzzleResponse {

--- a/collection/search.go
+++ b/collection/search.go
@@ -7,9 +7,9 @@ import (
 )
 
 type KuzzleSearchResult struct {
-Hits     []Document `json:"hits"`
-Total    int        `json:"total"`
-ScrollId string     `json:"_scroll_id"`
+	Hits     []Document `json:"hits"`
+	Total    int        `json:"total"`
+	ScrollId string     `json:"_scroll_id"`
 }
 
 /*

--- a/collection/search_test.go
+++ b/collection/search_test.go
@@ -24,7 +24,7 @@ func TestSearchError(t *testing.T) {
 
 func TestSearch(t *testing.T) {
 	hits := make([]types.KuzzleResult, 1)
-	hits[0] = types.KuzzleResult{Id: "doc42", Source: json.RawMessage(`{"foo":"bar"}`)}
+	hits[0] = types.KuzzleResult{Id: "doc42", Content: json.RawMessage(`{"foo":"bar"}`)}
 	var results = types.KuzzleSearchResult{Total: 42, Hits: hits}
 
 	c := &internal.MockedConnection{
@@ -48,12 +48,12 @@ func TestSearch(t *testing.T) {
 	assert.Equal(t, results.Total, res.Total)
 	assert.Equal(t, hits, res.Hits)
 	assert.Equal(t, res.Hits[0].Id, "doc42")
-	assert.Equal(t, res.Hits[0].Source, json.RawMessage(`{"foo":"bar"}`))
+	assert.Equal(t, res.Hits[0].Content, json.RawMessage(`{"foo":"bar"}`))
 }
 
 func TestSearchWithScroll(t *testing.T) {
 	hits := make([]types.KuzzleResult, 1)
-	hits[0] = types.KuzzleResult{Id: "doc42", Source: json.RawMessage(`{"foo":"bar"}`)}
+	hits[0] = types.KuzzleResult{Id: "doc42", Content: json.RawMessage(`{"foo":"bar"}`)}
 	var results = types.KuzzleSearchResult{Total: 42, Hits: hits}
 
 	c := &internal.MockedConnection{
@@ -85,5 +85,5 @@ func TestSearchWithScroll(t *testing.T) {
 	assert.Equal(t, hits, res.Hits)
 	assert.Equal(t, "f00b4r", res.ScrollId)
 	assert.Equal(t, res.Hits[0].Id, "doc42")
-	assert.Equal(t, res.Hits[0].Source, json.RawMessage(`{"foo":"bar"}`))
+	assert.Equal(t, res.Hits[0].Content, json.RawMessage(`{"foo":"bar"}`))
 }

--- a/collection/search_test.go
+++ b/collection/search_test.go
@@ -23,9 +23,9 @@ func TestSearchError(t *testing.T) {
 }
 
 func TestSearch(t *testing.T) {
-	hits := make([]types.KuzzleResult, 1)
-	hits[0] = types.KuzzleResult{Id: "doc42", Content: json.RawMessage(`{"foo":"bar"}`)}
-	var results = types.KuzzleSearchResult{Total: 42, Hits: hits}
+	hits := make([]collection.Document, 1)
+	hits[0] = collection.Document{Id: "doc42", Content: json.RawMessage(`{"foo":"bar"}`)}
+	var results = collection.KuzzleSearchResult{Total: 42, Hits: hits}
 
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) types.KuzzleResponse {
@@ -37,7 +37,7 @@ func TestSearch(t *testing.T) {
 			assert.Equal(t, "index", parsedQuery.Index)
 			assert.Equal(t, "collection", parsedQuery.Collection)
 
-			res := types.KuzzleSearchResult{Total: results.Total, Hits: results.Hits}
+			res := collection.KuzzleSearchResult{Total: results.Total, Hits: results.Hits}
 			r, _ := json.Marshal(res)
 			return types.KuzzleResponse{Result: r}
 		},
@@ -52,9 +52,9 @@ func TestSearch(t *testing.T) {
 }
 
 func TestSearchWithScroll(t *testing.T) {
-	hits := make([]types.KuzzleResult, 1)
-	hits[0] = types.KuzzleResult{Id: "doc42", Content: json.RawMessage(`{"foo":"bar"}`)}
-	var results = types.KuzzleSearchResult{Total: 42, Hits: hits}
+	hits := make([]collection.Document, 1)
+	hits[0] = collection.Document{Id: "doc42", Content: json.RawMessage(`{"foo":"bar"}`)}
+	var results = collection.KuzzleSearchResult{Total: 42, Hits: hits}
 
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) types.KuzzleResponse {
@@ -69,7 +69,7 @@ func TestSearchWithScroll(t *testing.T) {
 			assert.Equal(t, 4, parsedQuery.Size)
 			assert.Equal(t, "1m", parsedQuery.Scroll)
 
-			res := types.KuzzleSearchResult{Total: results.Total, Hits: results.Hits, ScrollId: "f00b4r"}
+			res := collection.KuzzleSearchResult{Total: results.Total, Hits: results.Hits, ScrollId: "f00b4r"}
 			r, _ := json.Marshal(res)
 			return types.KuzzleResponse{Result: r}
 		},

--- a/collection/update_document.go
+++ b/collection/update_document.go
@@ -9,9 +9,9 @@ import (
 /*
   Updates a document in Kuzzle.
 */
-func (dc Collection) UpdateDocument(id string, document interface{}, options types.QueryOptions) (types.Document, error) {
+func (dc Collection) UpdateDocument(id string, document interface{}, options types.QueryOptions) (Document, error) {
 	if id == "" {
-		return types.Document{}, errors.New("Collection.UpdateDocument: document id required")
+		return Document{}, errors.New("Collection.UpdateDocument: document id required")
 	}
 
 	ch := make(chan types.KuzzleResponse)
@@ -29,10 +29,10 @@ func (dc Collection) UpdateDocument(id string, document interface{}, options typ
 	res := <-ch
 
 	if res.Error.Message != "" {
-		return types.Document{}, errors.New(res.Error.Message)
+		return Document{}, errors.New(res.Error.Message)
 	}
 
-	documentResponse := types.Document{}
+	documentResponse := Document{collection: dc}
 	json.Unmarshal(res.Result, &documentResponse)
 
 	return documentResponse, nil
@@ -41,9 +41,9 @@ func (dc Collection) UpdateDocument(id string, document interface{}, options typ
 /*
   Update the provided documents.
 */
-func (dc Collection) MUpdateDocument(documents []types.Document, options types.QueryOptions) (types.KuzzleSearchResult, error) {
+func (dc Collection) MUpdateDocument(documents []Document, options types.QueryOptions) (KuzzleSearchResult, error) {
 	if len(documents) == 0 {
-		return types.KuzzleSearchResult{}, errors.New("Collection.MUpdateDocument: please provide at least one document to update")
+		return KuzzleSearchResult{}, errors.New("Collection.MUpdateDocument: please provide at least one document to update")
 	}
 
 	ch := make(chan types.KuzzleResponse)
@@ -77,11 +77,15 @@ func (dc Collection) MUpdateDocument(documents []types.Document, options types.Q
 	res := <-ch
 
 	if res.Error.Message != "" {
-		return types.KuzzleSearchResult{}, errors.New(res.Error.Message)
+		return KuzzleSearchResult{}, errors.New(res.Error.Message)
 	}
 
-	result := types.KuzzleSearchResult{}
+	result := KuzzleSearchResult{}
 	json.Unmarshal(res.Result, &result)
+
+	for _, d := range result.Hits {
+		d.collection = dc
+	}
 
 	return result, nil
 }

--- a/collection/update_document.go
+++ b/collection/update_document.go
@@ -61,7 +61,7 @@ func (dc Collection) MUpdateDocument(documents []types.Document, options types.Q
 	for _, doc := range documents {
 		docs = append(docs, CreationDocument{
 			Id:   doc.Id,
-			Body: doc.Source,
+			Body: doc.Content,
 		})
 	}
 

--- a/collection/update_document_test.go
+++ b/collection/update_document_test.go
@@ -75,7 +75,7 @@ func TestUpdateDocument(t *testing.T) {
 
 			assert.Equal(t, "Jedi Knight", parsedQuery.Body.(map[string]interface{})["Function"])
 
-			res := types.Document{Id: id, Content: []byte(`{"Name":"Anakin","Function":"Jedi Knight"}`)}
+			res := collection.Document{Id: id, Content: []byte(`{"Name":"Anakin","Function":"Jedi Knight"}`)}
 			r, _ := json.Marshal(res)
 			return types.KuzzleResponse{Result: r}
 		},
@@ -97,7 +97,7 @@ func TestUpdateDocument(t *testing.T) {
 }
 
 func TestMUpdateDocumentEmptyDocuments(t *testing.T) {
-	documents := []types.Document{}
+	documents := []collection.Document{}
 
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) types.KuzzleResponse {
@@ -111,7 +111,7 @@ func TestMUpdateDocumentEmptyDocuments(t *testing.T) {
 }
 
 func TestMUpdateDocumentError(t *testing.T) {
-	documents := []types.Document{
+	documents := []collection.Document{
 		{Id: "foo", Content: []byte(`{"title":"Foo"}`)},
 		{Id: "bar", Content: []byte(`{"title":"Bar"}`)},
 	}
@@ -128,7 +128,7 @@ func TestMUpdateDocumentError(t *testing.T) {
 }
 
 func TestMUpdateDocument(t *testing.T) {
-	documents := []types.Document{
+	documents := []collection.Document{
 		{Id: "foo", Content: []byte(`{"title":"Foo"}`)},
 		{Id: "bar", Content: []byte(`{"title":"Bar"}`)},
 	}
@@ -143,12 +143,12 @@ func TestMUpdateDocument(t *testing.T) {
 			assert.Equal(t, "index", parsedQuery.Index)
 			assert.Equal(t, "collection", parsedQuery.Collection)
 
-			results := []types.KuzzleResult{
+			results := []collection.Document{
 				{Id: "foo", Content: []byte(`{"title":"Foo"}`)},
 				{Id: "bar", Content: []byte(`{"title":"Bar"}`)},
 			}
 
-			res := types.KuzzleSearchResult{
+			res := collection.KuzzleSearchResult{
 				Total: 2,
 				Hits:  results,
 			}

--- a/collection/update_document_test.go
+++ b/collection/update_document_test.go
@@ -75,7 +75,7 @@ func TestUpdateDocument(t *testing.T) {
 
 			assert.Equal(t, "Jedi Knight", parsedQuery.Body.(map[string]interface{})["Function"])
 
-			res := types.Document{Id: id, Source: []byte(`{"Name":"Anakin","Function":"Jedi Knight"}`)}
+			res := types.Document{Id: id, Content: []byte(`{"Name":"Anakin","Function":"Jedi Knight"}`)}
 			r, _ := json.Marshal(res)
 			return types.KuzzleResponse{Result: r}
 		},
@@ -89,7 +89,7 @@ func TestUpdateDocument(t *testing.T) {
 	assert.Equal(t, id, res.Id)
 
 	var result InitialContent
-	json.Unmarshal(res.Source, &result)
+	json.Unmarshal(res.Content, &result)
 
 	assert.Equal(t, initialContent.Name, result.Name)
 	assert.NotEqual(t, initialContent.Function, result.Name)
@@ -112,8 +112,8 @@ func TestMUpdateDocumentEmptyDocuments(t *testing.T) {
 
 func TestMUpdateDocumentError(t *testing.T) {
 	documents := []types.Document{
-		{Id: "foo", Source: []byte(`{"title":"Foo"}`)},
-		{Id: "bar", Source: []byte(`{"title":"Bar"}`)},
+		{Id: "foo", Content: []byte(`{"title":"Foo"}`)},
+		{Id: "bar", Content: []byte(`{"title":"Bar"}`)},
 	}
 
 	c := &internal.MockedConnection{
@@ -129,8 +129,8 @@ func TestMUpdateDocumentError(t *testing.T) {
 
 func TestMUpdateDocument(t *testing.T) {
 	documents := []types.Document{
-		{Id: "foo", Source: []byte(`{"title":"Foo"}`)},
-		{Id: "bar", Source: []byte(`{"title":"Bar"}`)},
+		{Id: "foo", Content: []byte(`{"title":"Foo"}`)},
+		{Id: "bar", Content: []byte(`{"title":"Bar"}`)},
 	}
 
 	c := &internal.MockedConnection{
@@ -144,8 +144,8 @@ func TestMUpdateDocument(t *testing.T) {
 			assert.Equal(t, "collection", parsedQuery.Collection)
 
 			results := []types.KuzzleResult{
-				{Id: "foo", Source: []byte(`{"title":"Foo"}`)},
-				{Id: "bar", Source: []byte(`{"title":"Bar"}`)},
+				{Id: "foo", Content: []byte(`{"title":"Foo"}`)},
+				{Id: "bar", Content: []byte(`{"title":"Bar"}`)},
 			}
 
 			res := types.KuzzleSearchResult{
@@ -163,6 +163,6 @@ func TestMUpdateDocument(t *testing.T) {
 
 	for index, doc := range res.Hits {
 		assert.Equal(t, documents[index].Id, doc.Id)
-		assert.Equal(t, documents[index].Source, doc.Source)
+		assert.Equal(t, documents[index].Content, doc.Content)
 	}
 }

--- a/security/user/user_test.go
+++ b/security/user/user_test.go
@@ -118,7 +118,7 @@ func TestSearchWithScroll(t *testing.T) {
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) types.KuzzleResponse {
 			parsedQuery := &types.KuzzleRequest{}
- 			json.Unmarshal(query, parsedQuery)
+			json.Unmarshal(query, parsedQuery)
 
 			assert.Equal(t, "security", parsedQuery.Controller)
 			assert.Equal(t, "searchUsers", parsedQuery.Action)
@@ -507,7 +507,7 @@ func TestDelete(t *testing.T) {
 			assert.Equal(t, "deleteUser", parsedQuery.Action)
 			assert.Equal(t, id, parsedQuery.Id)
 
-			res := types.ShardResponse{Id: id, }
+			res := types.ShardResponse{Id: id}
 			r, _ := json.Marshal(res)
 			return types.KuzzleResponse{Result: r}
 		},

--- a/types/kuzzle_response.go
+++ b/types/kuzzle_response.go
@@ -20,11 +20,11 @@ type (
 	}
 
 	KuzzleResult struct {
-		Id         string           `json:"_id"`
-		Meta       KuzzleMeta       `json:"_meta"`
-		Content    json.RawMessage  `json:"_source"`
-		Version    int              `json:"_version"`
-		Collection string           `json:"collection"`
+		Id         string          `json:"_id"`
+		Meta       KuzzleMeta      `json:"_meta"`
+		Content    json.RawMessage `json:"_source"`
+		Version    int             `json:"_version"`
+		Collection string          `json:"collection"`
 	}
 
 	KuzzleNotification struct {

--- a/types/kuzzle_response.go
+++ b/types/kuzzle_response.go
@@ -33,7 +33,7 @@ type (
 	KuzzleResult struct {
 		Id      string          `json:"_id"`
 		Meta    KuzzleMeta      `json:"_meta"`
-		Source  json.RawMessage `json:"_source"`
+		Content json.RawMessage `json:"_source"`
 		Version int             `json:"_version"`
 	}
 
@@ -274,7 +274,7 @@ func (sr KuzzleResult) SourceToMap() map[string]interface{} {
 	type SourceMap map[string]interface{}
 	sourceMap := SourceMap{}
 
-	json.Unmarshal(sr.Source, &sourceMap)
+	json.Unmarshal(sr.Content, &sourceMap)
 
 	return sourceMap
 }

--- a/types/kuzzle_response.go
+++ b/types/kuzzle_response.go
@@ -19,6 +19,14 @@ type (
 		DeletedAt int    `json:"deletedAt"`
 	}
 
+	KuzzleResult struct {
+		Id         string           `json:"_id"`
+		Meta       KuzzleMeta       `json:"_meta"`
+		Content    json.RawMessage  `json:"_source"`
+		Version    int              `json:"_version"`
+		Collection string           `json:"collection"`
+	}
+
 	KuzzleNotification struct {
 		RequestId string       `json:"requestId"`
 		Result    KuzzleResult `json:"result"`
@@ -29,26 +37,12 @@ type (
 	IKuzzleResult interface {
 		SourceToMap()
 	}
-
-	KuzzleResult struct {
-		Id      string          `json:"_id"`
-		Meta    KuzzleMeta      `json:"_meta"`
-		Content json.RawMessage `json:"_source"`
-		Version int             `json:"_version"`
-	}
-
 	KuzzleResponse struct {
 		RequestId string          `json:"requestId"`
 		Result    json.RawMessage `json:"result"`
 		RoomId    string          `json:"room"`
 		Channel   string          `json:"channel"`
 		Error     MessageError    `json:"error"`
-	}
-
-	KuzzleSearchResult struct {
-		Hits     []KuzzleResult `json:"hits"`
-		Total    int            `json:"total"`
-		ScrollId string         `json:"_scroll_id"`
 	}
 
 	KuzzleSearchUsersResult struct {
@@ -116,8 +110,6 @@ type (
 		Acknowledged       bool `json:"acknowledged"`
 		ShardsAcknowledged bool `json:"shardsAcknowledged"`
 	}
-
-	Document KuzzleResult
 
 	ShardResponse struct {
 		Found   bool   `json:"found"`
@@ -268,13 +260,4 @@ func (role Role) Controllers() map[string]struct {
 	json.Unmarshal(role.Source, &controllers)
 
 	return controllers.Controllers
-}
-
-func (sr KuzzleResult) SourceToMap() map[string]interface{} {
-	type SourceMap map[string]interface{}
-	sourceMap := SourceMap{}
-
-	json.Unmarshal(sr.Content, &sourceMap)
-
-	return sourceMap
 }


### PR DESCRIPTION
**Changes:**

Merge types.Document and collection.CollectionDocument into one and attach the correct interface on it

**Boyscout:**

Rename Document.Source into Document.Content to follow other SDKs specification