### PR TITLE
ms.georadius(bymember) behavior is defined by query options

### DIFF
--- a/ms/georadius_test.go
+++ b/ms/georadius_test.go
@@ -66,7 +66,7 @@ func TestGeoradius(t *testing.T) {
 
 	res, _ := memoryStorage.Georadius("foo", float64(43.6075274), float64(3.9128795), float64(200), "km", qo)
 
-	assert.Equal(t, []string{"some", "results"}, res)
+	assert.Equal(t, []*types.Georadius{{Name: "some"}, {Name: "results"}}, res)
 }
 
 func ExampleMs_Georadius() {
@@ -85,32 +85,6 @@ func ExampleMs_Georadius() {
 	}
 
 	fmt.Println(res)
-}
-
-func TestGeoradiusWithCoordEmptyKey(t *testing.T) {
-	k, _ := kuzzle.NewKuzzle(&internal.MockedConnection{}, nil)
-	memoryStorage := MemoryStorage.NewMs(k)
-	qo := types.NewQueryOptions()
-
-	_, err := memoryStorage.GeoradiusWithCoord("", float64(43.6075274), float64(3.9128795), float64(200), "km", qo)
-
-	assert.NotNil(t, err)
-	assert.Equal(t, "[400] Ms.GeoradiusWithCoord: key required", fmt.Sprint(err))
-}
-
-func TestGeoradiusWithCoordError(t *testing.T) {
-	c := &internal.MockedConnection{
-		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "Unit test error"}}
-		},
-	}
-	k, _ := kuzzle.NewKuzzle(c, nil)
-	memoryStorage := MemoryStorage.NewMs(k)
-	qo := types.NewQueryOptions()
-
-	_, err := memoryStorage.GeoradiusWithCoord("foo", float64(43.6075274), float64(3.9128795), float64(200), "km", qo)
-
-	assert.NotNil(t, err)
 }
 
 func TestGeoradiusWithCoordLonConvError(t *testing.T) {
@@ -148,9 +122,9 @@ func TestGeoradiusWithCoordLonConvError(t *testing.T) {
 	k, _ := kuzzle.NewKuzzle(c, nil)
 	memoryStorage := MemoryStorage.NewMs(k)
 	qo := types.NewQueryOptions()
-	qo.SetSort("ASC").SetCount(42)
+	qo.SetSort("ASC").SetCount(42).SetWithcoord(true)
 
-	_, err := memoryStorage.GeoradiusWithCoord("foo", float64(43.6075274), float64(3.9128795), float64(200), "km", qo)
+	_, err := memoryStorage.Georadius("foo", float64(43.6075274), float64(3.9128795), float64(200), "km", qo)
 
 	assert.NotNil(t, err)
 }
@@ -190,9 +164,9 @@ func TestGeoradiusWithCoordLatConvError(t *testing.T) {
 	k, _ := kuzzle.NewKuzzle(c, nil)
 	memoryStorage := MemoryStorage.NewMs(k)
 	qo := types.NewQueryOptions()
-	qo.SetSort("ASC").SetCount(42)
+	qo.SetSort("ASC").SetCount(42).SetWithcoord(true)
 
-	_, err := memoryStorage.GeoradiusWithCoord("foo", float64(43.6075274), float64(3.9128795), float64(200), "km", qo)
+	_, err := memoryStorage.Georadius("foo", float64(43.6075274), float64(3.9128795), float64(200), "km", qo)
 
 	assert.NotNil(t, err)
 }
@@ -232,11 +206,11 @@ func TestGeoradiusWithCoord(t *testing.T) {
 	k, _ := kuzzle.NewKuzzle(c, nil)
 	memoryStorage := MemoryStorage.NewMs(k)
 	qo := types.NewQueryOptions()
-	qo.SetSort("ASC").SetCount(42)
+	qo.SetSort("ASC").SetCount(42).SetWithcoord(true)
 
-	res, _ := memoryStorage.GeoradiusWithCoord("foo", float64(43.6075274), float64(3.9128795), float64(200), "km", qo)
+	res, _ := memoryStorage.Georadius("foo", float64(43.6075274), float64(3.9128795), float64(200), "km", qo)
 
-	assert.Equal(t, []*types.GeoradiusPointWithCoord{{Name: "Montpellier", Lon: 43.6075274, Lat: 3.9128795}}, res)
+	assert.Equal(t, []*types.Georadius{{Name: "Montpellier", Lon: 43.6075274, Lat: 3.9128795}}, res)
 }
 
 func ExampleMs_GeoradiusWithCoord() {
@@ -245,9 +219,9 @@ func ExampleMs_GeoradiusWithCoord() {
 	memoryStorage := MemoryStorage.NewMs(k)
 	qo := types.NewQueryOptions()
 
-	qo.SetSort("ASC").SetCount(42)
+	qo.SetSort("ASC").SetCount(42).SetWithcoord(true)
 
-	res, err := memoryStorage.GeoradiusWithCoord("foo", float64(43.6075274), float64(3.9128795), float64(200), "km", qo)
+	res, err := memoryStorage.Georadius("foo", float64(43.6075274), float64(3.9128795), float64(200), "km", qo)
 
 	if err != nil {
 		fmt.Println(err.Error())
@@ -255,32 +229,6 @@ func ExampleMs_GeoradiusWithCoord() {
 	}
 
 	fmt.Println(res[0].Name, res[0].Lon, res[0].Lat)
-}
-
-func TestGeoradiusWithDistEmptyKey(t *testing.T) {
-	k, _ := kuzzle.NewKuzzle(&internal.MockedConnection{}, nil)
-	memoryStorage := MemoryStorage.NewMs(k)
-	qo := types.NewQueryOptions()
-
-	_, err := memoryStorage.GeoradiusWithDist("", float64(43.6075274), float64(3.9128795), float64(200), "km", qo)
-
-	assert.NotNil(t, err)
-	assert.Equal(t, "[400] Ms.GeoradiusWithDist: key required", fmt.Sprint(err))
-}
-
-func TestGeoradiusWithDistError(t *testing.T) {
-	c := &internal.MockedConnection{
-		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "Unit test error"}}
-		},
-	}
-	k, _ := kuzzle.NewKuzzle(c, nil)
-	memoryStorage := MemoryStorage.NewMs(k)
-	qo := types.NewQueryOptions()
-
-	_, err := memoryStorage.GeoradiusWithDist("foo", float64(43.6075274), float64(3.9128795), float64(200), "km", qo)
-
-	assert.NotNil(t, err)
 }
 
 func TestGeoradiusWithDistDistConvError(t *testing.T) {
@@ -315,9 +263,9 @@ func TestGeoradiusWithDistDistConvError(t *testing.T) {
 	k, _ := kuzzle.NewKuzzle(c, nil)
 	memoryStorage := MemoryStorage.NewMs(k)
 	qo := types.NewQueryOptions()
-	qo.SetSort("ASC").SetCount(42)
+	qo.SetSort("ASC").SetCount(42).SetWithdist(true)
 
-	_, err := memoryStorage.GeoradiusWithDist("foo", float64(43.6075274), float64(3.9128795), float64(200), "km", qo)
+	_, err := memoryStorage.Georadius("foo", float64(43.6075274), float64(3.9128795), float64(200), "km", qo)
 
 	assert.NotNil(t, err)
 }
@@ -354,11 +302,11 @@ func TestGeoradiusWithDist(t *testing.T) {
 	k, _ := kuzzle.NewKuzzle(c, nil)
 	memoryStorage := MemoryStorage.NewMs(k)
 	qo := types.NewQueryOptions()
-	qo.SetSort("ASC").SetCount(42)
+	qo.SetSort("ASC").SetCount(42).SetWithdist(true)
 
-	res, _ := memoryStorage.GeoradiusWithDist("foo", float64(43.6075274), float64(3.9128795), float64(200), "km", qo)
+	res, _ := memoryStorage.Georadius("foo", float64(43.6075274), float64(3.9128795), float64(200), "km", qo)
 
-	assert.Equal(t, []*types.GeoradiusPointWithDist{{Name: "Montpellier", Dist: 125}}, res)
+	assert.Equal(t, []*types.Georadius{{Name: "Montpellier", Dist: 125}}, res)
 }
 
 func ExampleMs_GeoradiusWithDist() {
@@ -367,9 +315,9 @@ func ExampleMs_GeoradiusWithDist() {
 	memoryStorage := MemoryStorage.NewMs(k)
 	qo := types.NewQueryOptions()
 
-	qo.SetSort("ASC").SetCount(42)
+	qo.SetSort("ASC").SetCount(42).SetWithdist(true)
 
-	res, err := memoryStorage.GeoradiusWithDist("foo", float64(43.6075274), float64(3.9128795), float64(200), "km", qo)
+	res, err := memoryStorage.Georadius("foo", float64(43.6075274), float64(3.9128795), float64(200), "km", qo)
 
 	if err != nil {
 		fmt.Println(err.Error())
@@ -377,164 +325,6 @@ func ExampleMs_GeoradiusWithDist() {
 	}
 
 	fmt.Println(res[0].Name, res[0].Dist)
-}
-
-func TestGeoradiusWithCoordAndDistEmptyKey(t *testing.T) {
-	k, _ := kuzzle.NewKuzzle(&internal.MockedConnection{}, nil)
-	memoryStorage := MemoryStorage.NewMs(k)
-	qo := types.NewQueryOptions()
-
-	_, err := memoryStorage.GeoradiusWithCoordAndDist("", float64(43.6075274), float64(3.9128795), float64(200), "km", qo)
-
-	assert.NotNil(t, err)
-	assert.Equal(t, "[400] Ms.GeoradiusWithCoordAndDist: key required", fmt.Sprint(err))
-}
-
-func TestGeoradiusWithCoordAndDistError(t *testing.T) {
-	c := &internal.MockedConnection{
-		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "Unit test error"}}
-		},
-	}
-	k, _ := kuzzle.NewKuzzle(c, nil)
-	memoryStorage := MemoryStorage.NewMs(k)
-	qo := types.NewQueryOptions()
-
-	_, err := memoryStorage.GeoradiusWithCoordAndDist("foo", float64(43.6075274), float64(3.9128795), float64(200), "km", qo)
-
-	assert.NotNil(t, err)
-}
-
-func TestGeoradiusWithCoordAndDistDistConvError(t *testing.T) {
-	c := &internal.MockedConnection{
-		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			parsedQuery := &types.KuzzleRequest{}
-			json.Unmarshal(query, parsedQuery)
-
-			assert.Equal(t, "ms", parsedQuery.Controller)
-			assert.Equal(t, "georadius", parsedQuery.Action)
-			assert.Equal(t, "foo", parsedQuery.Id)
-
-			var opts []interface{}
-			opts = append(opts, "count")
-			opts = append(opts, float64(42))
-			opts = append(opts, "ASC")
-			opts = append(opts, "withcoord")
-			opts = append(opts, "withdist")
-
-			assert.Equal(t, opts, parsedQuery.Options)
-
-			var response [][]interface{}
-			var location []interface{}
-			var point []interface{}
-
-			point = append(point, "43.6075274")
-			point = append(point, "3.9128795")
-			location = append(location, "Montpellier")
-			location = append(location, "125.23abc")
-			location = append(location, point)
-			response = append(response, location)
-
-			r, _ := json.Marshal(response)
-			return &types.KuzzleResponse{Result: r}
-		},
-	}
-	k, _ := kuzzle.NewKuzzle(c, nil)
-	memoryStorage := MemoryStorage.NewMs(k)
-	qo := types.NewQueryOptions()
-	qo.SetSort("ASC").SetCount(42)
-
-	_, err := memoryStorage.GeoradiusWithCoordAndDist("foo", float64(43.6075274), float64(3.9128795), float64(200), "km", qo)
-
-	assert.NotNil(t, err)
-}
-
-func TestGeoradiusWithCoordAndDistLonConvError(t *testing.T) {
-	c := &internal.MockedConnection{
-		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			parsedQuery := &types.KuzzleRequest{}
-			json.Unmarshal(query, parsedQuery)
-
-			assert.Equal(t, "ms", parsedQuery.Controller)
-			assert.Equal(t, "georadius", parsedQuery.Action)
-			assert.Equal(t, "foo", parsedQuery.Id)
-
-			var opts []interface{}
-			opts = append(opts, "count")
-			opts = append(opts, float64(42))
-			opts = append(opts, "ASC")
-			opts = append(opts, "withcoord")
-			opts = append(opts, "withdist")
-
-			assert.Equal(t, opts, parsedQuery.Options)
-
-			var response [][]interface{}
-			var location []interface{}
-			var point []interface{}
-
-			point = append(point, "43.6075abc")
-			point = append(point, "3.9128795")
-			location = append(location, "Montpellier")
-			location = append(location, "125")
-			location = append(location, point)
-			response = append(response, location)
-
-			r, _ := json.Marshal(response)
-			return &types.KuzzleResponse{Result: r}
-		},
-	}
-	k, _ := kuzzle.NewKuzzle(c, nil)
-	memoryStorage := MemoryStorage.NewMs(k)
-	qo := types.NewQueryOptions()
-	qo.SetSort("ASC").SetCount(42)
-
-	_, err := memoryStorage.GeoradiusWithCoordAndDist("foo", float64(43.6075274), float64(3.9128795), float64(200), "km", qo)
-
-	assert.NotNil(t, err)
-}
-
-func TestGeoradiusWithCoordAndDistLatConvError(t *testing.T) {
-	c := &internal.MockedConnection{
-		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			parsedQuery := &types.KuzzleRequest{}
-			json.Unmarshal(query, parsedQuery)
-
-			assert.Equal(t, "ms", parsedQuery.Controller)
-			assert.Equal(t, "georadius", parsedQuery.Action)
-			assert.Equal(t, "foo", parsedQuery.Id)
-
-			var opts []interface{}
-			opts = append(opts, "count")
-			opts = append(opts, float64(42))
-			opts = append(opts, "ASC")
-			opts = append(opts, "withcoord")
-			opts = append(opts, "withdist")
-
-			assert.Equal(t, opts, parsedQuery.Options)
-
-			var response [][]interface{}
-			var location []interface{}
-			var point []interface{}
-
-			point = append(point, "43.6075274")
-			point = append(point, "3.9128abc")
-			location = append(location, "Montpellier")
-			location = append(location, "125")
-			location = append(location, point)
-			response = append(response, location)
-
-			r, _ := json.Marshal(response)
-			return &types.KuzzleResponse{Result: r}
-		},
-	}
-	k, _ := kuzzle.NewKuzzle(c, nil)
-	memoryStorage := MemoryStorage.NewMs(k)
-	qo := types.NewQueryOptions()
-	qo.SetSort("ASC").SetCount(42)
-
-	_, err := memoryStorage.GeoradiusWithCoordAndDist("foo", float64(43.6075274), float64(3.9128795), float64(200), "km", qo)
-
-	assert.NotNil(t, err)
 }
 
 func TestGeoradiusWithCoordAndDist(t *testing.T) {
@@ -574,11 +364,11 @@ func TestGeoradiusWithCoordAndDist(t *testing.T) {
 	k, _ := kuzzle.NewKuzzle(c, nil)
 	memoryStorage := MemoryStorage.NewMs(k)
 	qo := types.NewQueryOptions()
-	qo.SetSort("ASC").SetCount(42)
+	qo.SetSort("ASC").SetCount(42).SetWithdist(true).SetWithcoord(true)
 
-	res, _ := memoryStorage.GeoradiusWithCoordAndDist("foo", float64(43.6075274), float64(3.9128795), float64(200), "km", qo)
+	res, _ := memoryStorage.Georadius("foo", float64(43.6075274), float64(3.9128795), float64(200), "km", qo)
 
-	assert.Equal(t, []*types.GeoradiusPointWithCoordAndDist{{Name: "Montpellier", Dist: 125, Lon: 43.6075274, Lat: 3.9128795}}, res)
+	assert.Equal(t, []*types.Georadius{{Name: "Montpellier", Dist: 125, Lon: 43.6075274, Lat: 3.9128795}}, res)
 }
 
 func ExampleMs_GeoradiusWithCoordAndDist() {
@@ -587,9 +377,9 @@ func ExampleMs_GeoradiusWithCoordAndDist() {
 	memoryStorage := MemoryStorage.NewMs(k)
 	qo := types.NewQueryOptions()
 
-	qo.SetSort("ASC").SetCount(42)
+	qo.SetSort("ASC").SetCount(42).SetWithcoord(true).SetWithdist(true)
 
-	res, err := memoryStorage.GeoradiusWithCoordAndDist("foo", float64(43.6075274), float64(3.9128795), float64(200), "km", qo)
+	res, err := memoryStorage.Georadius("foo", float64(43.6075274), float64(3.9128795), float64(200), "km", qo)
 
 	if err != nil {
 		fmt.Println(err.Error())

--- a/ms/georadiusbymember.go
+++ b/ms/georadiusbymember.go
@@ -1,13 +1,11 @@
 package ms
 
 import (
-	"encoding/json"
 	"github.com/kuzzleio/sdk-go/types"
-	"strconv"
 )
 
 // Georadiusbymember returns the geospatial members of a key inside the provided radius
-func (ms Ms) Georadiusbymember(key string, member string, distance float64, unit string, options types.QueryOptions) ([]string, error) {
+func (ms Ms) Georadiusbymember(key string, member string, distance float64, unit string, options types.QueryOptions) ([]*types.Georadius, error) {
 	if key == "" {
 		return nil, types.NewError("Ms.Georadiusbymember: key required", 400)
 	}
@@ -23,7 +21,7 @@ func (ms Ms) Georadiusbymember(key string, member string, distance float64, unit
 		Unit:       unit,
 	}
 
-	assignGeoradiusOptions(query, options, false, false)
+	assignGeoradiusOptions(query, options)
 
 	go ms.Kuzzle.Query(query, options, result)
 
@@ -32,168 +30,6 @@ func (ms Ms) Georadiusbymember(key string, member string, distance float64, unit
 	if res.Error != nil {
 		return nil, res.Error
 	}
-	var returnedResults []string
-	json.Unmarshal(res.Result, &returnedResults)
 
-	return returnedResults, nil
-}
-
-// GeoradiusbymemberWithCoord returns the geospatial members of a key inside the provided radius
-func (ms Ms) GeoradiusbymemberWithCoord(key string, member string, distance float64, unit string, options types.QueryOptions) ([]*types.GeoradiusPointWithCoord, error) {
-	if key == "" {
-		return nil, types.NewError("Ms.GeoradiusbymemberWithCoord: key required", 400)
-	}
-
-	result := make(chan *types.KuzzleResponse)
-
-	query := &types.KuzzleRequest{
-		Controller: "ms",
-		Action:     "georadiusbymember",
-		Id:         key,
-		Member:     member,
-		Distance:   distance,
-		Unit:       unit,
-	}
-
-	assignGeoradiusOptions(query, options, true, false)
-
-	go ms.Kuzzle.Query(query, options, result)
-
-	res := <-result
-
-	if res.Error != nil {
-		return nil, res.Error
-	}
-	var stringResults [][]interface{}
-	json.Unmarshal(res.Result, &stringResults)
-
-	returnedResults := make([]*types.GeoradiusPointWithCoord, len(stringResults))
-
-	for i, value := range stringResults {
-		returnedResults[i] = &types.GeoradiusPointWithCoord{Name: value[0].(string)}
-
-		tmp := value[1].([]interface{})[0].(string)
-		tmpF, err := strconv.ParseFloat(tmp, 64)
-		if err != nil {
-			return nil, types.NewError(err.Error())
-		}
-
-		returnedResults[i].Lon = tmpF
-
-		tmp = value[1].([]interface{})[1].(string)
-		tmpF, err = strconv.ParseFloat(tmp, 64)
-		if err != nil {
-			return nil, types.NewError(err.Error())
-		}
-
-		returnedResults[i].Lat = tmpF
-	}
-
-	return returnedResults, nil
-}
-
-// GeoradiusbymemberWithDist returns the geospatial members of a key inside the provided radius
-func (ms Ms) GeoradiusbymemberWithDist(key string, member string, distance float64, unit string, options types.QueryOptions) ([]*types.GeoradiusPointWithDist, error) {
-	if key == "" {
-		return nil, types.NewError("Ms.GeoradiusbymemberWithDist: key required", 400)
-	}
-
-	result := make(chan *types.KuzzleResponse)
-
-	query := &types.KuzzleRequest{
-		Controller: "ms",
-		Action:     "georadiusbymember",
-		Id:         key,
-		Member:     member,
-		Distance:   distance,
-		Unit:       unit,
-	}
-
-	assignGeoradiusOptions(query, options, false, true)
-
-	go ms.Kuzzle.Query(query, options, result)
-
-	res := <-result
-
-	if res.Error != nil {
-		return nil, res.Error
-	}
-	var stringResults [][]interface{}
-	json.Unmarshal(res.Result, &stringResults)
-
-	returnedResults := make([]*types.GeoradiusPointWithDist, len(stringResults))
-
-	for i, value := range stringResults {
-		returnedResults[i] = &types.GeoradiusPointWithDist{Name: value[0].(string)}
-
-		tmpF, err := strconv.ParseFloat(value[1].(string), 64)
-		if err != nil {
-			return nil, types.NewError(err.Error())
-		}
-
-		returnedResults[i].Dist = tmpF
-	}
-
-	return returnedResults, nil
-}
-
-// GeoradiusbymemberWithCoordAndDist returns the geospatial members of a key inside the provided radius
-func (ms Ms) GeoradiusbymemberWithCoordAndDist(key string, member string, distance float64, unit string, options types.QueryOptions) ([]*types.GeoradiusPointWithCoordAndDist, error) {
-	if key == "" {
-		return nil, types.NewError("Ms.GeoradiusbymemberWithCoordAndDist: key required", 400)
-	}
-
-	result := make(chan *types.KuzzleResponse)
-
-	query := &types.KuzzleRequest{
-		Controller: "ms",
-		Action:     "georadiusbymember",
-		Id:         key,
-		Member:     member,
-		Distance:   distance,
-		Unit:       unit,
-	}
-
-	assignGeoradiusOptions(query, options, true, true)
-
-	go ms.Kuzzle.Query(query, options, result)
-
-	res := <-result
-
-	if res.Error != nil {
-		return nil, res.Error
-	}
-	var stringResults [][]interface{}
-	json.Unmarshal(res.Result, &stringResults)
-
-	returnedResults := make([]*types.GeoradiusPointWithCoordAndDist, len(stringResults))
-
-	for i, value := range stringResults {
-		returnedResults[i] = &types.GeoradiusPointWithCoordAndDist{Name: value[0].(string)}
-
-		tmpF, err := strconv.ParseFloat(value[1].(string), 64)
-		if err != nil {
-			return nil, types.NewError(err.Error())
-		}
-
-		returnedResults[i].Dist = tmpF
-
-		tmp := value[2].([]interface{})[0].(string)
-		tmpF, err = strconv.ParseFloat(tmp, 64)
-		if err != nil {
-			return nil, types.NewError(err.Error())
-		}
-
-		returnedResults[i].Lon = tmpF
-
-		tmp = value[2].([]interface{})[1].(string)
-		tmpF, err = strconv.ParseFloat(tmp, 64)
-		if err != nil {
-			return nil, types.NewError(err.Error())
-		}
-
-		returnedResults[i].Lat = tmpF
-	}
-
-	return returnedResults, nil
+	return responseToGeoradius(res, options)
 }

--- a/ms/georadiusbymember_test.go
+++ b/ms/georadiusbymember_test.go
@@ -66,7 +66,7 @@ func TestGeoradiusbymember(t *testing.T) {
 
 	res, _ := memoryStorage.Georadiusbymember("foo", "member", float64(200), "km", qo)
 
-	assert.Equal(t, []string{"some", "results"}, res)
+	assert.Equal(t, []*types.Georadius{{Name: "some"}, {Name: "results"}}, res)
 }
 
 func ExampleMs_Georadiusbymember() {
@@ -85,32 +85,6 @@ func ExampleMs_Georadiusbymember() {
 	}
 
 	fmt.Println(res)
-}
-
-func TestGeoradiusbymemberWithCoordEmptyKey(t *testing.T) {
-	k, _ := kuzzle.NewKuzzle(&internal.MockedConnection{}, nil)
-	memoryStorage := MemoryStorage.NewMs(k)
-	qo := types.NewQueryOptions()
-
-	_, err := memoryStorage.GeoradiusbymemberWithCoord("", "member", float64(200), "km", qo)
-
-	assert.NotNil(t, err)
-	assert.Equal(t, "[400] Ms.GeoradiusbymemberWithCoord: key required", fmt.Sprint(err))
-}
-
-func TestGeoradiusbymemberWithCoordError(t *testing.T) {
-	c := &internal.MockedConnection{
-		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "Unit test error"}}
-		},
-	}
-	k, _ := kuzzle.NewKuzzle(c, nil)
-	memoryStorage := MemoryStorage.NewMs(k)
-	qo := types.NewQueryOptions()
-
-	_, err := memoryStorage.GeoradiusbymemberWithCoord("foo", "member", float64(200), "km", qo)
-
-	assert.NotNil(t, err)
 }
 
 func TestGeoradiusbymemberWithCoordLonConvError(t *testing.T) {
@@ -148,9 +122,9 @@ func TestGeoradiusbymemberWithCoordLonConvError(t *testing.T) {
 	k, _ := kuzzle.NewKuzzle(c, nil)
 	memoryStorage := MemoryStorage.NewMs(k)
 	qo := types.NewQueryOptions()
-	qo.SetSort("ASC").SetCount(42)
+	qo.SetSort("ASC").SetCount(42).SetWithcoord(true)
 
-	_, err := memoryStorage.GeoradiusbymemberWithCoord("foo", "member", float64(200), "km", qo)
+	_, err := memoryStorage.Georadiusbymember("foo", "member", float64(200), "km", qo)
 
 	assert.NotNil(t, err)
 }
@@ -190,9 +164,9 @@ func TestGeoradiusbymemberWithCoordLatConvError(t *testing.T) {
 	k, _ := kuzzle.NewKuzzle(c, nil)
 	memoryStorage := MemoryStorage.NewMs(k)
 	qo := types.NewQueryOptions()
-	qo.SetSort("ASC").SetCount(42)
+	qo.SetSort("ASC").SetCount(42).SetWithcoord(true)
 
-	_, err := memoryStorage.GeoradiusbymemberWithCoord("foo", "member", float64(200), "km", qo)
+	_, err := memoryStorage.Georadiusbymember("foo", "member", float64(200), "km", qo)
 
 	assert.NotNil(t, err)
 }
@@ -232,11 +206,11 @@ func TestGeoradiusbymemberWithCoord(t *testing.T) {
 	k, _ := kuzzle.NewKuzzle(c, nil)
 	memoryStorage := MemoryStorage.NewMs(k)
 	qo := types.NewQueryOptions()
-	qo.SetSort("ASC").SetCount(42)
+	qo.SetSort("ASC").SetCount(42).SetWithcoord(true)
 
-	res, _ := memoryStorage.GeoradiusbymemberWithCoord("foo", "member", float64(200), "km", qo)
+	res, _ := memoryStorage.Georadiusbymember("foo", "member", float64(200), "km", qo)
 
-	assert.Equal(t, []*types.GeoradiusPointWithCoord{{Name: "Montpellier", Lon: 43.6075274, Lat: 3.9128795}}, res)
+	assert.Equal(t, []*types.Georadius{{Name: "Montpellier", Lon: 43.6075274, Lat: 3.9128795}}, res)
 }
 
 func ExampleMs_GeoradiusbymemberWithCoord() {
@@ -245,9 +219,9 @@ func ExampleMs_GeoradiusbymemberWithCoord() {
 	memoryStorage := MemoryStorage.NewMs(k)
 	qo := types.NewQueryOptions()
 
-	qo.SetSort("ASC").SetCount(42)
+	qo.SetSort("ASC").SetCount(42).SetWithcoord(true)
 
-	res, err := memoryStorage.GeoradiusbymemberWithCoord("foo", "member", float64(200), "km", qo)
+	res, err := memoryStorage.Georadiusbymember("foo", "member", float64(200), "km", qo)
 
 	if err != nil {
 		fmt.Println(err.Error())
@@ -255,32 +229,6 @@ func ExampleMs_GeoradiusbymemberWithCoord() {
 	}
 
 	fmt.Println(res[0].Name, res[0].Lat, res[0].Lon)
-}
-
-func TestGeoradiusbymemberWithDistEmptyKey(t *testing.T) {
-	k, _ := kuzzle.NewKuzzle(&internal.MockedConnection{}, nil)
-	memoryStorage := MemoryStorage.NewMs(k)
-	qo := types.NewQueryOptions()
-
-	_, err := memoryStorage.GeoradiusbymemberWithDist("", "member", float64(200), "km", qo)
-
-	assert.NotNil(t, err)
-	assert.Equal(t, "[400] Ms.GeoradiusbymemberWithDist: key required", fmt.Sprint(err))
-}
-
-func TestGeoradiusbymemberWithDistError(t *testing.T) {
-	c := &internal.MockedConnection{
-		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "Unit test error"}}
-		},
-	}
-	k, _ := kuzzle.NewKuzzle(c, nil)
-	memoryStorage := MemoryStorage.NewMs(k)
-	qo := types.NewQueryOptions()
-
-	_, err := memoryStorage.GeoradiusbymemberWithDist("foo", "member", float64(200), "km", qo)
-
-	assert.NotNil(t, err)
 }
 
 func TestGeoradiusbymemberWithDistDistConvError(t *testing.T) {
@@ -315,9 +263,9 @@ func TestGeoradiusbymemberWithDistDistConvError(t *testing.T) {
 	k, _ := kuzzle.NewKuzzle(c, nil)
 	memoryStorage := MemoryStorage.NewMs(k)
 	qo := types.NewQueryOptions()
-	qo.SetSort("ASC").SetCount(42)
+	qo.SetSort("ASC").SetCount(42).SetWithdist(true)
 
-	_, err := memoryStorage.GeoradiusbymemberWithDist("foo", "member", float64(200), "km", qo)
+	_, err := memoryStorage.Georadiusbymember("foo", "member", float64(200), "km", qo)
 
 	assert.NotNil(t, err)
 }
@@ -354,11 +302,11 @@ func TestGeoradiusbymemberWithDist(t *testing.T) {
 	k, _ := kuzzle.NewKuzzle(c, nil)
 	memoryStorage := MemoryStorage.NewMs(k)
 	qo := types.NewQueryOptions()
-	qo.SetSort("ASC").SetCount(42)
+	qo.SetSort("ASC").SetCount(42).SetWithdist(true)
 
-	res, _ := memoryStorage.GeoradiusbymemberWithDist("foo", "member", float64(200), "km", qo)
+	res, _ := memoryStorage.Georadiusbymember("foo", "member", float64(200), "km", qo)
 
-	assert.Equal(t, []*types.GeoradiusPointWithDist{{Name: "Montpellier", Dist: 125}}, res)
+	assert.Equal(t, []*types.Georadius{{Name: "Montpellier", Dist: 125}}, res)
 }
 
 func ExampleMs_GeoradiusbymemberWithDist() {
@@ -367,9 +315,9 @@ func ExampleMs_GeoradiusbymemberWithDist() {
 	memoryStorage := MemoryStorage.NewMs(k)
 	qo := types.NewQueryOptions()
 
-	qo.SetSort("ASC").SetCount(42)
+	qo.SetSort("ASC").SetCount(42).SetWithdist(true)
 
-	res, err := memoryStorage.GeoradiusbymemberWithDist("foo", "member", float64(200), "km", qo)
+	res, err := memoryStorage.Georadiusbymember("foo", "member", float64(200), "km", qo)
 
 	if err != nil {
 		fmt.Println(err.Error())
@@ -377,163 +325,6 @@ func ExampleMs_GeoradiusbymemberWithDist() {
 	}
 
 	fmt.Println(res[0].Name, res[0].Dist)
-}
-
-func TestGeoradiusbymemberWithCoordAndDistEmptyKey(t *testing.T) {
-	k, _ := kuzzle.NewKuzzle(&internal.MockedConnection{}, nil)
-	memoryStorage := MemoryStorage.NewMs(k)
-	qo := types.NewQueryOptions()
-
-	_, err := memoryStorage.GeoradiusbymemberWithCoordAndDist("", "member", float64(200), "km", qo)
-
-	assert.NotNil(t, err)
-	assert.Equal(t, "[400] Ms.GeoradiusbymemberWithCoordAndDist: key required", fmt.Sprint(err))
-}
-
-func TestGeoradiusbymemberWithCoordAndDistError(t *testing.T) {
-	c := &internal.MockedConnection{
-		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "Unit test error"}}
-		},
-	}
-	k, _ := kuzzle.NewKuzzle(c, nil)
-	memoryStorage := MemoryStorage.NewMs(k)
-	qo := types.NewQueryOptions()
-
-	_, err := memoryStorage.GeoradiusbymemberWithCoordAndDist("foo", "member", float64(200), "km", qo)
-
-	assert.NotNil(t, err)
-}
-func TestGeoradiusbymemberWithCoordAndDistDistConvError(t *testing.T) {
-	c := &internal.MockedConnection{
-		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			parsedQuery := &types.KuzzleRequest{}
-			json.Unmarshal(query, parsedQuery)
-
-			assert.Equal(t, "ms", parsedQuery.Controller)
-			assert.Equal(t, "georadiusbymember", parsedQuery.Action)
-			assert.Equal(t, "foo", parsedQuery.Id)
-
-			var opts []interface{}
-			opts = append(opts, "count")
-			opts = append(opts, float64(42))
-			opts = append(opts, "ASC")
-			opts = append(opts, "withcoord")
-			opts = append(opts, "withdist")
-
-			assert.Equal(t, opts, parsedQuery.Options)
-
-			var response [][]interface{}
-			var location []interface{}
-			var point []interface{}
-
-			point = append(point, "43.6075274")
-			point = append(point, "3.9128795")
-			location = append(location, "Montpellier")
-			location = append(location, "125.23abc")
-			location = append(location, point)
-			response = append(response, location)
-
-			r, _ := json.Marshal(response)
-			return &types.KuzzleResponse{Result: r}
-		},
-	}
-	k, _ := kuzzle.NewKuzzle(c, nil)
-	memoryStorage := MemoryStorage.NewMs(k)
-	qo := types.NewQueryOptions()
-	qo.SetSort("ASC").SetCount(42)
-
-	_, err := memoryStorage.GeoradiusbymemberWithCoordAndDist("foo", "member", float64(200), "km", qo)
-
-	assert.NotNil(t, err)
-}
-
-func TestGeoradiusbymemberWithCoordAndDistLonConvError(t *testing.T) {
-	c := &internal.MockedConnection{
-		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			parsedQuery := &types.KuzzleRequest{}
-			json.Unmarshal(query, parsedQuery)
-
-			assert.Equal(t, "ms", parsedQuery.Controller)
-			assert.Equal(t, "georadiusbymember", parsedQuery.Action)
-			assert.Equal(t, "foo", parsedQuery.Id)
-
-			var opts []interface{}
-			opts = append(opts, "count")
-			opts = append(opts, float64(42))
-			opts = append(opts, "ASC")
-			opts = append(opts, "withcoord")
-			opts = append(opts, "withdist")
-
-			assert.Equal(t, opts, parsedQuery.Options)
-
-			var response [][]interface{}
-			var location []interface{}
-			var point []interface{}
-
-			point = append(point, "43.6075abc")
-			point = append(point, "3.9128795")
-			location = append(location, "Montpellier")
-			location = append(location, "125")
-			location = append(location, point)
-			response = append(response, location)
-
-			r, _ := json.Marshal(response)
-			return &types.KuzzleResponse{Result: r}
-		},
-	}
-	k, _ := kuzzle.NewKuzzle(c, nil)
-	memoryStorage := MemoryStorage.NewMs(k)
-	qo := types.NewQueryOptions()
-	qo.SetSort("ASC").SetCount(42)
-
-	_, err := memoryStorage.GeoradiusbymemberWithCoordAndDist("foo", "member", float64(200), "km", qo)
-
-	assert.NotNil(t, err)
-}
-
-func TestGeoradiusbymemberWithCoordAndDistLatConvError(t *testing.T) {
-	c := &internal.MockedConnection{
-		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			parsedQuery := &types.KuzzleRequest{}
-			json.Unmarshal(query, parsedQuery)
-
-			assert.Equal(t, "ms", parsedQuery.Controller)
-			assert.Equal(t, "georadiusbymember", parsedQuery.Action)
-			assert.Equal(t, "foo", parsedQuery.Id)
-
-			var opts []interface{}
-			opts = append(opts, "count")
-			opts = append(opts, float64(42))
-			opts = append(opts, "ASC")
-			opts = append(opts, "withcoord")
-			opts = append(opts, "withdist")
-
-			assert.Equal(t, opts, parsedQuery.Options)
-
-			var response [][]interface{}
-			var location []interface{}
-			var point []interface{}
-
-			point = append(point, "43.6075274")
-			point = append(point, "3.9128abc")
-			location = append(location, "Montpellier")
-			location = append(location, "125")
-			location = append(location, point)
-			response = append(response, location)
-
-			r, _ := json.Marshal(response)
-			return &types.KuzzleResponse{Result: r}
-		},
-	}
-	k, _ := kuzzle.NewKuzzle(c, nil)
-	memoryStorage := MemoryStorage.NewMs(k)
-	qo := types.NewQueryOptions()
-	qo.SetSort("ASC").SetCount(42)
-
-	_, err := memoryStorage.GeoradiusbymemberWithCoordAndDist("foo", "member", float64(200), "km", qo)
-
-	assert.NotNil(t, err)
 }
 
 func TestGeoradiusbymemberWithCoordAndDist(t *testing.T) {
@@ -573,11 +364,11 @@ func TestGeoradiusbymemberWithCoordAndDist(t *testing.T) {
 	k, _ := kuzzle.NewKuzzle(c, nil)
 	memoryStorage := MemoryStorage.NewMs(k)
 	qo := types.NewQueryOptions()
-	qo.SetSort("ASC").SetCount(42)
+	qo.SetSort("ASC").SetCount(42).SetWithdist(true).SetWithcoord(true)
 
-	res, _ := memoryStorage.GeoradiusbymemberWithCoordAndDist("foo", "member", float64(200), "km", qo)
+	res, _ := memoryStorage.Georadiusbymember("foo", "member", float64(200), "km", qo)
 
-	assert.Equal(t, []*types.GeoradiusPointWithCoordAndDist{{Name: "Montpellier", Dist: 125, Lon: 43.6075274, Lat: 3.9128795}}, res)
+	assert.Equal(t, []*types.Georadius{{Name: "Montpellier", Dist: 125, Lon: 43.6075274, Lat: 3.9128795}}, res)
 }
 
 func ExampleMs_GeoradiusbymemberWithCoordAndDist() {
@@ -586,9 +377,9 @@ func ExampleMs_GeoradiusbymemberWithCoordAndDist() {
 	memoryStorage := MemoryStorage.NewMs(k)
 	qo := types.NewQueryOptions()
 
-	qo.SetSort("ASC").SetCount(42)
+	qo.SetSort("ASC").SetCount(42).SetWithcoord(true).SetWithdist(true)
 
-	res, err := memoryStorage.GeoradiusbymemberWithCoordAndDist("foo", "member", float64(200), "km", qo)
+	res, err := memoryStorage.Georadiusbymember("foo", "member", float64(200), "km", qo)
 
 	if err != nil {
 		fmt.Println(err.Error())

--- a/types/kuzzle_response.go
+++ b/types/kuzzle_response.go
@@ -239,18 +239,7 @@ type (
 		Strategies []string        `json:"strategies"`
 	}
 
-	GeoradiusPointWithCoord struct {
-		Name string
-		Lon  float64
-		Lat  float64
-	}
-
-	GeoradiusPointWithDist struct {
-		Name string
-		Dist float64
-	}
-
-	GeoradiusPointWithCoordAndDist struct {
+	Georadius struct {
 		Name string
 		Lon  float64
 		Lat  float64

--- a/types/query_options.go
+++ b/types/query_options.go
@@ -59,6 +59,10 @@ type QueryOptions interface {
 	SetAlpha(bool) *queryOptions
 	GetUnit() string
 	SetUnit(string) *queryOptions
+	GetWithdist() bool
+	SetWithdist(bool) *queryOptions
+	GetWithcoord() bool
+	SetWithcoord(bool) *queryOptions
 }
 
 type queryOptions struct {
@@ -91,6 +95,8 @@ type queryOptions struct {
 	get             []string
 	alpha           bool
 	unit            string
+	withcoord				bool
+	withdist				bool
 }
 
 func (qo queryOptions) GetQueuable() bool {
@@ -353,6 +359,25 @@ func (qo *queryOptions) SetUnit(unit string) *queryOptions {
 	qo.unit = unit
 	return qo
 }
+
+func (qo *queryOptions) GetWithcoord() bool {
+	return qo.withcoord
+}
+
+func (qo *queryOptions) SetWithcoord(withcoord bool) *queryOptions {
+	qo.withcoord = withcoord
+	return qo
+}
+
+func (qo *queryOptions) GetWithdist() bool {
+	return qo.withdist
+}
+
+func (qo *queryOptions) SetWithdist(withdist bool) *queryOptions {
+	qo.withdist = withdist
+	return qo
+}
+
 func NewQueryOptions() *queryOptions {
 	return &queryOptions{
 		size:    10,


### PR DESCRIPTION
`ms.Georadius` and `ms.Georadiusbymember` behavior was inconsistent:

* 4 functions for each of these methods depending on the withdist/withcoord options combination, were the SDK specifications state that these are options
* 4 different types returned ( `[]string` and 3 different structures) depending on the function called, when a single structure is enough to describe returned geopoints, with parts set to `nil` if the provided options don't allow to fill them

This PR merges these 4 * 2 functions into 2 functions, returning a `[]*types.Geopoint` value.
That structure contains the following members:
- `Name`: always filled
- `Lon` and `Lat`: filled if `withcoord` is set, `nil` otherwise
- `Dist`: filled if `withdist` is set, `nil` otherwise

Also, the `QueryOptions` interface has been extended to had the `withdist` and `withcoord` boolean properties, with their corresponding getters and setters.

These changes also radically reduce cyclomatic complexity on these 2 exposed methods.