### PR TITLE
Is action allowed bool result

### DIFF
--- a/security/is_action_allowed.go
+++ b/security/is_action_allowed.go
@@ -12,15 +12,15 @@ const (
 
 // IsActionAllowed indicates whether an action is allowed, denied or conditional based on user rights provided as the first argument.
 // An action is defined as a couple of action and controller (mandatory), plus an index and a collection(optional).
-func (s *Security) IsActionAllowed(rights []*types.UserRights, controller string, action string, index string, collection string) (int, error) {
+func IsActionAllowed(rights []*types.UserRights, controller string, action string, index string, collection string) int {
 	if rights == nil {
-		return -1, types.NewError("Security.User.IsActionAllowed: Rights parameter is mandatory", 400)
+		return ActionIsDenied
 	}
 	if controller == "" {
-		return -1, types.NewError("Security.User.IsActionAllowed: Controller parameter is mandatory", 400)
+		return ActionIsDenied
 	}
 	if action == "" {
-		return -1, types.NewError("Security.User.IsActionAllowed: Action parameter is mandatory", 400)
+		return ActionIsDenied
 	}
 
 	filteredUserRights := make([]*types.UserRights, 0, len(rights))
@@ -33,12 +33,12 @@ func (s *Security) IsActionAllowed(rights []*types.UserRights, controller string
 
 	for _, ur := range filteredUserRights {
 		if ur.Value == "allowed" {
-			return ActionIsAllowed, nil
+			return ActionIsAllowed
 		}
 		if ur.Value == "conditional" {
-			return ActionIsConditional, nil
+			return ActionIsConditional
 		}
 	}
 
-	return ActionIsDenied, nil
+	return ActionIsDenied
 }

--- a/security/is_action_allowed_test.go
+++ b/security/is_action_allowed_test.go
@@ -4,93 +4,64 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/kuzzleio/sdk-go/connection/websocket"
-	"github.com/kuzzleio/sdk-go/internal"
-	"github.com/kuzzleio/sdk-go/kuzzle"
 	"github.com/kuzzleio/sdk-go/security"
 	"github.com/kuzzleio/sdk-go/types"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestIsActionAllowedNilRights(t *testing.T) {
-	k, _ := kuzzle.NewKuzzle(&internal.MockedConnection{}, nil)
-
-	_, err := k.Security.IsActionAllowed(nil, "wow-controller", "such-action", "", "")
-	assert.NotNil(t, err)
+	res := security.IsActionAllowed(nil, "wow-controller", "such-action", "", "")
+	assert.Equal(t, security.ActionIsDenied, res)
 }
 
 func TestIsActionAllowedEmptyController(t *testing.T) {
-	k, _ := kuzzle.NewKuzzle(&internal.MockedConnection{}, nil)
-
-	_, err := k.Security.IsActionAllowed([]*types.UserRights{}, "", "such-action", "", "")
-	assert.NotNil(t, err)
+	res := security.IsActionAllowed([]*types.UserRights{}, "", "such-action", "", "")
+	assert.Equal(t, security.ActionIsDenied, res)
 }
 
 func TestIsActionAllowedEmptyAction(t *testing.T) {
-	k, _ := kuzzle.NewKuzzle(&internal.MockedConnection{}, nil)
-
-	_, err := k.Security.IsActionAllowed([]*types.UserRights{}, "wow-controller", "", "", "")
-	assert.NotNil(t, err)
+	res := security.IsActionAllowed([]*types.UserRights{}, "wow-controller", "", "", "")
+	assert.Equal(t, security.ActionIsDenied, res)
 }
 
 func TestIsActionAllowedEmptyRights(t *testing.T) {
-	k, _ := kuzzle.NewKuzzle(&internal.MockedConnection{}, nil)
-
-	res, _ := k.Security.IsActionAllowed([]*types.UserRights{}, "wow-controller", "such-action", "much-index", "very-collection")
-
+	res := security.IsActionAllowed([]*types.UserRights{}, "wow-controller", "such-action", "much-index", "very-collection")
 	assert.Equal(t, security.ActionIsDenied, res)
 }
 
 func TestIsActionAllowedResultAllowed(t *testing.T) {
-	k, _ := kuzzle.NewKuzzle(&internal.MockedConnection{}, nil)
-
 	userRights := []*types.UserRights{
 		{Controller: "wow-controller", Action: "*", Index: "much-index", Collection: "very-collection", Value: "allowed"},
 	}
 
-	res, _ := k.Security.IsActionAllowed(userRights, "wow-controller", "such-action", "much-index", "very-collection")
-
+	res := security.IsActionAllowed(userRights, "wow-controller", "such-action", "much-index", "very-collection")
 	assert.Equal(t, security.ActionIsAllowed, res)
 }
 
 func TestIsActionAllowedResultConditional(t *testing.T) {
-	k, _ := kuzzle.NewKuzzle(&internal.MockedConnection{}, nil)
-
 	userRights := []*types.UserRights{
 		{Controller: "wow-controller", Action: "*", Index: "much-index", Collection: "very-collection", Value: "conditional"},
 	}
 
-	res, _ := k.Security.IsActionAllowed(userRights, "wow-controller", "action", "much-index", "very-collection")
+	res := security.IsActionAllowed(userRights, "wow-controller", "action", "much-index", "very-collection")
 
 	assert.Equal(t, security.ActionIsConditional, res)
 }
 
 func TestIsActionAllowedResultDenied(t *testing.T) {
-	k, _ := kuzzle.NewKuzzle(&internal.MockedConnection{}, nil)
-
 	userRights := []*types.UserRights{
 		{Controller: "wow-controller.", Action: "action-such", Index: "much-index", Collection: "very-collection", Value: "allowed"},
 	}
 
-	res, _ := k.Security.IsActionAllowed(userRights, "wow-controller", "action", "much-index", "very-collection")
-
+	res := security.IsActionAllowed(userRights, "wow-controller", "action", "much-index", "very-collection")
 	assert.Equal(t, security.ActionIsDenied, res)
 }
 
 func ExampleSecurityUser_IsActionAllowed() {
-	c := websocket.NewWebSocket("localhost:7512", nil)
-	k, _ := kuzzle.NewKuzzle(c, nil)
-
 	userRights := []*types.UserRights{
 		{Controller: "wow-controller", Action: "*", Index: "much-index", Collection: "very-collection", Value: "allowed"},
 	}
 
-	res, err := k.Security.IsActionAllowed(userRights, "wow-controller", "such-action", "much-index", "very-collection")
-
-	if err != nil {
-		fmt.Println(err.Error())
-		return
-	}
-
+	res := security.IsActionAllowed(userRights, "wow-controller", "such-action", "much-index", "very-collection")
 	fmt.Println(res)
 }


### PR DESCRIPTION
:warning: relies on #92 

* Make `IsActionAllowed` static
* Returns a single boolean-like value. Invalid parameters now lead to a `denied` response.

The main motivation for this last change is that it is much simpler to handle on C side. Further, the tested cases are only a subset of invalid entries. For instance, an non-existing controller/action will reply denied. Replying a denied response for anything which is not either conditional or allowed is more consistent imo