### PR TITLE
add linter check to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,6 @@ go:
   - 1.9
 install:
   go get -t -v ./...
-script: ./coverage.sh
+script: ./test.sh
 after_success:
   - cd .cover && bash <(curl -s https://codecov.io/bash)

--- a/test.sh
+++ b/test.sh
@@ -22,6 +22,17 @@ show_cover_report() {
     go tool cover -${1}="$profile"
 }
 
+linter_check() {
+    invalid_files=$(gofmt -l .)
+
+    if [ -n "${invalid_files}" ]; then
+        echo "Lint errors on the following files:"
+        echo ${invalid_files}
+        exit 1
+    fi
+}
+
+linter_check
 generate_cover_data
 show_cover_report func
 case "$1" in


### PR DESCRIPTION
Makes travis fail if a file does not follow Go's formatting rules.