### PR TITLE
Harmonize values returned by memory storage functions

### DIFF
--- a/ms/expire.go
+++ b/ms/expire.go
@@ -6,7 +6,7 @@ import (
 )
 
 // Expire sets an expiration timeout on a key
-func (ms Ms) Expire(key string, seconds int, options types.QueryOptions) (int, error) {
+func (ms Ms) Expire(key string, seconds int, options types.QueryOptions) (bool, error) {
 	result := make(chan *types.KuzzleResponse)
 
 	type body struct {
@@ -25,10 +25,11 @@ func (ms Ms) Expire(key string, seconds int, options types.QueryOptions) (int, e
 	res := <-result
 
 	if res.Error != nil {
-		return 0, res.Error
+		return false, res.Error
 	}
+
 	var returnedResult int
 	json.Unmarshal(res.Result, &returnedResult)
 
-	return returnedResult, nil
+	return returnedResult == 1, nil
 }

--- a/ms/expire_test.go
+++ b/ms/expire_test.go
@@ -43,7 +43,7 @@ func TestExpire(t *testing.T) {
 
 	res, _ := k.MemoryStorage.Expire("foo", 2, nil)
 
-	assert.Equal(t, 1, res)
+	assert.True(t, res)
 }
 
 func ExampleMs_Expire() {

--- a/ms/expireat.go
+++ b/ms/expireat.go
@@ -6,7 +6,7 @@ import (
 )
 
 // Expireat sets an expiration timestamp to a key
-func (ms Ms) Expireat(key string, timestamp int, options types.QueryOptions) (int, error) {
+func (ms Ms) Expireat(key string, timestamp int, options types.QueryOptions) (bool, error) {
 	result := make(chan *types.KuzzleResponse)
 
 	type body struct {
@@ -25,10 +25,10 @@ func (ms Ms) Expireat(key string, timestamp int, options types.QueryOptions) (in
 	res := <-result
 
 	if res.Error != nil {
-		return 0, res.Error
+		return false, res.Error
 	}
 	var returnedResult int
 	json.Unmarshal(res.Result, &returnedResult)
 
-	return returnedResult, nil
+	return returnedResult == 1, nil
 }

--- a/ms/expireat_test.go
+++ b/ms/expireat_test.go
@@ -43,7 +43,7 @@ func TestExpireat(t *testing.T) {
 
 	res, _ := k.MemoryStorage.Expireat("foo", 2, nil)
 
-	assert.Equal(t, 1, res)
+	assert.True(t, res)
 }
 
 func ExampleMs_Expireat() {

--- a/ms/flushdb.go
+++ b/ms/flushdb.go
@@ -1,12 +1,11 @@
 package ms
 
 import (
-	"encoding/json"
 	"github.com/kuzzleio/sdk-go/types"
 )
 
 // Flushdb delete all keys from the database
-func (ms Ms) Flushdb(options types.QueryOptions) (string, error) {
+func (ms Ms) Flushdb(options types.QueryOptions) error {
 	result := make(chan *types.KuzzleResponse)
 
 	query := &types.KuzzleRequest{
@@ -17,11 +16,5 @@ func (ms Ms) Flushdb(options types.QueryOptions) (string, error) {
 
 	res := <-result
 
-	if res.Error != nil {
-		return "", res.Error
-	}
-	var returnedResult string
-	json.Unmarshal(res.Result, &returnedResult)
-
-	return returnedResult, nil
+	return res.Error
 }

--- a/ms/flushdb_test.go
+++ b/ms/flushdb_test.go
@@ -19,7 +19,7 @@ func TestFlushdbError(t *testing.T) {
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)
 
-	_, err := k.MemoryStorage.Flushdb(nil)
+	err := k.MemoryStorage.Flushdb(nil)
 
 	assert.NotNil(t, err)
 }
@@ -39,21 +39,21 @@ func TestFlushdb(t *testing.T) {
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)
 
-	res, _ := k.MemoryStorage.Flushdb(nil)
+	err := k.MemoryStorage.Flushdb(nil)
 
-	assert.Equal(t, "OK", res)
+	assert.Nil(t, err)
 }
 
 func ExampleMs_Flushdb() {
 	c := websocket.NewWebSocket("localhost:7512", nil)
 	k, _ := kuzzle.NewKuzzle(c, nil)
 
-	res, err := k.MemoryStorage.Flushdb(nil)
+	err := k.MemoryStorage.Flushdb(nil)
 
 	if err != nil {
 		fmt.Println(err.Error())
 		return
 	}
 
-	fmt.Println(res)
+	fmt.Println("success")
 }

--- a/ms/hexists.go
+++ b/ms/hexists.go
@@ -6,7 +6,7 @@ import (
 )
 
 // Hexists check if a field exists in a hash
-func (ms Ms) Hexists(key string, field string, options types.QueryOptions) (int, error) {
+func (ms Ms) Hexists(key string, field string, options types.QueryOptions) (bool, error) {
 	result := make(chan *types.KuzzleResponse)
 
 	query := &types.KuzzleRequest{
@@ -21,11 +21,11 @@ func (ms Ms) Hexists(key string, field string, options types.QueryOptions) (int,
 	res := <-result
 
 	if res.Error != nil {
-		return -1, res.Error
+		return false, res.Error
 	}
 
 	var returnedResult int
 	json.Unmarshal(res.Result, &returnedResult)
 
-	return returnedResult, nil
+	return returnedResult == 1, nil
 }

--- a/ms/hexists_test.go
+++ b/ms/hexists_test.go
@@ -43,7 +43,7 @@ func TestHexists(t *testing.T) {
 
 	res, _ := k.MemoryStorage.Hexists("foo", "bar", nil)
 
-	assert.Equal(t, 1, res)
+	assert.True(t, res)
 }
 
 func ExampleMs_Hexists() {

--- a/ms/hmset.go
+++ b/ms/hmset.go
@@ -1,14 +1,13 @@
 package ms
 
 import (
-	"encoding/json"
 	"github.com/kuzzleio/sdk-go/types"
 )
 
 // Hmset sets multiple fields at once in a hash.
-func (ms Ms) Hmset(key string, entries []*types.MsHashField, options types.QueryOptions) (string, error) {
+func (ms Ms) Hmset(key string, entries []*types.MsHashField, options types.QueryOptions) error {
 	if len(entries) == 0 {
-		return "", types.NewError("Ms.Hmset: at least one entry field to set is required", 400)
+		return types.NewError("Ms.Hmset: at least one entry field to set is required", 400)
 	}
 
 	result := make(chan *types.KuzzleResponse)
@@ -28,12 +27,5 @@ func (ms Ms) Hmset(key string, entries []*types.MsHashField, options types.Query
 
 	res := <-result
 
-	if res.Error != nil {
-		return "", res.Error
-	}
-
-	var returnedResult string
-	json.Unmarshal(res.Result, &returnedResult)
-
-	return returnedResult, nil
+	return res.Error
 }

--- a/ms/hmset_test.go
+++ b/ms/hmset_test.go
@@ -14,7 +14,7 @@ import (
 func TestHmsetEmptyEntries(t *testing.T) {
 	k, _ := kuzzle.NewKuzzle(&internal.MockedConnection{}, nil)
 
-	_, err := k.MemoryStorage.Hmset("", []*types.MsHashField{}, nil)
+	err := k.MemoryStorage.Hmset("", []*types.MsHashField{}, nil)
 
 	assert.NotNil(t, err)
 	assert.Equal(t, "[400] Ms.Hmset: at least one entry field to set is required", fmt.Sprint(err))
@@ -28,7 +28,7 @@ func TestHmsetError(t *testing.T) {
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)
 
-	_, err := k.MemoryStorage.Hmset("foo", []*types.MsHashField{}, nil)
+	err := k.MemoryStorage.Hmset("foo", []*types.MsHashField{}, nil)
 
 	assert.NotNil(t, err)
 }
@@ -51,21 +51,21 @@ func TestHmset(t *testing.T) {
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)
 
-	res, _ := k.MemoryStorage.Hmset("foo", []*types.MsHashField{{Field: "foo", Value: "bar"}}, nil)
+	err := k.MemoryStorage.Hmset("foo", []*types.MsHashField{{Field: "foo", Value: "bar"}}, nil)
 
-	assert.Equal(t, "result", res)
+	assert.Nil(t, err)
 }
 
 func ExampleMs_Hmset() {
 	c := websocket.NewWebSocket("localhost:7512", nil)
 	k, _ := kuzzle.NewKuzzle(c, nil)
 
-	res, err := k.MemoryStorage.Hmset("foo", []*types.MsHashField{{Field: "foo", Value: "bar"}}, nil)
+	err := k.MemoryStorage.Hmset("foo", []*types.MsHashField{{Field: "foo", Value: "bar"}}, nil)
 
 	if err != nil {
 		fmt.Println(err.Error())
 		return
 	}
 
-	fmt.Println(res)
+	fmt.Println("success")
 }

--- a/ms/hset.go
+++ b/ms/hset.go
@@ -7,7 +7,7 @@ import (
 
 // Hset sets a field and its value in a hash.
 // if the key does not exist, a new key holding a hash is created.
-func (ms Ms) Hset(key string, field string, value string, options types.QueryOptions) (int, error) {
+func (ms Ms) Hset(key string, field string, value string, options types.QueryOptions) (bool, error) {
 	result := make(chan *types.KuzzleResponse)
 
 	type body struct {
@@ -27,11 +27,11 @@ func (ms Ms) Hset(key string, field string, value string, options types.QueryOpt
 	res := <-result
 
 	if res.Error != nil {
-		return 0, res.Error
+		return false, res.Error
 	}
 
 	var returnedResult int
 	json.Unmarshal(res.Result, &returnedResult)
 
-	return returnedResult, nil
+	return returnedResult == 1, nil
 }

--- a/ms/hset_test.go
+++ b/ms/hset_test.go
@@ -44,7 +44,7 @@ func TestHset(t *testing.T) {
 
 	res, _ := k.MemoryStorage.Hset("foo", "bar", "barbar", nil)
 
-	assert.Equal(t, 1, res)
+	assert.True(t, res)
 }
 
 func ExampleMs_Hset() {

--- a/ms/hsetnx.go
+++ b/ms/hsetnx.go
@@ -6,7 +6,7 @@ import (
 )
 
 // Hsetnx sets a field and its value in a hash, only if the field does not already exist.
-func (ms Ms) Hsetnx(key string, field string, value string, options types.QueryOptions) (int, error) {
+func (ms Ms) Hsetnx(key string, field string, value string, options types.QueryOptions) (bool, error) {
 	result := make(chan *types.KuzzleResponse)
 
 	type body struct {
@@ -26,11 +26,11 @@ func (ms Ms) Hsetnx(key string, field string, value string, options types.QueryO
 	res := <-result
 
 	if res.Error != nil {
-		return 0, res.Error
+		return false, res.Error
 	}
 
 	var returnedResult int
 	json.Unmarshal(res.Result, &returnedResult)
 
-	return returnedResult, nil
+	return returnedResult == 1, nil
 }

--- a/ms/hsetnx_test.go
+++ b/ms/hsetnx_test.go
@@ -44,7 +44,7 @@ func TestHsetnx(t *testing.T) {
 
 	res, _ := k.MemoryStorage.Hsetnx("foo", "bar", "barbar", nil)
 
-	assert.Equal(t, 1, res)
+	assert.True(t, res)
 }
 
 func ExampleMs_Hsetnx() {

--- a/ms/lset.go
+++ b/ms/lset.go
@@ -1,12 +1,11 @@
 package ms
 
 import (
-	"encoding/json"
 	"github.com/kuzzleio/sdk-go/types"
 )
 
 // Lset sets the list element at index with the provided value.
-func (ms Ms) Lset(key string, index int, value string, options types.QueryOptions) (string, error) {
+func (ms Ms) Lset(key string, index int, value string, options types.QueryOptions) error {
 	result := make(chan *types.KuzzleResponse)
 
 	type body struct {
@@ -25,11 +24,5 @@ func (ms Ms) Lset(key string, index int, value string, options types.QueryOption
 
 	res := <-result
 
-	if res.Error != nil {
-		return "", res.Error
-	}
-	var returnedResult string
-	json.Unmarshal(res.Result, &returnedResult)
-
-	return returnedResult, nil
+	return res.Error
 }

--- a/ms/lset_test.go
+++ b/ms/lset_test.go
@@ -19,7 +19,7 @@ func TestLsetError(t *testing.T) {
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)
 
-	_, err := k.MemoryStorage.Lset("foo", 1, "bar", nil)
+	err := k.MemoryStorage.Lset("foo", 1, "bar", nil)
 
 	assert.NotNil(t, err)
 }
@@ -42,21 +42,21 @@ func TestLset(t *testing.T) {
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)
 
-	res, _ := k.MemoryStorage.Lset("foo", 1, "bar", nil)
+	err := k.MemoryStorage.Lset("foo", 1, "bar", nil)
 
-	assert.Equal(t, "result", res)
+	assert.Nil(t, err)
 }
 
 func ExampleMs_Lset() {
 	c := websocket.NewWebSocket("localhost:7512", nil)
 	k, _ := kuzzle.NewKuzzle(c, nil)
 
-	res, err := k.MemoryStorage.Lset("foo", 1, "bar", nil)
+	err := k.MemoryStorage.Lset("foo", 1, "bar", nil)
 
 	if err != nil {
 		fmt.Println(err.Error())
 		return
 	}
 
-	fmt.Println(res)
+	fmt.Println("success")
 }

--- a/ms/ltrim.go
+++ b/ms/ltrim.go
@@ -1,13 +1,12 @@
 package ms
 
 import (
-	"encoding/json"
 	"github.com/kuzzleio/sdk-go/types"
 )
 
 // Ltrim trims an existing list so that it will
 // contain only the specified range of elements specified.
-func (ms Ms) Ltrim(key string, start int, stop int, options types.QueryOptions) (string, error) {
+func (ms Ms) Ltrim(key string, start int, stop int, options types.QueryOptions) error {
 	result := make(chan *types.KuzzleResponse)
 
 	type body struct {
@@ -26,11 +25,5 @@ func (ms Ms) Ltrim(key string, start int, stop int, options types.QueryOptions) 
 
 	res := <-result
 
-	if res.Error != nil {
-		return "", res.Error
-	}
-	var returnedResult string
-	json.Unmarshal(res.Result, &returnedResult)
-
-	return returnedResult, nil
+	return res.Error
 }

--- a/ms/ltrim_test.go
+++ b/ms/ltrim_test.go
@@ -19,7 +19,7 @@ func TestLtrimError(t *testing.T) {
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)
 
-	_, err := k.MemoryStorage.Ltrim("foo", 1, 2, nil)
+	err := k.MemoryStorage.Ltrim("foo", 1, 2, nil)
 
 	assert.NotNil(t, err)
 }
@@ -42,21 +42,21 @@ func TestLtrim(t *testing.T) {
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)
 
-	res, _ := k.MemoryStorage.Ltrim("foo", 1, 2, nil)
+	err := k.MemoryStorage.Ltrim("foo", 1, 2, nil)
 
-	assert.Equal(t, "result", res)
+	assert.Nil(t, err)
 }
 
 func ExampleMs_Ltrim() {
 	c := websocket.NewWebSocket("localhost:7512", nil)
 	k, _ := kuzzle.NewKuzzle(c, nil)
 
-	res, err := k.MemoryStorage.Ltrim("foo", 1, 2, nil)
+	err := k.MemoryStorage.Ltrim("foo", 1, 2, nil)
 
 	if err != nil {
 		fmt.Println(err.Error())
 		return
 	}
 
-	fmt.Println(res)
+	fmt.Println("success")
 }

--- a/ms/mset.go
+++ b/ms/mset.go
@@ -1,15 +1,14 @@
 package ms
 
 import (
-	"encoding/json"
 	"github.com/kuzzleio/sdk-go/types"
 )
 
 // Mset sets the provided keys to their respective values.
 // If a key does not exist, it is created. Otherwise, the key’s value is overwritten.
-func (ms Ms) Mset(entries []*types.MSKeyValue, options types.QueryOptions) (string, error) {
+func (ms Ms) Mset(entries []*types.MSKeyValue, options types.QueryOptions) error {
 	if len(entries) == 0 {
-		return "", types.NewError("Ms.Mset: please provide at least one key/value entry", 400)
+		return types.NewError("Ms.Mset: please provide at least one key/value entry", 400)
 	}
 
 	result := make(chan *types.KuzzleResponse)
@@ -27,11 +26,5 @@ func (ms Ms) Mset(entries []*types.MSKeyValue, options types.QueryOptions) (stri
 
 	res := <-result
 
-	if res.Error != nil {
-		return "", res.Error
-	}
-	var returnedResult string
-	json.Unmarshal(res.Result, &returnedResult)
-
-	return returnedResult, nil
+	return res.Error
 }

--- a/ms/mset_test.go
+++ b/ms/mset_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestMsetEmptyEntries(t *testing.T) {
 	k, _ := kuzzle.NewKuzzle(&internal.MockedConnection{}, nil)
-	_, err := k.MemoryStorage.Mset([]*types.MSKeyValue{}, nil)
+	err := k.MemoryStorage.Mset([]*types.MSKeyValue{}, nil)
 
 	assert.NotNil(t, err)
 	assert.Equal(t, "[400] Ms.Mset: please provide at least one key/value entry", fmt.Sprint(err))
@@ -32,7 +32,7 @@ func TestMsetError(t *testing.T) {
 		{Key: "bar", Value: "foo"},
 	}
 
-	_, err := k.MemoryStorage.Mset(entries, nil)
+	err := k.MemoryStorage.Mset(entries, nil)
 
 	assert.NotNil(t, err)
 }
@@ -57,9 +57,9 @@ func TestMset(t *testing.T) {
 		{Key: "bar", Value: "foo"},
 	}
 
-	res, _ := k.MemoryStorage.Mset(entries, nil)
+	err := k.MemoryStorage.Mset(entries, nil)
 
-	assert.Equal(t, "OK", res)
+	assert.Nil(t, err)
 }
 
 func ExampleMs_Mset() {
@@ -71,12 +71,12 @@ func ExampleMs_Mset() {
 		{Key: "bar", Value: "foo"},
 	}
 
-	res, err := k.MemoryStorage.Mset(entries, nil)
+	err := k.MemoryStorage.Mset(entries, nil)
 
 	if err != nil {
 		fmt.Println(err.Error())
 		return
 	}
 
-	fmt.Println(res)
+	fmt.Println("success")
 }

--- a/ms/msetnx.go
+++ b/ms/msetnx.go
@@ -7,9 +7,9 @@ import (
 
 // MsetNx sets the provided keys to their respective values, only if they do not exist.
 // If a key exists, then the whole operation is aborted and no key is set.
-func (ms Ms) Msetnx(entries []*types.MSKeyValue, options types.QueryOptions) (int, error) {
+func (ms Ms) Msetnx(entries []*types.MSKeyValue, options types.QueryOptions) (bool, error) {
 	if len(entries) == 0 {
-		return 0, types.NewError("Ms.Msetnx: please provide at least one key/value entry", 400)
+		return false, types.NewError("Ms.Msetnx: please provide at least one key/value entry", 400)
 	}
 
 	result := make(chan *types.KuzzleResponse)
@@ -28,10 +28,10 @@ func (ms Ms) Msetnx(entries []*types.MSKeyValue, options types.QueryOptions) (in
 	res := <-result
 
 	if res.Error != nil {
-		return 0, res.Error
+		return false, res.Error
 	}
 	var returnedResult int
 	json.Unmarshal(res.Result, &returnedResult)
 
-	return returnedResult, nil
+	return returnedResult == 1, nil
 }

--- a/ms/msetnx_test.go
+++ b/ms/msetnx_test.go
@@ -60,7 +60,7 @@ func TestMsetnx(t *testing.T) {
 
 	res, _ := k.MemoryStorage.Msetnx(entries, nil)
 
-	assert.Equal(t, 1, res)
+	assert.True(t, res)
 }
 
 func ExampleMs_Msetnx() {

--- a/ms/persist.go
+++ b/ms/persist.go
@@ -6,7 +6,7 @@ import (
 )
 
 // Persist removes the expiration delay or timestamp from a key, making it persistent.
-func (ms Ms) Persist(key string, options types.QueryOptions) (int, error) {
+func (ms Ms) Persist(key string, options types.QueryOptions) (bool, error) {
 	result := make(chan *types.KuzzleResponse)
 
 	query := &types.KuzzleRequest{
@@ -19,10 +19,10 @@ func (ms Ms) Persist(key string, options types.QueryOptions) (int, error) {
 	res := <-result
 
 	if res.Error != nil {
-		return 0, res.Error
+		return false, res.Error
 	}
 	var returnedResult int
 	json.Unmarshal(res.Result, &returnedResult)
 
-	return returnedResult, nil
+	return returnedResult == 1, nil
 }

--- a/ms/persist_test.go
+++ b/ms/persist_test.go
@@ -41,7 +41,7 @@ func TestPersists(t *testing.T) {
 
 	res, _ := k.MemoryStorage.Persist("foo", nil)
 
-	assert.Equal(t, 1, res)
+	assert.True(t, res)
 }
 
 func ExampleMs_Persist() {

--- a/ms/pexpire.go
+++ b/ms/pexpire.go
@@ -7,7 +7,7 @@ import (
 
 // Pexpire sets a timeout (in milliseconds) on a key.
 // After the timeout has expired, the key will automatically be deleted.
-func (ms Ms) Pexpire(key string, ttl int, options types.QueryOptions) (int, error) {
+func (ms Ms) Pexpire(key string, ttl int, options types.QueryOptions) (bool, error) {
 	result := make(chan *types.KuzzleResponse)
 
 	type body struct {
@@ -25,10 +25,10 @@ func (ms Ms) Pexpire(key string, ttl int, options types.QueryOptions) (int, erro
 	res := <-result
 
 	if res.Error != nil {
-		return 0, res.Error
+		return false, res.Error
 	}
 	var returnedResult int
 	json.Unmarshal(res.Result, &returnedResult)
 
-	return returnedResult, nil
+	return returnedResult == 1, nil
 }

--- a/ms/pexpire_test.go
+++ b/ms/pexpire_test.go
@@ -41,7 +41,7 @@ func TestPexpire(t *testing.T) {
 
 	res, _ := k.MemoryStorage.Pexpire("foo", 10, nil)
 
-	assert.Equal(t, 1, res)
+	assert.True(t, res)
 }
 
 func ExampleMs_Pexpire() {

--- a/ms/pexpireat.go
+++ b/ms/pexpireat.go
@@ -8,7 +8,7 @@ import (
 // PexipreAt sets an expiration timestamp on a key.
 // After the timestamp has been reached, the key will automatically be deleted.
 // The timestamp parameter accepts an Epoch time value, in milliseconds.
-func (ms Ms) Pexpireat(key string, timestamp int, options types.QueryOptions) (int, error) {
+func (ms Ms) Pexpireat(key string, timestamp int, options types.QueryOptions) (bool, error) {
 	result := make(chan *types.KuzzleResponse)
 
 	type body struct {
@@ -26,10 +26,10 @@ func (ms Ms) Pexpireat(key string, timestamp int, options types.QueryOptions) (i
 	res := <-result
 
 	if res.Error != nil {
-		return 0, res.Error
+		return false, res.Error
 	}
 	var returnedResult int
 	json.Unmarshal(res.Result, &returnedResult)
 
-	return returnedResult, nil
+	return returnedResult == 1, nil
 }

--- a/ms/pexpireat_test.go
+++ b/ms/pexpireat_test.go
@@ -41,7 +41,7 @@ func TestPexpireat(t *testing.T) {
 
 	res, _ := k.MemoryStorage.Pexpireat("foo", 1488540242465, nil)
 
-	assert.Equal(t, 1, res)
+	assert.True(t, res)
 }
 
 func ExampleMs_Pexpireat() {

--- a/ms/pfadd.go
+++ b/ms/pfadd.go
@@ -6,9 +6,9 @@ import (
 )
 
 // Pfadd Adds elements to an HyperLogLog data structure.
-func (ms Ms) Pfadd(key string, elements []string, options types.QueryOptions) (int, error) {
+func (ms Ms) Pfadd(key string, elements []string, options types.QueryOptions) (bool, error) {
 	if len(elements) == 0 {
-		return 0, types.NewError("Ms.Pfadd: please provide at least one element to add", 400)
+		return false, types.NewError("Ms.Pfadd: please provide at least one element to add", 400)
 	}
 
 	result := make(chan *types.KuzzleResponse)
@@ -28,10 +28,10 @@ func (ms Ms) Pfadd(key string, elements []string, options types.QueryOptions) (i
 	res := <-result
 
 	if res.Error != nil {
-		return 0, res.Error
+		return false, res.Error
 	}
 	var returnedResult int
 	json.Unmarshal(res.Result, &returnedResult)
 
-	return returnedResult, nil
+	return returnedResult == 1, nil
 }

--- a/ms/pfadd_test.go
+++ b/ms/pfadd_test.go
@@ -50,7 +50,7 @@ func TestPfadd(t *testing.T) {
 
 	res, _ := k.MemoryStorage.Pfadd("foo", []string{"bar", "rab"}, nil)
 
-	assert.Equal(t, 1, res)
+	assert.True(t, res)
 }
 
 func ExampleMs_Pfadd() {

--- a/ms/pfmerge.go
+++ b/ms/pfmerge.go
@@ -1,15 +1,14 @@
 package ms
 
 import (
-	"encoding/json"
 	"github.com/kuzzleio/sdk-go/types"
 )
 
 // Pfmerge merges multiple HyperLogLog data structures into an unique HyperLogLog
 // structure stored at key, approximating the cardinality of the union of the source structures.
-func (ms Ms) Pfmerge(key string, sources []string, options types.QueryOptions) (string, error) {
+func (ms Ms) Pfmerge(key string, sources []string, options types.QueryOptions) error {
 	if len(sources) == 0 {
-		return "", types.NewError("Ms.Pfmerge: please provide at least one source to merge", 400)
+		return types.NewError("Ms.Pfmerge: please provide at least one source to merge", 400)
 	}
 
 	result := make(chan *types.KuzzleResponse)
@@ -28,11 +27,5 @@ func (ms Ms) Pfmerge(key string, sources []string, options types.QueryOptions) (
 
 	res := <-result
 
-	if res.Error != nil {
-		return "", res.Error
-	}
-	var returnedResult string
-	json.Unmarshal(res.Result, &returnedResult)
-
-	return returnedResult, nil
+	return res.Error
 }

--- a/ms/pfmerge_test.go
+++ b/ms/pfmerge_test.go
@@ -14,7 +14,7 @@ import (
 func TestPfmergeEmptySources(t *testing.T) {
 	k, _ := kuzzle.NewKuzzle(&internal.MockedConnection{}, nil)
 
-	_, err := k.MemoryStorage.Pfmerge("foo", []string{}, nil)
+	err := k.MemoryStorage.Pfmerge("foo", []string{}, nil)
 
 	assert.NotNil(t, err)
 	assert.Equal(t, "[400] Ms.Pfmerge: please provide at least one source to merge", fmt.Sprint(err))
@@ -28,7 +28,7 @@ func TestPfmergeError(t *testing.T) {
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)
 
-	_, err := k.MemoryStorage.Pfmerge("foo", []string{"bar", "rab"}, nil)
+	err := k.MemoryStorage.Pfmerge("foo", []string{"bar", "rab"}, nil)
 
 	assert.NotNil(t, err)
 }
@@ -48,21 +48,21 @@ func TestPfmerge(t *testing.T) {
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)
 
-	res, _ := k.MemoryStorage.Pfmerge("foo", []string{"bar", "rab"}, nil)
+	err := k.MemoryStorage.Pfmerge("foo", []string{"bar", "rab"}, nil)
 
-	assert.Equal(t, "OK", res)
+	assert.Nil(t, err)
 }
 
 func ExampleMs_Pfmerge() {
 	c := websocket.NewWebSocket("localhost:7512", nil)
 	k, _ := kuzzle.NewKuzzle(c, nil)
 
-	res, err := k.MemoryStorage.Pfmerge("foo", []string{"bar", "rab"}, nil)
+	err := k.MemoryStorage.Pfmerge("foo", []string{"bar", "rab"}, nil)
 
 	if err != nil {
 		fmt.Println(err.Error())
 		return
 	}
 
-	fmt.Println(res)
+	fmt.Println("success")
 }

--- a/ms/psetex.go
+++ b/ms/psetex.go
@@ -1,13 +1,12 @@
 package ms
 
 import (
-	"encoding/json"
 	"github.com/kuzzleio/sdk-go/types"
 )
 
 // Psetex sets a key with the provided value, and an expiration delay expressed in milliseconds.
 // If the key does not exist, it is created beforehand.
-func (ms Ms) Psetex(key string, value string, ttl int, options types.QueryOptions) (string, error) {
+func (ms Ms) Psetex(key string, value string, ttl int, options types.QueryOptions) error {
 	result := make(chan *types.KuzzleResponse)
 
 	type body struct {
@@ -25,11 +24,5 @@ func (ms Ms) Psetex(key string, value string, ttl int, options types.QueryOption
 
 	res := <-result
 
-	if res.Error != nil {
-		return "", res.Error
-	}
-	var returnedResult string
-	json.Unmarshal(res.Result, &returnedResult)
-
-	return returnedResult, nil
+	return res.Error
 }

--- a/ms/psetex_test.go
+++ b/ms/psetex_test.go
@@ -19,7 +19,7 @@ func TestPsetexError(t *testing.T) {
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)
 
-	_, err := k.MemoryStorage.Psetex("foo", "bar", 60000, nil)
+	err := k.MemoryStorage.Psetex("foo", "bar", 60000, nil)
 
 	assert.NotNil(t, err)
 }
@@ -39,21 +39,21 @@ func TestPsetex(t *testing.T) {
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)
 
-	res, _ := k.MemoryStorage.Psetex("foo", "bar", 60000, nil)
+	err := k.MemoryStorage.Psetex("foo", "bar", 60000, nil)
 
-	assert.Equal(t, "OK", res)
+	assert.Nil(t, err)
 }
 
 func ExampleMs_Psetex() {
 	c := websocket.NewWebSocket("localhost:7512", nil)
 	k, _ := kuzzle.NewKuzzle(c, nil)
 
-	res, err := k.MemoryStorage.Psetex("foo", "bar", 60000, nil)
+	err := k.MemoryStorage.Psetex("foo", "bar", 60000, nil)
 
 	if err != nil {
 		fmt.Println(err.Error())
 		return
 	}
 
-	fmt.Println(res)
+	fmt.Println("success")
 }

--- a/ms/rename.go
+++ b/ms/rename.go
@@ -1,12 +1,11 @@
 package ms
 
 import (
-	"encoding/json"
 	"github.com/kuzzleio/sdk-go/types"
 )
 
 // Rename renames a key to newkey. If newkey already exists, it is overwritten.
-func (ms Ms) Rename(key string, newkey string, options types.QueryOptions) (string, error) {
+func (ms Ms) Rename(key string, newkey string, options types.QueryOptions) error {
 	result := make(chan *types.KuzzleResponse)
 
 	type body struct {
@@ -23,11 +22,5 @@ func (ms Ms) Rename(key string, newkey string, options types.QueryOptions) (stri
 
 	res := <-result
 
-	if res.Error != nil {
-		return "", res.Error
-	}
-	var returnedResult string
-	json.Unmarshal(res.Result, &returnedResult)
-
-	return returnedResult, nil
+	return res.Error
 }

--- a/ms/rename_test.go
+++ b/ms/rename_test.go
@@ -19,7 +19,7 @@ func TestRenameError(t *testing.T) {
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)
 
-	_, err := k.MemoryStorage.Rename("foo", "bar", nil)
+	err := k.MemoryStorage.Rename("foo", "bar", nil)
 
 	assert.NotNil(t, err)
 }
@@ -39,21 +39,21 @@ func TestRename(t *testing.T) {
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)
 
-	res, _ := k.MemoryStorage.Rename("foo", "bar", nil)
+	err := k.MemoryStorage.Rename("foo", "bar", nil)
 
-	assert.Equal(t, "OK", res)
+	assert.Nil(t, err)
 }
 
 func ExampleMs_Rename() {
 	c := websocket.NewWebSocket("localhost:7512", nil)
 	k, _ := kuzzle.NewKuzzle(c, nil)
 
-	res, err := k.MemoryStorage.Rename("foo", "bar", nil)
+	err := k.MemoryStorage.Rename("foo", "bar", nil)
 
 	if err != nil {
 		fmt.Println(err.Error())
 		return
 	}
 
-	fmt.Println(res)
+	fmt.Println("success")
 }

--- a/ms/renamenx.go
+++ b/ms/renamenx.go
@@ -6,7 +6,7 @@ import (
 )
 
 // RenameNx renames a key to newkey, only if newkey does not already exist.
-func (ms Ms) Renamenx(key string, newkey string, options types.QueryOptions) (int, error) {
+func (ms Ms) Renamenx(key string, newkey string, options types.QueryOptions) (bool, error) {
 	result := make(chan *types.KuzzleResponse)
 
 	type body struct {
@@ -24,10 +24,10 @@ func (ms Ms) Renamenx(key string, newkey string, options types.QueryOptions) (in
 	res := <-result
 
 	if res.Error != nil {
-		return 0, res.Error
+		return false, res.Error
 	}
 	var returnedResult int
 	json.Unmarshal(res.Result, &returnedResult)
 
-	return returnedResult, nil
+	return returnedResult == 1, nil
 }

--- a/ms/renamenx_test.go
+++ b/ms/renamenx_test.go
@@ -41,7 +41,7 @@ func TestRenamenx(t *testing.T) {
 
 	res, _ := k.MemoryStorage.Renamenx("foo", "bar", nil)
 
-	assert.Equal(t, 1, res)
+	assert.True(t, res)
 }
 
 func ExampleMs_Renamenx() {

--- a/ms/set.go
+++ b/ms/set.go
@@ -1,12 +1,11 @@
 package ms
 
 import (
-	"encoding/json"
 	"github.com/kuzzleio/sdk-go/types"
 )
 
 // Set creates a key holding the provided value, or overwrites it if it already exists.
-func (ms Ms) Set(key string, value interface{}, options types.QueryOptions) (string, error) {
+func (ms Ms) Set(key string, value interface{}, options types.QueryOptions) error {
 	result := make(chan *types.KuzzleResponse)
 
 	type body struct {
@@ -43,12 +42,5 @@ func (ms Ms) Set(key string, value interface{}, options types.QueryOptions) (str
 
 	res := <-result
 
-	if res.Error != nil {
-		return "", res.Error
-	}
-
-	var returnedResult string
-	json.Unmarshal(res.Result, &returnedResult)
-
-	return returnedResult, nil
+	return res.Error
 }

--- a/ms/set_test.go
+++ b/ms/set_test.go
@@ -19,7 +19,7 @@ func TestSetError(t *testing.T) {
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)
 
-	_, err := k.MemoryStorage.Set("foo", "bar", nil)
+	err := k.MemoryStorage.Set("foo", "bar", nil)
 
 	assert.NotNil(t, err)
 }
@@ -39,9 +39,9 @@ func TestSet(t *testing.T) {
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)
 
-	res, _ := k.MemoryStorage.Set("foo", []string{"bar", "rab"}, nil)
+	err := k.MemoryStorage.Set("foo", []string{"bar", "rab"}, nil)
 
-	assert.Equal(t, "OK", res)
+	assert.Nil(t, err)
 }
 
 func TestSetWithOptions(t *testing.T) {
@@ -65,21 +65,21 @@ func TestSetWithOptions(t *testing.T) {
 	qo.SetPx(42)
 	qo.SetXx(true)
 
-	res, _ := k.MemoryStorage.Set("foo", []string{"bar", "rab"}, qo)
+	err := k.MemoryStorage.Set("foo", []string{"bar", "rab"}, qo)
 
-	assert.Equal(t, "OK", res)
+	assert.Nil(t, err)
 }
 
 func ExampleMs_Set() {
 	c := websocket.NewWebSocket("localhost:7512", nil)
 	k, _ := kuzzle.NewKuzzle(c, nil)
 
-	res, err := k.MemoryStorage.Set("foo", []string{"bar", "rab"}, nil)
+	err := k.MemoryStorage.Set("foo", []string{"bar", "rab"}, nil)
 
 	if err != nil {
 		fmt.Println(err.Error())
 		return
 	}
 
-	fmt.Println(res)
+	fmt.Println("success")
 }

--- a/ms/setex.go
+++ b/ms/setex.go
@@ -1,13 +1,12 @@
 package ms
 
 import (
-	"encoding/json"
 	"github.com/kuzzleio/sdk-go/types"
 )
 
 // SetEx sets a key with the provided value, and an expiration delay expressed in seconds.
 // If the key does not exist, it is created beforehand.
-func (ms Ms) Setex(key string, value interface{}, ttl int, options types.QueryOptions) (string, error) {
+func (ms Ms) Setex(key string, value interface{}, ttl int, options types.QueryOptions) error {
 	result := make(chan *types.KuzzleResponse)
 
 	type body struct {
@@ -26,11 +25,5 @@ func (ms Ms) Setex(key string, value interface{}, ttl int, options types.QueryOp
 
 	res := <-result
 
-	if res.Error != nil {
-		return "", res.Error
-	}
-	var returnedResult string
-	json.Unmarshal(res.Result, &returnedResult)
-
-	return returnedResult, nil
+	return res.Error
 }

--- a/ms/setex_test.go
+++ b/ms/setex_test.go
@@ -19,7 +19,7 @@ func TestSetexError(t *testing.T) {
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)
 
-	_, err := k.MemoryStorage.Setex("foo", "bar", 60, nil)
+	err := k.MemoryStorage.Setex("foo", "bar", 60, nil)
 
 	assert.NotNil(t, err)
 }
@@ -39,21 +39,21 @@ func TestSetEx(t *testing.T) {
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)
 
-	res, _ := k.MemoryStorage.Setex("foo", "bar", 60, nil)
+	err := k.MemoryStorage.Setex("foo", "bar", 60, nil)
 
-	assert.Equal(t, "OK", res)
+	assert.Nil(t, err)
 }
 
 func ExampleMs_SetEx() {
 	c := websocket.NewWebSocket("localhost:7512", nil)
 	k, _ := kuzzle.NewKuzzle(c, nil)
 
-	res, err := k.MemoryStorage.Setex("foo", "bar", 60, nil)
+	err := k.MemoryStorage.Setex("foo", "bar", 60, nil)
 
 	if err != nil {
 		fmt.Println(err.Error())
 		return
 	}
 
-	fmt.Println(res)
+	fmt.Println("success")
 }

--- a/ms/setnx.go
+++ b/ms/setnx.go
@@ -6,7 +6,7 @@ import (
 )
 
 // SetNx sets a value on a key, only if it does not already exist.
-func (ms Ms) Setnx(key string, value interface{}, options types.QueryOptions) (int, error) {
+func (ms Ms) Setnx(key string, value interface{}, options types.QueryOptions) (bool, error) {
 	result := make(chan *types.KuzzleResponse)
 
 	type body struct {
@@ -25,10 +25,10 @@ func (ms Ms) Setnx(key string, value interface{}, options types.QueryOptions) (i
 	res := <-result
 
 	if res.Error != nil {
-		return 0, res.Error
+		return false, res.Error
 	}
 	var returnedResult int
 	json.Unmarshal(res.Result, &returnedResult)
 
-	return returnedResult, nil
+	return returnedResult == 1, nil
 }

--- a/ms/setnx_test.go
+++ b/ms/setnx_test.go
@@ -41,7 +41,7 @@ func TestSetnx(t *testing.T) {
 
 	res, _ := k.MemoryStorage.Setnx("foo", "bar", nil)
 
-	assert.Equal(t, 1, res)
+	assert.True(t, res)
 }
 
 func ExampleMs_Setnx() {

--- a/ms/sismember.go
+++ b/ms/sismember.go
@@ -6,7 +6,7 @@ import (
 )
 
 // Sismember checks if member is a member of the set of unique values stored at key.
-func (ms Ms) Sismember(key string, member string, options types.QueryOptions) (int, error) {
+func (ms Ms) Sismember(key string, member string, options types.QueryOptions) (bool, error) {
 	result := make(chan *types.KuzzleResponse)
 
 	query := &types.KuzzleRequest{
@@ -21,10 +21,10 @@ func (ms Ms) Sismember(key string, member string, options types.QueryOptions) (i
 	res := <-result
 
 	if res.Error != nil {
-		return 0, res.Error
+		return false, res.Error
 	}
 	var returnedResult int
 	json.Unmarshal(res.Result, &returnedResult)
 
-	return returnedResult, nil
+	return returnedResult == 1, nil
 }

--- a/ms/sismember_test.go
+++ b/ms/sismember_test.go
@@ -41,7 +41,7 @@ func TestSismember(t *testing.T) {
 
 	res, _ := k.MemoryStorage.Sismember("foo", "bar", nil)
 
-	assert.Equal(t, 1, res)
+	assert.True(t, res)
 }
 
 func ExampleMs_Sismember() {

--- a/ms/smove.go
+++ b/ms/smove.go
@@ -6,7 +6,7 @@ import (
 )
 
 // Smove moves a member from a set of unique values to another.
-func (ms Ms) Smove(key string, destination string, member string, options types.QueryOptions) (int, error) {
+func (ms Ms) Smove(key string, destination string, member string, options types.QueryOptions) (bool, error) {
 	result := make(chan *types.KuzzleResponse)
 
 	type body struct {
@@ -26,11 +26,11 @@ func (ms Ms) Smove(key string, destination string, member string, options types.
 	res := <-result
 
 	if res.Error != nil {
-		return 0, res.Error
+		return false, res.Error
 	}
 
 	var returnedResult int
 	json.Unmarshal(res.Result, &returnedResult)
 
-	return returnedResult, nil
+	return returnedResult == 1, nil
 }

--- a/ms/smove_test.go
+++ b/ms/smove_test.go
@@ -41,7 +41,7 @@ func TestSmove(t *testing.T) {
 
 	res, _ := k.MemoryStorage.Smove("wowKey", "suchDestination", "muchMember", nil)
 
-	assert.Equal(t, 1, res)
+	assert.True(t, res)
 }
 
 func ExampleMs_Smove() {


### PR DESCRIPTION
* MS functions returning either `0` or `1` are now returning a boolean instead of an integer
* MS functions returning `"OK"` now don't return anything when successful, and an error otherwise
