### PR TITLE
mono repo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,16 @@ language: go
 go:
   - 1.9
 install:
-  go get -t -v ./...
-script: ./test.sh
+  - git clone https://github.com/json-c/json-c.git
+  - cd json-c
+  - sudo apt-get install build-essential swig
+  - sh autogen.sh
+  - ./configure
+  - make
+  - sudo make install
+  - cd -
+  - go get -t -v ./...
+script: 
+  - bash ./test.sh
 after_success:
   - cd .cover && bash <(curl -s https://codecov.io/bash)

--- a/internal/wrappers/.gitignore
+++ b/internal/wrappers/.gitignore
@@ -1,8 +1,9 @@
 # IDE
 .idea
 
-# Libgokcore
-libgokcore.*
+# Auto-generated library
+kuzzle.h
+libkuzzlesdk.so
 
 # .out files
 *.out

--- a/internal/wrappers/.gitignore
+++ b/internal/wrappers/.gitignore
@@ -1,0 +1,16 @@
+# IDE
+.idea
+
+# Libgokcore
+libgokcore.*
+
+# .out files
+*.out
+
+# build
+/kcore_wrap.c
+/kcore_wrap.o
+/kuzzle.h
+/libkuzzle.so
+/libkuzzlesdk.so
+

--- a/internal/wrappers/.travis.yml
+++ b/internal/wrappers/.travis.yml
@@ -1,0 +1,17 @@
+language: go
+sudo: required
+go:
+  - 1.9
+install:
+  - git clone https://github.com/json-c/json-c.git
+  - cd json-c
+  - sudo apt-get install build-essential
+  - sh autogen.sh
+  - ./configure
+  - make
+  - sudo make install
+  - cd -
+  - go get -t -v ./...
+script:
+  - wrongfmt=$(gofmt -l .); if [ -n "$wrongfmt" ]; then printf "File format error:\n$wrongfmt\n"; (exit 1); fi
+  - make core

--- a/internal/wrappers/LICENSE
+++ b/internal/wrappers/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/internal/wrappers/Makefile
+++ b/internal/wrappers/Makefile
@@ -1,5 +1,5 @@
 CC = gcc
-CFLAGS = -fPIC -I$(PWD)/headers -I${JAVA_HOME}/include -I${JAVA_HOME}/include/linux
+CFLAGS = -std=c99 -fPIC -I$(PWD)/headers -I${JAVA_HOME}/include -I${JAVA_HOME}/include/linux
 LDFLAGS = -L./
 LIBS = -lkuzzlesdk -ljson-c
 SRCS = kcore_wrap.c

--- a/internal/wrappers/Makefile
+++ b/internal/wrappers/Makefile
@@ -1,0 +1,44 @@
+CC = gcc
+CFLAGS = -fPIC -I$(PWD)/headers -I${JAVA_HOME}/include -I${JAVA_HOME}/include/linux
+LDFLAGS = -L./
+LIBS = -lkuzzlesdk -ljson-c
+SRCS = kcore_wrap.c
+OBJS = $(SRCS:.c=.o)
+TARGET = libkcore.so
+
+GOROOT ?= /usr/local
+GOCC = $(GOROOT)/bin/go
+GOFLAGS = -buildmode=c-shared
+GOSRC = ./cgo/kuzzle/
+GOTARGET = libkuzzlesdk.so
+
+SWIG = swig
+
+all: java
+
+kcore_wrap.o: kcore_wrap.c
+	$(CC) -ggdb -c $< -o $@ $(CFLAGS) $(LDFLAGS) $(LIBS)
+
+core:
+ifeq ($(wildcard $(GOCC)),)
+	$(error "Unable to find go compiler")
+endif
+	$(GOCC) build -o $(GOTARGET) $(GOFLAGS) $(GOSRC)
+	mv -f libkuzzlesdk.h kuzzle.h
+
+wrapper: $(OBJS)
+
+object:
+	gcc -ggdb -shared kcore_wrap.o -o libkuzzle.so $(LDFLAGS) $(LIBS)
+
+swigjava:
+	$(SWIG) -Wall -java -package io.kuzzle.sdk -outdir ./io/kuzzle/sdk -o kcore_wrap.c -I/usr/local/include templates/java/core.i
+
+java: 	core swigjava wrapper object
+
+clean:
+	rm -rf build *.class *.o *.h *.so io/kuzzle/sdk/*.java io/kuzzle/sdk/*.class *.c *~ *.go
+
+.PHONY: all java wrapper swigjava clean object core
+
+.DEFAULT_GOAL := all

--- a/internal/wrappers/README.md
+++ b/internal/wrappers/README.md
@@ -1,0 +1,30 @@
+[![Build Status](https://travis-ci.org/kuzzleio/sdk-go.svg?branch=master)](https://travis-ci.org/kuzzleio/sdk-go)
+
+# SDK Wrappers
+
+This project contains a CGO wrapper to Kuzzle's [Go SDK](https://github.com/kuzzleio/sdk-go) and [SWIG templates](http://www.swig.org/), allowing to publish Kuzzle's SDK in multiple languages.
+
+# Pre-requisites
+
+* [Go](https://golang.org/doc/install)
+* [JSON-C library](https://github.com/json-c/json-c#install-using-apt-eg-ubuntu-16042-lts)
+
+# Contributing
+
+* Clone this project:
+
+```sh
+$ git clone git@github.com:kuzzleio/sdk-wrappers.git
+```
+
+* Build all SDKs:
+
+```sh
+$ make
+```
+
+* If you need to build the CGO wrapper only:
+
+```sh
+$ make core
+```

--- a/internal/wrappers/cgo/kuzzle/auth.go
+++ b/internal/wrappers/cgo/kuzzle/auth.go
@@ -1,0 +1,146 @@
+package main
+
+/*
+  #cgo CFLAGS: -I../../headers
+  #cgo LDFLAGS: -ljson-c
+
+  #include <stdlib.h>
+  #include <errno.h>
+  #include "kuzzlesdk.h"
+  #include "sdk_wrappers_internal.h"
+*/
+import "C"
+import (
+	"github.com/kuzzleio/sdk-go/kuzzle"
+)
+
+//export kuzzle_wrapper_set_jwt
+func kuzzle_wrapper_set_jwt(k *C.kuzzle, token *C.char) {
+	(*kuzzle.Kuzzle)(k.instance).SetJwt(C.GoString(token))
+}
+
+//export kuzzle_wrapper_unset_jwt
+func kuzzle_wrapper_unset_jwt(k *C.kuzzle) {
+	(*kuzzle.Kuzzle)(k.instance).UnsetJwt()
+}
+
+// Allocates memory
+//export kuzzle_wrapper_get_jwt
+func kuzzle_wrapper_get_jwt(k *C.kuzzle) *C.char {
+	return C.CString((*kuzzle.Kuzzle)(k.instance).GetJwt())
+}
+
+//export kuzzle_wrapper_login
+func kuzzle_wrapper_login(k *C.kuzzle, strategy *C.char, credentials *C.json_object, expires_in *C.int) *C.string_result {
+	var expire int
+	if expires_in != nil {
+		expire = int(*expires_in)
+	}
+
+	res, err := (*kuzzle.Kuzzle)(k.instance).Login(C.GoString(strategy), JsonCConvert(credentials).(map[string]interface{}), &expire)
+
+	return goToCStringResult(&res, err)
+}
+
+//export kuzzle_wrapper_logout
+func kuzzle_wrapper_logout(k *C.kuzzle) *C.char {
+	err := (*kuzzle.Kuzzle)(k.instance).Logout()
+	if err != nil {
+		return C.CString(err.Error())
+	}
+
+	return nil
+}
+
+//export kuzzle_wrapper_check_token
+func kuzzle_wrapper_check_token(k *C.kuzzle, token *C.char) *C.token_validity {
+	result := (*C.token_validity)(C.calloc(1, C.sizeof_token_validity))
+
+	res, err := (*kuzzle.Kuzzle)(k.instance).CheckToken(C.GoString(token))
+	if err != nil {
+		Set_token_validity_error(result, err)
+		return result
+	}
+
+	result.valid = C.bool(res.Valid)
+	result.state = C.CString(res.State)
+	result.expires_at = C.ulonglong(res.ExpiresAt)
+
+	return result
+}
+
+//export kuzzle_wrapper_create_my_credentials
+func kuzzle_wrapper_create_my_credentials(k *C.kuzzle, strategy *C.char, credentials *C.json_object, options *C.query_options) *C.json_result {
+	res, err := (*kuzzle.Kuzzle)(k.instance).CreateMyCredentials(
+		C.GoString(strategy),
+		JsonCConvert(credentials).(map[string]interface{}),
+		SetQueryOptions(options))
+
+	return goToCJsonResult(res, err)
+}
+
+//export kuzzle_wrapper_delete_my_credentials
+func kuzzle_wrapper_delete_my_credentials(k *C.kuzzle, strategy *C.char, options *C.query_options) *C.bool_result {
+	res, err := (*kuzzle.Kuzzle)(k.instance).DeleteMyCredentials(
+		C.GoString(strategy),
+		SetQueryOptions(options))
+
+	return goToCBoolResult(res, err)
+}
+
+//export kuzzle_wrapper_get_my_credentials
+func kuzzle_wrapper_get_my_credentials(k *C.kuzzle, strategy *C.char, options *C.query_options) *C.json_result {
+	res, err := (*kuzzle.Kuzzle)(k.instance).GetMyCredentials(
+		C.GoString(strategy),
+		SetQueryOptions(options))
+
+	return goToCJsonResult(res, err)
+}
+
+//export kuzzle_wrapper_update_my_credentials
+func kuzzle_wrapper_update_my_credentials(k *C.kuzzle, strategy *C.char, credentials *C.json_object, options *C.query_options) *C.json_result {
+	res, err := (*kuzzle.Kuzzle)(k.instance).UpdateMyCredentials(
+		C.GoString(strategy),
+		JsonCConvert(credentials).(map[string]interface{}),
+		SetQueryOptions(options))
+
+	return goToCJsonResult(res, err)
+}
+
+//export kuzzle_wrapper_validate_my_credentials
+func kuzzle_wrapper_validate_my_credentials(k *C.kuzzle, strategy *C.char, credentials *C.json_object, options *C.query_options) *C.bool_result {
+	res, err := (*kuzzle.Kuzzle)(k.instance).ValidateMyCredentials(
+		C.GoString(strategy),
+		JsonCConvert(credentials).(map[string]interface{}),
+		SetQueryOptions(options))
+
+	return goToCBoolResult(res, err)
+}
+
+//export kuzzle_wrapper_get_my_rights
+func kuzzle_wrapper_get_my_rights(k *C.kuzzle, options *C.query_options) *C.json_result {
+	res, err := (*kuzzle.Kuzzle)(k.instance).GetMyRights(SetQueryOptions(options))
+
+	return goToCJsonResult(res, err)
+}
+
+//export kuzzle_wrapper_update_self
+func kuzzle_wrapper_update_self(k *C.kuzzle, data *C.user_data, options *C.query_options) *C.json_result {
+	userData, err := cToGoUserData(data)
+	if err != nil {
+		return goToCJsonResult(nil, err)
+	}
+
+	res, err := (*kuzzle.Kuzzle)(k.instance).UpdateSelf(
+		userData,
+		SetQueryOptions(options))
+
+	return goToCJsonResult(res, err)
+}
+
+//export kuzzle_wrapper_who_am_i
+func kuzzle_wrapper_who_am_i(k *C.kuzzle) *C.user_result {
+	res, err := (*kuzzle.Kuzzle)(k.instance).WhoAmI()
+
+	return goToCUserResult(k, res, err)
+}

--- a/internal/wrappers/cgo/kuzzle/c_to_go.go
+++ b/internal/wrappers/cgo/kuzzle/c_to_go.go
@@ -84,7 +84,7 @@ func cToGoSearchFilters(searchFilters *C.search_filters) *types.SearchFilters {
 }
 
 // convert a C char** to a go array of string
-func cToGoStrings(arr **C.char, len C.uint) []string {
+func cToGoStrings(arr **C.char, len C.size_t) []string {
 	if len == 0 {
 		return nil
 	}

--- a/internal/wrappers/cgo/kuzzle/c_to_go.go
+++ b/internal/wrappers/cgo/kuzzle/c_to_go.go
@@ -1,0 +1,264 @@
+package main
+
+/*
+	#cgo CFLAGS: -I../../headers
+	#include <stdlib.h>
+	#include "kuzzlesdk.h"
+*/
+import "C"
+import (
+	"encoding/json"
+	"github.com/kuzzleio/sdk-go/collection"
+	"github.com/kuzzleio/sdk-go/kuzzle"
+	"github.com/kuzzleio/sdk-go/security"
+	"github.com/kuzzleio/sdk-go/types"
+	"unsafe"
+)
+
+func cToGoControllers(c *C.controllers) (*types.Controllers, error) {
+	if c == nil {
+		return nil, nil
+	}
+
+	if JsonCType(c) != C.json_type_object {
+		return nil, types.NewError("Invalid controller structure", 400)
+	}
+	j := JsonCConvert(c)
+	controllers := &types.Controllers{}
+
+	for controller, val := range j.(map[string]interface{}) {
+		rawController, ok := val.(map[string]interface{})
+		if !ok {
+			return nil, types.NewError("Invalid controllers structure", 400)
+		}
+
+		rawActions, ok := rawController["Actions"]
+		if !ok {
+			return nil, types.NewError("Invalid controllers structure", 400)
+		}
+
+		actionsMap, ok := rawActions.(map[string]interface{})
+		if !ok {
+			return nil, types.NewError("Invalid controllers structure", 400)
+		}
+
+		controllers.Controllers[controller] = &types.Controller{}
+		for action, value := range actionsMap {
+			boolValue, ok := value.(bool)
+			if !ok {
+				return nil, types.NewError("Invalid controllers structure", 400)
+			}
+
+			controllers.Controllers[controller].Actions[action] = boolValue
+		}
+	}
+
+	return controllers, nil
+}
+
+func cToGoRole(crole *C.role) (*security.Role, error) {
+	id := C.GoString(crole.id)
+	var controllers *types.Controllers
+
+	if crole.controllers != nil {
+		c, err := cToGoControllers(crole.controllers)
+
+		if err != nil {
+			return nil, err
+		}
+		controllers = c
+	}
+
+	role := (*kuzzle.Kuzzle)(crole.kuzzle.instance).Security.NewRole(id, controllers)
+
+	return role, nil
+}
+
+func cToGoSearchFilters(searchFilters *C.search_filters) *types.SearchFilters {
+	return &types.SearchFilters{
+		Query:        JsonCConvert(searchFilters.query),
+		Sort:         JsonCConvert(searchFilters.sort).([]interface{}),
+		Aggregations: JsonCConvert(searchFilters.aggregations),
+		SearchAfter:  JsonCConvert(searchFilters.search_after).([]interface{}),
+	}
+}
+
+// convert a C char** to a go array of string
+func cToGoStrings(arr **C.char, len C.uint) []string {
+	if len == 0 {
+		return nil
+	}
+
+	tmpslice := (*[1 << 30]*C.char)(unsafe.Pointer(arr))[:len:len]
+	goStrings := make([]string, len)
+	for i, s := range tmpslice {
+		goStrings[i] = C.GoString(s)
+	}
+
+	return goStrings
+}
+
+// Helper to convert a C document** to a go array of document pointers
+func cToGoDocuments(col *C.collection, docs **C.document, length C.uint) []*collection.Document {
+	if length == 0 {
+		return nil
+	}
+	tmpslice := (*[1 << 30]*C.document)(unsafe.Pointer(docs))[:length:length]
+	godocuments := make([]*collection.Document, length)
+	for i, doc := range tmpslice {
+		godocuments[i] = cToGoDocument(col, doc)
+	}
+	return godocuments
+}
+
+func cToGoShards(cShards *C.shards) *types.Shards {
+	return &types.Shards{
+		Total:      int(cShards.total),
+		Successful: int(cShards.successful),
+		Failed:     int(cShards.failed),
+	}
+}
+
+func cToGoKuzzleMeta(cMeta *C.meta) *types.Meta {
+	return &types.Meta{
+		Author:    C.GoString(cMeta.author),
+		CreatedAt: int(cMeta.created_at),
+		UpdatedAt: int(cMeta.updated_at),
+		Updater:   C.GoString(cMeta.updater),
+		Active:    bool(cMeta.active),
+		DeletedAt: int(cMeta.deleted_at),
+	}
+}
+
+func cToGoCollection(c *C.collection) *collection.Collection {
+	return collection.NewCollection((*kuzzle.Kuzzle)(c.kuzzle.instance), C.GoString(c.collection), C.GoString(c.index))
+}
+
+func cToGoMapping(cMapping *C.mapping) *collection.Mapping {
+	mapping := collection.NewMapping(cToGoCollection(cMapping.collection))
+	json.Unmarshal([]byte(C.GoString(C.json_object_to_json_string(cMapping.mapping))), &mapping.Mapping)
+
+	return mapping
+}
+
+func cToGoSpecification(cSpec *C.specification) *types.Specification {
+	spec := types.Specification{}
+	spec.Strict = bool(cSpec.strict)
+	json.Unmarshal([]byte(C.GoString(C.json_object_to_json_string(cSpec.fields))), &spec.Fields)
+	json.Unmarshal([]byte(C.GoString(C.json_object_to_json_string(cSpec.validators))), &spec.Validators)
+
+	return &spec
+}
+
+func cToGoDocument(c *C.collection, cDoc *C.document) *collection.Document {
+	gDoc := cToGoCollection(c).Document()
+	gDoc.Id = C.GoString(cDoc.id)
+	gDoc.Index = C.GoString(cDoc.index)
+	gDoc.Meta = cToGoKuzzleMeta(cDoc.meta)
+	gDoc.Shards = cToGoShards(cDoc.shards)
+	gDoc.Content = []byte(C.GoString(C.json_object_to_json_string(cDoc.content)))
+	gDoc.Version = int(cDoc.version)
+	gDoc.Result = C.GoString(cDoc.result)
+	gDoc.Collection = C.GoString(cDoc.collection)
+	gDoc.Created = bool(cDoc.created)
+
+	return gDoc
+}
+
+func cToGoPolicyRestriction(r *C.policy_restriction) *types.PolicyRestriction {
+	restriction := &types.PolicyRestriction{
+		Index: C.GoString(r.index),
+	}
+
+	if r.collections == nil {
+		return restriction
+	}
+
+	slice := (*[1<<30 - 1]*C.char)(unsafe.Pointer(r.collections))[:r.collections_length:r.collections_length]
+	for _, col := range slice {
+		restriction.Collections = append(restriction.Collections, C.GoString(col))
+	}
+
+	return restriction
+}
+
+func cToGoPolicy(p *C.policy) *types.Policy {
+	policy := &types.Policy{
+		RoleId: C.GoString(p.role_id),
+	}
+
+	if p.restricted_to == nil {
+		return policy
+	}
+
+	slice := (*[1<<30 - 1]*C.policy_restriction)(unsafe.Pointer(p.restricted_to))[:p.restricted_to_length]
+	for _, crestriction := range slice {
+		policy.RestrictedTo = append(policy.RestrictedTo, cToGoPolicyRestriction(crestriction))
+	}
+
+	return policy
+}
+
+func cToGoProfile(p *C.profile) *security.Profile {
+	profile := &security.Profile{
+		Id:       C.GoString(p.id),
+		Security: (*kuzzle.Kuzzle)(p.kuzzle.instance).Security,
+	}
+
+	if p.policies == nil {
+		return profile
+	}
+
+	slice := (*[1<<30 - 1]*C.policy)(unsafe.Pointer(p.policies))[:p.policies_length]
+	for _, cpolicy := range slice {
+		profile.Policies = append(profile.Policies, cToGoPolicy(cpolicy))
+	}
+
+	return profile
+}
+
+func cToGoUserData(cdata *C.user_data) (*types.UserData, error) {
+	if cdata == nil {
+		return nil, nil
+	}
+
+	data := &types.UserData{}
+
+	if cdata.content != nil {
+		err := json.Unmarshal([]byte(C.GoString(C.json_object_to_json_string(cdata.content))), data.Content)
+		if err != nil {
+			return nil, types.NewError(err.Error(), 400)
+		}
+	}
+
+	if cdata.profile_ids_length > 0 {
+		size := int(cdata.profile_ids_length)
+		carray := (*[1<<30 - 1]*C.char)(unsafe.Pointer(cdata.profile_ids))[:size:size]
+		for i := 0; i < size; i++ {
+			data.ProfileIds = append(data.ProfileIds, C.GoString(carray[i]))
+		}
+	}
+
+	return data, nil
+}
+
+func cToGoUser(u *C.user) *security.User {
+	if u == nil {
+		return nil
+	}
+
+	user := (*kuzzle.Kuzzle)(u.kuzzle.instance).Security.NewUser(C.GoString(u.id), nil)
+
+	return user
+}
+
+func cToGoUserRigh(r *C.user_right) *types.UserRights {
+	right := &types.UserRights{
+		Controller: C.GoString(r.controller),
+		Action:     C.GoString(r.action),
+		Index:      C.GoString(r.index),
+		Value:      C.GoString(r.value),
+	}
+
+	return right
+}

--- a/internal/wrappers/cgo/kuzzle/collection.go
+++ b/internal/wrappers/cgo/kuzzle/collection.go
@@ -1,0 +1,63 @@
+package main
+
+/*
+	#cgo CFLAGS: -I../../headers
+	#include "kuzzlesdk.h"
+	#include "sdk_wrappers_internal.h"
+*/
+import "C"
+import (
+	"github.com/kuzzleio/sdk-go/types"
+	"unsafe"
+)
+
+// Allocates memory
+//export kuzzle_wrapper_new_collection
+func kuzzle_wrapper_new_collection(k *C.kuzzle, colName *C.char, index *C.char) *C.collection {
+	col := (*C.collection)(C.calloc(1, C.sizeof_collection))
+	col.index = C.CString(C.GoString(index))
+	col.collection = C.CString(C.GoString(colName))
+	col.kuzzle = k
+
+	return col
+}
+
+//export kuzzle_wrapper_collection_create
+func kuzzle_wrapper_collection_create(c *C.collection, options *C.query_options) *C.bool_result {
+	res, err := cToGoCollection(c).Create(SetQueryOptions(options))
+	return goToCBoolResult(res, err)
+}
+
+//export kuzzle_wrapper_collection_publish_message
+func kuzzle_wrapper_collection_publish_message(c *C.collection, message *C.json_object, options *C.query_options) *C.bool_result {
+	res, err := cToGoCollection(c).PublishMessage(JsonCConvert(message).(map[string]interface{}), SetQueryOptions(options))
+	return goToCBoolResult(res, err)
+}
+
+//export kuzzle_wrapper_collection_set_headers
+func kuzzle_wrapper_collection_set_headers(c *C.collection, content *C.json_object, replace C.uint) {
+	if JsonCType(content) == C.json_type_object {
+		r := replace != 0
+		cToGoCollection(c).SetHeaders(JsonCConvert(content).(map[string]interface{}), r)
+	}
+
+	return
+}
+
+//export kuzzle_wrapper_collection_truncate
+func kuzzle_wrapper_collection_truncate(c *C.collection, options *C.query_options) *C.bool_result {
+	res, err := cToGoCollection(c).Truncate(SetQueryOptions(options))
+	return goToCBoolResult(res, err)
+}
+
+//export kuzzle_wrapper_collection_subscribe
+// TODO loop and close on Unsubscribe
+func kuzzle_wrapper_collection_subscribe(col *C.collection, filters *C.search_filters, options *C.room_options, cb unsafe.Pointer) {
+	c := make(chan *types.KuzzleNotification)
+	cToGoCollection(col).Subscribe(cToGoSearchFilters(filters), SetRoomOptions(options), c)
+
+	go func() {
+		res := <-c
+		C.call_notification_result(cb, goToCNotificationResult(res))
+	}()
+}

--- a/internal/wrappers/cgo/kuzzle/collection_document.go
+++ b/internal/wrappers/cgo/kuzzle/collection_document.go
@@ -73,13 +73,13 @@ func kuzzle_wrapper_collection_m_create_or_replace_document(c *C.collection, doc
 }
 
 //export kuzzle_wrapper_collection_m_delete_document
-func kuzzle_wrapper_collection_m_delete_document(c *C.collection, ids **C.char, idsCount C.uint, options *C.query_options) *C.string_array_result {
+func kuzzle_wrapper_collection_m_delete_document(c *C.collection, ids **C.char, idsCount C.size_t, options *C.query_options) *C.string_array_result {
 	res, err := cToGoCollection(c).MDeleteDocument(cToGoStrings(ids, idsCount), SetQueryOptions(options))
 	return goToCStringArrayResult(res, err)
 }
 
 //export kuzzle_wrapper_collection_m_get_document
-func kuzzle_wrapper_collection_m_get_document(c *C.collection, ids **C.char, idsCount C.uint, options *C.query_options) *C.search_result {
+func kuzzle_wrapper_collection_m_get_document(c *C.collection, ids **C.char, idsCount C.size_t, options *C.query_options) *C.search_result {
 	res, err := cToGoCollection(c).MGetDocument(cToGoStrings(ids, idsCount), SetQueryOptions(options))
 	return goToCSearchResult(c, res, err)
 }

--- a/internal/wrappers/cgo/kuzzle/collection_document.go
+++ b/internal/wrappers/cgo/kuzzle/collection_document.go
@@ -1,0 +1,97 @@
+package main
+
+/*
+	#cgo CFLAGS: -I../../headers
+	#include "kuzzlesdk.h"
+*/
+import "C"
+
+//export kuzzle_wrapper_collection_count
+func kuzzle_wrapper_collection_count(c *C.collection, searchFilters *C.search_filters, options *C.query_options) *C.int_result {
+	res, err := cToGoCollection(c).Count(cToGoSearchFilters(searchFilters), SetQueryOptions(options))
+	return goToCIntResult(res, err)
+}
+
+//export kuzzle_wrapper_collection_create_document
+func kuzzle_wrapper_collection_create_document(c *C.collection, id *C.char, document *C.document, options *C.query_options) *C.document_result {
+	res, err := cToGoCollection(c).CreateDocument(C.GoString(id), cToGoDocument(c, document), SetQueryOptions(options))
+	return goToCDocumentResult(c, res, err)
+}
+
+//export kuzzle_wrapper_collection_delete_document
+func kuzzle_wrapper_collection_delete_document(c *C.collection, id *C.char, options *C.query_options) *C.string_result {
+	res, err := cToGoCollection(c).DeleteDocument(C.GoString(id), SetQueryOptions(options))
+	return goToCStringResult(&res, err)
+}
+
+//export kuzzle_wrapper_collection_document_exists
+func kuzzle_wrapper_collection_document_exists(c *C.collection, id *C.char, options *C.query_options) *C.bool_result {
+	res, err := cToGoCollection(c).DocumentExists(C.GoString(id), SetQueryOptions(options))
+	return goToCBoolResult(res, err)
+}
+
+//export kuzzle_wrapper_collection_fetch_document
+func kuzzle_wrapper_collection_fetch_document(c *C.collection, id *C.char, options *C.query_options) *C.document_result {
+	res, err := cToGoCollection(c).FetchDocument(C.GoString(id), SetQueryOptions(options))
+	return goToCDocumentResult(c, res, err)
+}
+
+//export kuzzle_wrapper_collection_replace_document
+func kuzzle_wrapper_collection_replace_document(c *C.collection, id *C.char, document *C.document, options *C.query_options) *C.document_result {
+	res, err := cToGoCollection(c).ReplaceDocument(C.GoString(id), cToGoDocument(c, document), SetQueryOptions(options))
+	return goToCDocumentResult(c, res, err)
+}
+
+//export kuzzle_wrapper_collection_update_document
+func kuzzle_wrapper_collection_update_document(c *C.collection, id *C.char, document *C.document, options *C.query_options) *C.document_result {
+	res, err := cToGoCollection(c).UpdateDocument(C.GoString(id), cToGoDocument(c, document), SetQueryOptions(options))
+	return goToCDocumentResult(c, res, err)
+}
+
+//export kuzzle_wrapper_collection_scroll
+func kuzzle_wrapper_collection_scroll(c *C.collection, scrollId *C.char, options *C.query_options) *C.search_result {
+	res, err := cToGoCollection(c).Scroll(C.GoString(scrollId), SetQueryOptions(options))
+	return goToCSearchResult(c, res, err)
+}
+
+//export kuzzle_wrapper_collection_search
+func kuzzle_wrapper_collection_search(c *C.collection, searchFilters *C.search_filters, options *C.query_options) *C.search_result {
+	res, err := cToGoCollection(c).Search(cToGoSearchFilters(searchFilters), SetQueryOptions(options))
+	return goToCSearchResult(c, res, err)
+}
+
+//export kuzzle_wrapper_collection_m_create_document
+func kuzzle_wrapper_collection_m_create_document(c *C.collection, documents **C.document, docCount C.uint, options *C.query_options) *C.search_result {
+	res, err := cToGoCollection(c).MCreateDocument(cToGoDocuments(c, documents, docCount), SetQueryOptions(options))
+	return goToCSearchResult(c, res, err)
+}
+
+//export kuzzle_wrapper_collection_m_create_or_replace_document
+func kuzzle_wrapper_collection_m_create_or_replace_document(c *C.collection, documents **C.document, docCount C.uint, options *C.query_options) *C.search_result {
+	res, err := cToGoCollection(c).MCreateOrReplaceDocument(cToGoDocuments(c, documents, docCount), SetQueryOptions(options))
+	return goToCSearchResult(c, res, err)
+}
+
+//export kuzzle_wrapper_collection_m_delete_document
+func kuzzle_wrapper_collection_m_delete_document(c *C.collection, ids **C.char, idsCount C.uint, options *C.query_options) *C.string_array_result {
+	res, err := cToGoCollection(c).MDeleteDocument(cToGoStrings(ids, idsCount), SetQueryOptions(options))
+	return goToCStringArrayResult(res, err)
+}
+
+//export kuzzle_wrapper_collection_m_get_document
+func kuzzle_wrapper_collection_m_get_document(c *C.collection, ids **C.char, idsCount C.uint, options *C.query_options) *C.search_result {
+	res, err := cToGoCollection(c).MGetDocument(cToGoStrings(ids, idsCount), SetQueryOptions(options))
+	return goToCSearchResult(c, res, err)
+}
+
+//export kuzzle_wrapper_collection_m_replace_document
+func kuzzle_wrapper_collection_m_replace_document(c *C.collection, documents **C.document, docCount C.uint, options *C.query_options) *C.search_result {
+	res, err := cToGoCollection(c).MReplaceDocument(cToGoDocuments(c, documents, docCount), SetQueryOptions(options))
+	return goToCSearchResult(c, res, err)
+}
+
+//export kuzzle_wrapper_collection_m_update_document
+func kuzzle_wrapper_collection_m_update_document(c *C.collection, documents **C.document, docCount C.uint, options *C.query_options) *C.search_result {
+	res, err := cToGoCollection(c).MUpdateDocument(cToGoDocuments(c, documents, docCount), SetQueryOptions(options))
+	return goToCSearchResult(c, res, err)
+}

--- a/internal/wrappers/cgo/kuzzle/collection_mapping.go
+++ b/internal/wrappers/cgo/kuzzle/collection_mapping.go
@@ -1,0 +1,62 @@
+package main
+
+/*
+	#cgo CFLAGS: -I../../headers
+	#include "kuzzlesdk.h"
+*/
+import "C"
+import (
+	"encoding/json"
+	"github.com/kuzzleio/sdk-go/types"
+)
+
+//export kuzzle_wrapper_new_mapping
+func kuzzle_wrapper_new_mapping(c *C.collection) *C.mapping {
+	cm := (*C.mapping)(C.calloc(1, C.sizeof_mapping))
+	cm.mapping = C.json_object_new_object()
+	cm.collection = c
+
+	return cm
+}
+
+//export kuzzle_wrapper_collection_get_mapping
+func kuzzle_wrapper_collection_get_mapping(c *C.collection, options *C.query_options) *C.mapping_result {
+	res, err := cToGoCollection(c).GetMapping(SetQueryOptions(options))
+	return goToCMappingResult(c, res, err)
+}
+
+//export kuzzle_wrapper_mapping_apply
+func kuzzle_wrapper_mapping_apply(cm *C.mapping, options *C.query_options) *C.bool_result {
+	_, err := cToGoMapping(cm).Apply(SetQueryOptions(options))
+	return goToCBoolResult(true, err)
+}
+
+//export kuzzle_wrapper_mapping_refresh
+func kuzzle_wrapper_mapping_refresh(cm *C.mapping, options *C.query_options) *C.bool_result {
+	_, err := cToGoMapping(cm).Refresh(SetQueryOptions(options))
+	return goToCBoolResult(true, err)
+}
+
+//export kuzzle_wrapper_mapping_set
+func kuzzle_wrapper_mapping_set(cm *C.mapping, jMap *C.json_object) {
+	var mappings types.MappingFields
+
+	if JsonCType(jMap) == C.json_type_object {
+		jsonString := []byte(C.GoString(C.json_object_to_json_string(jMap)))
+		json.Unmarshal(jsonString, &mappings)
+	}
+
+	cToGoMapping(cm).Set(&mappings)
+
+	return
+}
+
+//export kuzzle_wrapper_mapping_set_headers
+func kuzzle_wrapper_mapping_set_headers(cm *C.mapping, content *C.json_object, replace C.uint) {
+	if JsonCType(content) == C.json_type_object {
+		r := replace != 0
+		cToGoMapping(cm).SetHeaders(JsonCConvert(content).(map[string]interface{}), r)
+	}
+
+	return
+}

--- a/internal/wrappers/cgo/kuzzle/collection_specification.go
+++ b/internal/wrappers/cgo/kuzzle/collection_specification.go
@@ -1,0 +1,43 @@
+package main
+
+/*
+	#cgo CFLAGS: -I../../headers
+	#include "kuzzlesdk.h"
+*/
+import "C"
+
+//export kuzzle_wrapper_collection_delete_specifications
+func kuzzle_wrapper_collection_delete_specifications(c *C.collection, options *C.query_options) *C.bool_result {
+	res, err := cToGoCollection(c).DeleteSpecifications(SetQueryOptions(options))
+	return goToCBoolResult(res, err)
+}
+
+//export kuzzle_wrapper_collection_get_specifications
+func kuzzle_wrapper_collection_get_specifications(c *C.collection, options *C.query_options) *C.specification_result {
+	res, err := cToGoCollection(c).GetSpecifications(SetQueryOptions(options))
+	return goToCSpecificationResult(res.Validation, err)
+}
+
+//export kuzzle_wrapper_collection_scroll_specifications
+func kuzzle_wrapper_collection_scroll_specifications(c *C.collection, scrollId *C.char, options *C.query_options) *C.specification_search_result {
+	res, err := cToGoCollection(c).ScrollSpecifications(C.GoString(scrollId), SetQueryOptions(options))
+	return goToCSpecificationSearchResult(res, err)
+}
+
+//export kuzzle_wrapper_collection_search_specifications
+func kuzzle_wrapper_collection_search_specifications(c *C.collection, searchFilters *C.search_filters, options *C.query_options) *C.specification_search_result {
+	res, err := cToGoCollection(c).SearchSpecifications(cToGoSearchFilters(searchFilters), SetQueryOptions(options))
+	return goToCSpecificationSearchResult(res, err)
+}
+
+//export kuzzle_wrapper_collection_update_specifications
+func kuzzle_wrapper_collection_update_specifications(c *C.collection, specification *C.specification, options *C.query_options) *C.specification_result {
+	res, err := cToGoCollection(c).UpdateSpecifications(cToGoSpecification(specification), SetQueryOptions(options))
+	return goToCSpecificationResult(res, err)
+}
+
+//export kuzzle_wrapper_collection_validate_specifications
+func kuzzle_wrapper_collection_validate_specifications(c *C.collection, specification *C.specification, options *C.query_options) *C.bool_result {
+	res, err := cToGoCollection(c).ValidateSpecifications(cToGoSpecification(specification), SetQueryOptions(options))
+	return goToCBoolResult(res.Valid, err)
+}

--- a/internal/wrappers/cgo/kuzzle/destructors.go
+++ b/internal/wrappers/cgo/kuzzle/destructors.go
@@ -1,0 +1,831 @@
+package main
+
+/*
+  #cgo CFLAGS: -std=c99 -I../../../headers
+  #cgo LDFLAGS: -ljson-c
+
+  #include <stdlib.h>
+  #include "kuzzlesdk.h"
+
+  static void free_char_array(char **arr, size_t length) {
+    if (arr != NULL) {
+      for(int i = 0; i < length; i++) {
+        free(arr[i]);
+      }
+
+      free(arr);
+    }
+  }
+*/
+import "C"
+
+import (
+	"unsafe"
+)
+
+//export destroy_kuzzle_request
+func destroy_kuzzle_request(st *C.kuzzle_request) {
+	if st != nil {
+		C.free(unsafe.Pointer(st.request_id))
+		C.free(unsafe.Pointer(st.controller))
+		C.free(unsafe.Pointer(st.action))
+		C.free(unsafe.Pointer(st.index))
+		C.free(unsafe.Pointer(st.collection))
+		C.free(unsafe.Pointer(st.id))
+		C.free(unsafe.Pointer(st.scroll))
+		C.free(unsafe.Pointer(st.scroll_id))
+		C.free(unsafe.Pointer(st.strategy))
+		C.free(unsafe.Pointer(st.scope))
+		C.free(unsafe.Pointer(st.state))
+		C.free(unsafe.Pointer(st.user))
+		C.free(unsafe.Pointer(st.member))
+		C.free(unsafe.Pointer(st.member1))
+		C.free(unsafe.Pointer(st.member2))
+		C.free(unsafe.Pointer(st.unit))
+		C.free(unsafe.Pointer(st.field))
+		C.free(unsafe.Pointer(st.subcommand))
+		C.free(unsafe.Pointer(st.pattern))
+		C.free(unsafe.Pointer(st.min))
+		C.free(unsafe.Pointer(st.max))
+		C.free(unsafe.Pointer(st.limit))
+		C.free(unsafe.Pointer(st.match))
+
+		C.free_char_array(st.members, st.members_length)
+		C.free_char_array(st.keys, st.keys_length)
+		C.free_char_array(st.fields, st.fields_length)
+
+		kuzzle_wrapper_free_json_object(st.body)
+		kuzzle_wrapper_free_json_object(st.volatiles)
+		kuzzle_wrapper_free_json_object(st.options)
+
+		C.free(unsafe.Pointer(st))
+	}
+
+}
+
+//export destroy_query_object
+func destroy_query_object(st *C.query_object) {
+	if st != nil {
+		kuzzle_wrapper_free_json_object(st.query)
+		C.free(unsafe.Pointer(st.request_id))
+
+		C.free(unsafe.Pointer(st))
+	}
+}
+
+//export destroy_offline_queue
+func destroy_offline_queue(st *C.offline_queue) {
+	if st != nil && st.queries != nil {
+		queries := (*[1<<30 - 1]*C.query_object)(unsafe.Pointer(st.queries))[:int(st.queries_length):int(st.queries_length)]
+
+		for _, query := range queries {
+			destroy_query_object(query)
+		}
+
+		C.free(unsafe.Pointer(st.queries))
+	}
+
+	C.free(unsafe.Pointer(st))
+}
+
+//export destroy_query_options
+func destroy_query_options(st *C.query_options) {
+	if st != nil {
+		C.free(unsafe.Pointer(st.scroll))
+		C.free(unsafe.Pointer(st.scroll_id))
+		C.free(unsafe.Pointer(st.refresh))
+		C.free(unsafe.Pointer(st.if_exist))
+		kuzzle_wrapper_free_json_object(st.volatiles)
+
+		C.free(unsafe.Pointer(st))
+	}
+}
+
+//export destroy_room_options
+func destroy_room_options(st *C.room_options) {
+	if st != nil {
+		C.free(unsafe.Pointer(st.scope))
+		C.free(unsafe.Pointer(st.state))
+		C.free(unsafe.Pointer(st.user))
+		kuzzle_wrapper_free_json_object(st.volatiles)
+		C.free(unsafe.Pointer(st))
+	}
+}
+
+//export destroy_options
+func destroy_options(st *C.options) {
+	if st != nil {
+		C.free(unsafe.Pointer(st.refresh))
+		C.free(unsafe.Pointer(st.default_index))
+		kuzzle_wrapper_free_json_object(st.headers)
+		C.free(unsafe.Pointer(st))
+	}
+}
+
+//export destroy_meta
+func destroy_meta(st *C.meta) {
+	if st != nil {
+		C.free(unsafe.Pointer(st.author))
+		C.free(unsafe.Pointer(st.updater))
+		C.free(unsafe.Pointer(st))
+	}
+}
+
+// do not export => used to free the content of a structure
+// and not the structure itself
+func _free_policy_restriction(st *C.policy_restriction) {
+	if st != nil {
+		C.free(unsafe.Pointer(st.index))
+		C.free_char_array(st.collections, st.collections_length)
+	}
+}
+
+//export destroy_policy_restriction
+func destroy_policy_restriction(st *C.policy_restriction) {
+	_free_policy_restriction(st)
+	C.free(unsafe.Pointer(st))
+}
+
+// do not export => used to free the content of a structure
+// and not the structure itself
+func _free_policy(st *C.policy) {
+	if st != nil {
+		C.free(unsafe.Pointer(st.role_id))
+
+		if st.restricted_to != nil {
+			restrictions := (*[1<<30 - 1]C.policy_restriction)(unsafe.Pointer(st.restricted_to))[:int(st.restricted_to_length):int(st.restricted_to_length)]
+
+			for _, restriction := range restrictions {
+				_free_policy_restriction(&restriction)
+			}
+
+			C.free(unsafe.Pointer(st.restricted_to))
+		}
+	}
+}
+
+//export destroy_policy
+func destroy_policy(st *C.policy) {
+	_free_policy(st)
+	C.free(unsafe.Pointer(st))
+}
+
+// do not export => used to free the content of a structure
+// and not the structure itself
+func _free_profile(st *C.profile) {
+	if st != nil {
+		C.free(unsafe.Pointer(st.id))
+
+		if st.policies != nil {
+			policies := (*[1<<30 - 1]C.policy)(unsafe.Pointer(st.policies))[:int(st.policies_length):int(st.policies_length)]
+
+			for _, policy := range policies {
+				_free_policy(&policy)
+			}
+
+			C.free(unsafe.Pointer(st.policies))
+		}
+	}
+}
+
+//export destroy_profile
+func destroy_profile(st *C.profile) {
+	_free_profile(st)
+	C.free(unsafe.Pointer(st))
+}
+
+//do not export
+func _free_role(st *C.role) {
+	if st != nil {
+		C.free(unsafe.Pointer(st.id))
+		kuzzle_wrapper_free_json_object(st.controllers)
+	}
+}
+
+//export destroy_role
+func destroy_role(st *C.role) {
+	_free_role(st)
+	C.free(unsafe.Pointer(st))
+}
+
+//do not export
+func _free_user(st *C.user) {
+	if st != nil {
+		C.free(unsafe.Pointer(st.id))
+		kuzzle_wrapper_free_json_object(st.content)
+		C.free_char_array(st.profile_ids, st.profile_ids_length)
+	}
+}
+
+//export destroy_user
+func destroy_user(st *C.user) {
+	_free_user(st)
+	C.free(unsafe.Pointer(st))
+}
+
+//export destroy_user_data
+func destroy_user_data(st *C.user_data) {
+	if st != nil {
+		kuzzle_wrapper_free_json_object(st.content)
+		C.free_char_array(st.profile_ids, st.profile_ids_length)
+		C.free(unsafe.Pointer(st))
+	}
+}
+
+//export destroy_collection
+func destroy_collection(st *C.collection) {
+	if st != nil {
+		C.free(unsafe.Pointer(st.index))
+		C.free(unsafe.Pointer(st.collection))
+		C.free(unsafe.Pointer(st))
+	}
+}
+
+//do not export
+func _free_document(st *C.document) {
+	if st != nil {
+		C.free(unsafe.Pointer(st.id))
+		C.free(unsafe.Pointer(st.index))
+		C.free(unsafe.Pointer(st.shards))
+		C.free(unsafe.Pointer(st.result))
+		C.free(unsafe.Pointer(st.collection))
+
+		kuzzle_wrapper_free_json_object(st.content)
+
+		destroy_meta(st.meta)
+		destroy_collection(st._collection)
+	}
+}
+
+//export destroy_document
+func destroy_document(st *C.document) {
+	_free_document(st)
+	C.free(unsafe.Pointer(st))
+}
+
+//export destroy_document_result
+func destroy_document_result(st *C.document_result) {
+	if st != nil {
+		destroy_document(st.result)
+		C.free(unsafe.Pointer(st.error))
+		C.free(unsafe.Pointer(st.stack))
+		C.free(unsafe.Pointer(st))
+	}
+}
+
+//export destroy_notification_content
+func destroy_notification_content(st *C.notification_content) {
+	if st != nil {
+		C.free(unsafe.Pointer(st.id))
+		destroy_meta(st.meta)
+		kuzzle_wrapper_free_json_object(st.content)
+		C.free(unsafe.Pointer(st))
+	}
+}
+
+//export destroy_notification_result
+func destroy_notification_result(st *C.notification_result) {
+	if st != nil {
+		C.free(unsafe.Pointer(st.request_id))
+		C.free(unsafe.Pointer(st.index))
+		C.free(unsafe.Pointer(st.collection))
+		C.free(unsafe.Pointer(st.controller))
+		C.free(unsafe.Pointer(st.action))
+		C.free(unsafe.Pointer(st.protocol))
+		C.free(unsafe.Pointer(st.scope))
+		C.free(unsafe.Pointer(st.state))
+		C.free(unsafe.Pointer(st.user))
+		C.free(unsafe.Pointer(st.n_type))
+		C.free(unsafe.Pointer(st.room_id))
+		C.free(unsafe.Pointer(st.error))
+		C.free(unsafe.Pointer(st.stack))
+
+		kuzzle_wrapper_free_json_object(st.volatiles)
+
+		destroy_notification_content(st.result)
+
+		C.free(unsafe.Pointer(st))
+	}
+}
+
+//export destroy_profile_result
+func destroy_profile_result(st *C.profile_result) {
+	if st != nil {
+		destroy_profile(st.profile)
+		C.free(unsafe.Pointer(st.error))
+		C.free(unsafe.Pointer(st.stack))
+		C.free(unsafe.Pointer(st))
+	}
+}
+
+//export destroy_profiles_result
+func destroy_profiles_result(st *C.profiles_result) {
+	if st != nil {
+		if st.profiles != nil {
+			profiles := (*[1<<30 - 1]C.profile)(unsafe.Pointer(st.profiles))[:int(st.profiles_length):int(st.profiles_length)]
+
+			for _, profile := range profiles {
+				_free_profile(&profile)
+			}
+
+			C.free(unsafe.Pointer(st.profiles))
+		}
+
+		C.free(unsafe.Pointer(st.error))
+		C.free(unsafe.Pointer(st.stack))
+		C.free(unsafe.Pointer(st))
+	}
+}
+
+//export destroy_role_result
+func destroy_role_result(st *C.role_result) {
+	if st != nil {
+		destroy_role(st.role)
+		C.free(unsafe.Pointer(st.error))
+		C.free(unsafe.Pointer(st.stack))
+		C.free(unsafe.Pointer(st))
+	}
+}
+
+// do not export => used to free the content of a structure
+// and not the structure itself
+func _free_user_right(st *C.user_right) {
+	if st != nil {
+		C.free(unsafe.Pointer(st.controller))
+		C.free(unsafe.Pointer(st.action))
+		C.free(unsafe.Pointer(st.index))
+		C.free(unsafe.Pointer(st.collection))
+		C.free(unsafe.Pointer(st.value))
+	}
+}
+
+//export destroy_user_right
+func destroy_user_right(st *C.user_right) {
+	_free_user_right(st)
+	C.free(unsafe.Pointer(st))
+}
+
+//export destroy_user_rights_result
+func destroy_user_rights_result(st *C.user_rights_result) {
+	if st != nil {
+		if st.user_rights != nil {
+			rights := (*[1<<30 - 1]C.user_right)(unsafe.Pointer(st.user_rights))[:int(st.user_rights_length):int(st.user_rights_length)]
+
+			for _, right := range rights {
+				_free_user_right(&right)
+			}
+
+			C.free(unsafe.Pointer(st.user_rights))
+		}
+
+		C.free(unsafe.Pointer(st.error))
+		C.free(unsafe.Pointer(st.stack))
+		C.free(unsafe.Pointer(st))
+	}
+}
+
+//export destroy_user_result
+func destroy_user_result(st *C.user_result) {
+	if st != nil {
+		destroy_user(st.user)
+		C.free(unsafe.Pointer(st.error))
+		C.free(unsafe.Pointer(st.stack))
+		C.free(unsafe.Pointer(st))
+	}
+}
+
+// do not export => used to free the content of a structure
+// and not the structure itself
+func _free_statistics(st *C.statistics) {
+	if st != nil {
+		kuzzle_wrapper_free_json_object(st.completed_requests)
+		kuzzle_wrapper_free_json_object(st.connections)
+		kuzzle_wrapper_free_json_object(st.failed_requests)
+		kuzzle_wrapper_free_json_object(st.ongoing_requests)
+	}
+}
+
+//export destroy_statistics
+func destroy_statistics(st *C.statistics) {
+	_free_statistics(st)
+	C.free(unsafe.Pointer(st))
+}
+
+//export destroy_statistics_result
+func destroy_statistics_result(st *C.statistics_result) {
+	if st != nil {
+		destroy_statistics(st.result)
+		C.free(unsafe.Pointer(st.error))
+		C.free(unsafe.Pointer(st.stack))
+		C.free(unsafe.Pointer(st))
+	}
+}
+
+//export destroy_all_statistics_result
+func destroy_all_statistics_result(st *C.all_statistics_result) {
+	if st != nil {
+		if st.result != nil {
+			stats := (*[1<<30 - 1]C.statistics)(unsafe.Pointer(st.result))
+
+			for _, stat := range stats {
+				_free_statistics(&stat)
+			}
+
+			C.free(unsafe.Pointer(st.result))
+		}
+
+		C.free(unsafe.Pointer(st.error))
+		C.free(unsafe.Pointer(st.stack))
+		C.free(unsafe.Pointer(st))
+	}
+}
+
+//export destroy_geopos_result
+func destroy_geopos_result(st *C.geopos_result) {
+	if st != nil {
+		C.free(unsafe.Pointer(st.result))
+		C.free(unsafe.Pointer(st.error))
+		C.free(unsafe.Pointer(st.stack))
+		C.free(unsafe.Pointer(st))
+	}
+}
+
+//export destroy_token_validity
+func destroy_token_validity(st *C.token_validity) {
+	if st != nil {
+		C.free(unsafe.Pointer(st.state))
+		C.free(unsafe.Pointer(st.error))
+		C.free(unsafe.Pointer(st.stack))
+		C.free(unsafe.Pointer(st))
+	}
+}
+
+//export destroy_kuzzle_response
+func destroy_kuzzle_response(st *C.kuzzle_response) {
+	if st != nil {
+		C.free(unsafe.Pointer(st.request_id))
+		C.free(unsafe.Pointer(st.index))
+		C.free(unsafe.Pointer(st.collection))
+		C.free(unsafe.Pointer(st.controller))
+		C.free(unsafe.Pointer(st.action))
+		C.free(unsafe.Pointer(st.room_id))
+		C.free(unsafe.Pointer(st.channel))
+		C.free(unsafe.Pointer(st.error))
+		C.free(unsafe.Pointer(st.stack))
+
+		kuzzle_wrapper_free_json_object(st.result)
+		kuzzle_wrapper_free_json_object(st.volatiles)
+
+		C.free(unsafe.Pointer(st))
+	}
+}
+
+//export destroy_json_result
+func destroy_json_result(st *C.json_result) {
+	if st != nil {
+		kuzzle_wrapper_free_json_object(st.result)
+		C.free(unsafe.Pointer(st.error))
+		C.free(unsafe.Pointer(st.stack))
+		C.free(unsafe.Pointer(st))
+	}
+}
+
+//export destroy_json_array_result
+func destroy_json_array_result(st *C.json_array_result) {
+	if st != nil {
+		if st.result != nil {
+			jobjects := (*[1<<30 - 1]*C.json_object)(unsafe.Pointer(st.result))[:int(st.result_length):int(st.result_length)]
+
+			for _, jobject := range jobjects {
+				kuzzle_wrapper_free_json_object(jobject)
+			}
+
+			C.free(unsafe.Pointer(st.result))
+		}
+
+		C.free(unsafe.Pointer(st.error))
+		C.free(unsafe.Pointer(st.stack))
+		C.free(unsafe.Pointer(st))
+	}
+}
+
+//export destroy_bool_result
+func destroy_bool_result(st *C.bool_result) {
+	if st != nil {
+		C.free(unsafe.Pointer(st.error))
+		C.free(unsafe.Pointer(st.stack))
+		C.free(unsafe.Pointer(st))
+	}
+}
+
+//export destroy_int_result
+func destroy_int_result(st *C.int_result) {
+	if st != nil {
+		C.free(unsafe.Pointer(st.error))
+		C.free(unsafe.Pointer(st.stack))
+		C.free(unsafe.Pointer(st))
+	}
+}
+
+//export destroy_double_result
+func destroy_double_result(st *C.double_result) {
+	if st != nil {
+		C.free(unsafe.Pointer(st.error))
+		C.free(unsafe.Pointer(st.stack))
+		C.free(unsafe.Pointer(st))
+	}
+}
+
+//export destroy_int_array_result
+func destroy_int_array_result(st *C.int_array_result) {
+	if st != nil {
+		C.free(unsafe.Pointer(st.result))
+		C.free(unsafe.Pointer(st.error))
+		C.free(unsafe.Pointer(st.stack))
+		C.free(unsafe.Pointer(st))
+	}
+}
+
+//export destroy_string_result
+func destroy_string_result(st *C.string_result) {
+	if st != nil {
+		C.free(unsafe.Pointer(st.result))
+		C.free(unsafe.Pointer(st.error))
+		C.free(unsafe.Pointer(st.stack))
+		C.free(unsafe.Pointer(st))
+	}
+}
+
+//export destroy_string_array_result
+func destroy_string_array_result(st *C.string_array_result) {
+	if st != nil {
+		C.free_char_array(st.result, st.result_length)
+		C.free(unsafe.Pointer(st.error))
+		C.free(unsafe.Pointer(st.stack))
+		C.free(unsafe.Pointer(st))
+	}
+}
+
+//export destroy_search_filters
+func destroy_search_filters(st *C.search_filters) {
+	if st != nil {
+		kuzzle_wrapper_free_json_object(st.query)
+		kuzzle_wrapper_free_json_object(st.sort)
+		kuzzle_wrapper_free_json_object(st.aggregations)
+		kuzzle_wrapper_free_json_object(st.search_after)
+		C.free(unsafe.Pointer(st))
+	}
+}
+
+//export destroy_document_search
+func destroy_document_search(st *C.document_search) {
+	if st != nil {
+		C.free(unsafe.Pointer(st.scroll_id))
+
+		if st.hits != nil {
+			hits := (*[1<<30 - 1]C.document)(unsafe.Pointer(st.hits))[:int(st.hits_length):int(st.hits_length)]
+
+			for _, document := range hits {
+				_free_document(&document)
+			}
+
+			C.free(unsafe.Pointer(st.hits))
+		}
+
+		C.free(unsafe.Pointer(st))
+	}
+}
+
+//export destroy_profile_search
+func destroy_profile_search(st *C.profile_search) {
+	if st != nil {
+		C.free(unsafe.Pointer(st.scroll_id))
+
+		if st.hits != nil {
+			hits := (*[1<<30 - 1]C.profile)(unsafe.Pointer(st.hits))[:int(st.hits_length):int(st.hits_length)]
+
+			for _, profile := range hits {
+				_free_profile(&profile)
+			}
+
+			C.free(unsafe.Pointer(st.hits))
+		}
+
+		C.free(unsafe.Pointer(st))
+	}
+}
+
+//export destroy_role_search
+func destroy_role_search(st *C.role_search) {
+	if st != nil {
+		if st.hits != nil {
+			hits := (*[1<<30 - 1]C.role)(unsafe.Pointer(st.hits))[:int(st.hits_length):int(st.hits_length)]
+
+			for _, role := range hits {
+				_free_role(&role)
+			}
+
+			C.free(unsafe.Pointer(st.hits))
+		}
+
+		C.free(unsafe.Pointer(st))
+	}
+}
+
+//export destroy_ack_result
+func destroy_ack_result(st *C.ack_result) {
+	if st != nil {
+		C.free(unsafe.Pointer(st.error))
+		C.free(unsafe.Pointer(st.stack))
+		C.free(unsafe.Pointer(st))
+	}
+}
+
+//export destroy_shards_result
+func destroy_shards_result(st *C.shards_result) {
+	if st != nil {
+		C.free(unsafe.Pointer(st.result))
+		C.free(unsafe.Pointer(st.error))
+		C.free(unsafe.Pointer(st.stack))
+		C.free(unsafe.Pointer(st))
+	}
+}
+
+//export destroy_specification
+func destroy_specification(st *C.specification) {
+	if st != nil {
+		kuzzle_wrapper_free_json_object(st.fields)
+		kuzzle_wrapper_free_json_object(st.validators)
+		C.free(unsafe.Pointer(st))
+	}
+}
+
+//do not export
+func _free_specification_entry(st *C.specification_entry) {
+	if st != nil {
+		destroy_specification(st.validation)
+		C.free(unsafe.Pointer(st.index))
+		C.free(unsafe.Pointer(st.collection))
+	}
+}
+
+//export destroy_specification_entry
+func destroy_specification_entry(st *C.specification_entry) {
+	_free_specification_entry(st)
+	C.free(unsafe.Pointer(st))
+}
+
+//export destroy_specification_result
+func destroy_specification_result(st *C.specification_result) {
+	if st != nil {
+		destroy_specification(st.result)
+		C.free(unsafe.Pointer(st.error))
+		C.free(unsafe.Pointer(st.stack))
+		C.free(unsafe.Pointer(st))
+	}
+}
+
+//export destroy_search_result
+func destroy_search_result(st *C.search_result) {
+	if st != nil {
+		destroy_document_search(st.result)
+		C.free(unsafe.Pointer(st.error))
+		C.free(unsafe.Pointer(st.stack))
+		C.free(unsafe.Pointer(st))
+	}
+}
+
+//export destroy_search_profiles_result
+func destroy_search_profiles_result(st *C.search_profiles_result) {
+	if st != nil {
+		destroy_profile_search(st.result)
+		C.free(unsafe.Pointer(st.error))
+		C.free(unsafe.Pointer(st.stack))
+		C.free(unsafe.Pointer(st))
+	}
+}
+
+//export destroy_search_roles_result
+func destroy_search_roles_result(st *C.search_roles_result) {
+	if st != nil {
+		destroy_role_search(st.result)
+		C.free(unsafe.Pointer(st.error))
+		C.free(unsafe.Pointer(st.stack))
+		C.free(unsafe.Pointer(st))
+	}
+}
+
+//export destroy_specification_search
+func destroy_specification_search(st *C.specification_search) {
+	if st != nil {
+		if st.hits != nil {
+			hits := (*[1<<30 - 1]C.specification_entry)(unsafe.Pointer(st.hits))[:int(st.hits_length):int(st.hits_length)]
+
+			for _, entry := range hits {
+				_free_specification_entry(&entry)
+			}
+
+			C.free(unsafe.Pointer(st.hits))
+			C.free(unsafe.Pointer(st.scroll_id))
+			C.free(unsafe.Pointer(st))
+		}
+	}
+}
+
+//export destroy_specification_search_result
+func destroy_specification_search_result(st *C.specification_search_result) {
+	if st != nil {
+		destroy_specification_search(st.result)
+		C.free(unsafe.Pointer(st.error))
+		C.free(unsafe.Pointer(st.stack))
+		C.free(unsafe.Pointer(st))
+	}
+}
+
+//export destroy_mapping
+func destroy_mapping(st *C.mapping) {
+	if st != nil {
+		kuzzle_wrapper_free_json_object(st.mapping)
+		destroy_collection(st.collection)
+		C.free(unsafe.Pointer(st))
+	}
+}
+
+//export destroy_mapping_result
+func destroy_mapping_result(st *C.mapping_result) {
+	if st != nil {
+		destroy_mapping(st.result)
+		C.free(unsafe.Pointer(st.error))
+		C.free(unsafe.Pointer(st.stack))
+		C.free(unsafe.Pointer(st))
+	}
+}
+
+//export destroy_void_result
+func destroy_void_result(st *C.void_result) {
+	if st != nil {
+		C.free(unsafe.Pointer(st.error))
+		C.free(unsafe.Pointer(st.stack))
+		C.free(unsafe.Pointer(st))
+	}
+}
+
+//do not export
+func _free_collection_entry(st *C.collection_entry) {
+	if st != nil {
+		C.free(unsafe.Pointer(st.name))
+	}
+}
+
+//export destroy_collection_entry
+func destroy_collection_entry(st *C.collection_entry) {
+	_free_collection_entry(st)
+	C.free(unsafe.Pointer(st))
+}
+
+//export destroy_collection_entry_result
+func destroy_collection_entry_result(st *C.collection_entry_result) {
+	if st != nil {
+		if st.result != nil {
+			entries := (*[1<<30 - 1]C.collection_entry)(unsafe.Pointer(st.result))[:int(st.result_length):int(st.result_length)]
+
+			for _, entry := range entries {
+				_free_collection_entry(&entry)
+			}
+
+			C.free(unsafe.Pointer(st.result))
+		}
+
+		C.free(unsafe.Pointer(st.error))
+		C.free(unsafe.Pointer(st.stack))
+		C.free(unsafe.Pointer(st))
+	}
+}
+
+//export destroy_user_search
+func destroy_user_search(st *C.user_search) {
+	if st != nil {
+		if st.hits != nil {
+			hits := (*[1<<30 - 1]C.user)(unsafe.Pointer(st.hits))[:int(st.hits_length):int(st.hits_length)]
+
+			for _, user := range hits {
+				_free_user(&user)
+			}
+
+			C.free(unsafe.Pointer(st.hits))
+		}
+
+		C.free(unsafe.Pointer(st.scroll_id))
+		C.free(unsafe.Pointer(st))
+	}
+}
+
+//export destroy_search_users_result
+func destroy_search_users_result(st *C.search_users_result) {
+	if st != nil {
+		destroy_user_search(st.result)
+		C.free(unsafe.Pointer(st.error))
+		C.free(unsafe.Pointer(st.stack))
+		C.free(unsafe.Pointer(st))
+	}
+}

--- a/internal/wrappers/cgo/kuzzle/document.go
+++ b/internal/wrappers/cgo/kuzzle/document.go
@@ -1,0 +1,83 @@
+package main
+
+/*
+	#cgo CFLAGS: -I../../headers
+	#include "kuzzlesdk.h"
+    #include "sdk_wrappers_internal.h"
+*/
+import "C"
+import (
+	"github.com/kuzzleio/sdk-go/types"
+	"unsafe"
+)
+
+//export kuzzle_wrapper_new_document
+func kuzzle_wrapper_new_document(c *C.collection) *C.document {
+	return goToCDocument(c, cToGoCollection(c).Document(), nil)
+}
+
+//export kuzzle_wrapper_document_subscribe
+// TODO loop and close on Unsubscribe
+func kuzzle_wrapper_document_subscribe(d *C.document, options *C.room_options, cb unsafe.Pointer) {
+	c := make(chan *types.KuzzleNotification)
+	cToGoDocument(d._collection, d).Subscribe(SetRoomOptions(options), c)
+
+	go func() {
+		res := <-c
+		C.call_notification_result(cb, goToCNotificationResult(res))
+	}()
+}
+
+// Does not re-allocate the document
+// export kuzzle_wrapper_document_save
+func kuzzle_wrapper_document_save(d *C.document, options *C.query_options) *C.document_result {
+	_, err := cToGoDocument(d._collection, d).Save(SetQueryOptions(options))
+	return currentDocumentResult(d, err)
+}
+
+// export kuzzle_wrapper_document_refresh
+func kuzzle_wrapper_document_refresh(d *C.document, options *C.query_options) *C.document_result {
+	res, err := cToGoDocument(d._collection, d).Refresh(SetQueryOptions(options))
+	return goToCDocumentResult(d._collection, res, err)
+}
+
+//export kuzzle_wrapper_document_set_headers
+func kuzzle_wrapper_document_set_headers(d *C.document, content *C.json_object, replace C.uint) {
+	if JsonCType(content) == C.json_type_object {
+		r := replace != 0
+		cToGoDocument(d._collection, d).SetHeaders(JsonCConvert(content).(map[string]interface{}), r)
+	}
+
+	return
+}
+
+// export kuzzle_wrapper_document_publish
+func kuzzle_wrapper_document_publish(d *C.document, options *C.query_options) *C.bool_result {
+	res, err := cToGoDocument(d._collection, d).Publish(SetQueryOptions(options))
+	return goToCBoolResult(res, err)
+}
+
+// export kuzzle_wrapper_document_exists
+func kuzzle_wrapper_document_exists(d *C.document, options *C.query_options) *C.bool_result {
+	res, err := cToGoDocument(d._collection, d).Exists(SetQueryOptions(options))
+	return goToCBoolResult(res, err)
+}
+
+// export kuzzle_wrapper_document_delete
+func kuzzle_wrapper_document_delete(d *C.document, options *C.query_options) *C.string_result {
+	res, err := cToGoDocument(d._collection, d).Delete(SetQueryOptions(options))
+	return goToCStringResult(&res, err)
+}
+
+// Allocates memory for result, not document
+func currentDocumentResult(d *C.document, err error) *C.document_result {
+	result := (*C.document_result)(C.calloc(1, C.sizeof_document_result))
+
+	if err != nil {
+		Set_document_error(result, err)
+	}
+
+	result.result = d
+
+	return result
+}

--- a/internal/wrappers/cgo/kuzzle/errors.go
+++ b/internal/wrappers/cgo/kuzzle/errors.go
@@ -139,6 +139,14 @@ func Set_notification_result_error(s *C.notification_result, err error) {
 	setErr(&s.status, s.error, s.stack, err)
 }
 
+func Set_collection_entry_error(s *C.collection_entry_result, err error) {
+	setErr(&s.status, s.error, s.stack, err)
+}
+
+func Set_void_result_error(s *C.void_result, err error) {
+	setErr(&s.status, s.error, s.stack, err)
+}
+
 func setErr(status *C.int, error *C.char, stack *C.char, err error) {
 	kuzzleError := err.(*types.KuzzleError)
 	*status = C.int(kuzzleError.Status)

--- a/internal/wrappers/cgo/kuzzle/errors.go
+++ b/internal/wrappers/cgo/kuzzle/errors.go
@@ -1,0 +1,150 @@
+package main
+
+/*
+  #cgo CFLAGS: -I../../../headers
+  #cgo LDFLAGS: -ljson-c
+
+  #include "kuzzlesdk.h"
+*/
+import "C"
+
+import (
+	"github.com/kuzzleio/sdk-go/types"
+)
+
+// apply a types.KuzzleError on a json_result* C struct
+func Set_json_result_error(s *C.json_result, err error) {
+	setErr(&s.status, s.error, s.stack, err)
+}
+
+// apply a types.KuzzleError on a token_validity* C struct
+func Set_token_validity_error(s *C.token_validity, err error) {
+	setErr(&s.status, s.error, s.stack, err)
+}
+
+// apply a types.KuzzleError on a ack_result* C struct
+func Set_ack_result_error(s *C.ack_result, err error) {
+	setErr(&s.status, s.error, s.stack, err)
+}
+
+// apply a types.KuzzleError on a bool_result* C struct
+func Set_bool_result_error(s *C.bool_result, err error) {
+	setErr(&s.status, s.error, s.stack, err)
+}
+
+// apply a types.KuzzleError on a kuzzle_response* C struct
+func Set_kuzzle_response_error(s *C.kuzzle_response, err error) {
+	setErr(&s.status, s.error, s.stack, err)
+}
+
+// apply a types.KuzzleError on a statistics* C struct
+func Set_statistics_error(s *C.statistics_result, err error) {
+	setErr(&s.status, s.error, s.stack, err)
+}
+
+// apply a types.KuzzleError on a string_array_result* C struct
+func Set_string_array_result_error(s *C.string_array_result, err error) {
+	setErr(&s.status, s.error, s.stack, err)
+}
+
+// apply a types.KuzzleError on a int_result* C struct
+func Set_int_result_error(s *C.int_result, err error) {
+	setErr(&s.status, s.error, s.stack, err)
+}
+
+// apply a types.KuzzleError on a int_array_result* C struct
+func Set_int_array_result_error(s *C.int_array_result, err error) {
+	setErr(&s.status, s.error, s.stack, err)
+}
+
+// apply a types.KuzzleError on a string_result* C struct
+func Set_string_result_error(s *C.string_result, err error) {
+	setErr(&s.status, s.error, s.stack, err)
+}
+
+// apply a types.KuzzleError on a shards* C struct
+func Set_shards_result_error(s *C.shards_result, err error) {
+	setErr(&s.status, s.error, s.stack, err)
+}
+
+// apply a types.KuzzleError on a document* C struct
+func Set_document_error(s *C.document_result, err error) {
+	setErr(&s.status, s.error, s.stack, err)
+}
+
+// apply a types.KuzzleError on a search_result* C struct
+func Set_search_result_error(s *C.search_result, err error) {
+	setErr(&s.status, s.error, s.stack, err)
+}
+
+// apply a types.KuzzleError on a search_result* C struct
+func Set_mapping_result_error(s *C.mapping_result, err error) {
+	setErr(&s.status, s.error, s.stack, err)
+}
+
+// apply a types.KuzzleError on a all_statistics_result* C struct
+func Set_all_statistics_error(s *C.all_statistics_result, err error) {
+	setErr(&s.status, s.error, s.stack, err)
+}
+
+func Set_specification_result_err(s *C.specification_result, err error) {
+	setErr(&s.status, s.error, s.stack, err)
+}
+
+func Set_specification_search_result_error(s *C.specification_search_result, err error) {
+	setErr(&s.status, s.error, s.stack, err)
+}
+
+func Set_double_result_error(s *C.double_result, err error) {
+	setErr(&s.status, s.error, s.stack, err)
+}
+
+func Set_json_array_result_error(s *C.json_array_result, err error) {
+	setErr(&s.status, s.error, s.stack, err)
+}
+
+func Set_profile_result_error(s *C.profile_result, err error) {
+	setErr(&s.status, s.error, s.stack, err)
+}
+
+func Set_role_result_error(s *C.role_result, err error) {
+	setErr(&s.status, s.error, s.stack, err)
+}
+
+func Set_search_profiles_result_error(s *C.search_profiles_result, err error) {
+	setErr(&s.status, s.error, s.stack, err)
+}
+
+func Set_search_roles_result_error(s *C.search_roles_result, err error) {
+	setErr(&s.status, s.error, s.stack, err)
+}
+
+func Set_search_users_result_error(s *C.search_users_result, err error) {
+	setErr(&s.status, s.error, s.stack, err)
+}
+
+func Set_user_result_error(s *C.user_result, err error) {
+	setErr(&s.status, s.error, s.stack, err)
+}
+
+func Set_profiles_result_error(s *C.profiles_result, err error) {
+	setErr(&s.status, s.error, s.stack, err)
+}
+
+func Set_user_rights_error(s *C.user_rights_result, err error) {
+	setErr(&s.status, s.error, s.stack, err)
+}
+
+func Set_notification_result_error(s *C.notification_result, err error) {
+	setErr(&s.status, s.error, s.stack, err)
+}
+
+func setErr(status *C.int, error *C.char, stack *C.char, err error) {
+	kuzzleError := err.(*types.KuzzleError)
+	*status = C.int(kuzzleError.Status)
+	error = C.CString(kuzzleError.Message)
+
+	if len(kuzzleError.Stack) > 0 {
+		stack = C.CString(kuzzleError.Stack)
+	}
+}

--- a/internal/wrappers/cgo/kuzzle/go_to_c.go
+++ b/internal/wrappers/cgo/kuzzle/go_to_c.go
@@ -178,7 +178,7 @@ func goToCPolicyRestriction(restriction *types.PolicyRestriction, dest *C.policy
 		crestriction = dest
 	}
 	crestriction.index = C.CString(restriction.Index)
-	crestriction.collections_length = C.int(len(restriction.Collections))
+	crestriction.collections_length = C.size_t(len(restriction.Collections))
 
 	if restriction.Collections != nil {
 		crestriction.collections = (**C.char)(C.calloc(C.size_t(len(restriction.Collections)), C.sizeof_char_ptr))
@@ -218,7 +218,7 @@ func goToCStringArrayResult(goRes []string, err error) *C.string_array_result {
 
 	if goRes != nil {
 		result.result = (**C.char)(C.calloc(C.size_t(len(goRes)), C.sizeof_char_ptr))
-		result.length = C.ulong(len(goRes))
+		result.result_length = C.size_t(len(goRes))
 
 		cArray := (*[1<<30 - 1]*C.char)(unsafe.Pointer(result.result))[:len(goRes):len(goRes)]
 
@@ -255,7 +255,7 @@ func goToCIntArrayResult(goRes []int, err error) *C.int_array_result {
 
 	if goRes != nil {
 		result.result = (*C.longlong)(C.calloc(C.size_t(len(goRes)), C.sizeof_longlong))
-		result.length = C.uint(len(goRes))
+		result.result_length = C.size_t(len(goRes))
 
 		cArray := (*[1<<20 - 1]C.longlong)(unsafe.Pointer(result.result))[:len(goRes):len(goRes)]
 
@@ -290,7 +290,7 @@ func goToCPolicy(policy *types.Policy, dest *C.policy) *C.policy {
 	}
 
 	cpolicy.role_id = C.CString(policy.RoleId)
-	cpolicy.restricted_to_length = C.int(len(policy.RestrictedTo))
+	cpolicy.restricted_to_length = C.size_t(len(policy.RestrictedTo))
 
 	if policy.RestrictedTo != nil {
 		cpolicy.restricted_to = (*C.policy_restriction)(C.calloc(C.size_t(len(policy.RestrictedTo)), C.sizeof_policy_restriction))
@@ -313,7 +313,7 @@ func goToCProfile(k *C.kuzzle, profile *security.Profile, dest *C.profile) *C.pr
 	}
 
 	cprofile.id = C.CString(profile.Id)
-	cprofile.policies_length = C.int(len(profile.Policies))
+	cprofile.policies_length = C.size_t(len(profile.Policies))
 	cprofile.kuzzle = k
 
 	if profile.Policies != nil {
@@ -336,10 +336,10 @@ func goToCProfileSearchResult(k *C.kuzzle, res *security.ProfileSearchResult, er
 	}
 
 	result.result = (*C.profile_search)(C.calloc(1, C.sizeof_profile_search))
-	result.result.length = C.uint(len(res.Hits))
+	result.result.hits_length = C.size_t(len(res.Hits))
 	result.result.total = C.uint(res.Total)
 	if res.ScrollId != "" {
-		result.result.scrollId = C.CString(res.ScrollId)
+		result.result.scroll_id = C.CString(res.ScrollId)
 	}
 
 	if len(res.Hits) > 0 {
@@ -363,7 +363,7 @@ func goToCRoleSearchResult(k *C.kuzzle, res *security.RoleSearchResult, err erro
 	}
 
 	result.result = (*C.role_search)(C.calloc(1, C.sizeof_role_search))
-	result.result.length = C.uint(len(res.Hits))
+	result.result.hits_length = C.size_t(len(res.Hits))
 	result.result.total = C.uint(res.Total)
 
 	if len(res.Hits) > 0 {
@@ -402,10 +402,10 @@ func goToCSearchResult(col *C.collection, goRes *collection.SearchResult, err er
 	}
 
 	result.result = (*C.document_search)(C.calloc(1, C.sizeof_document_search))
-	result.result.length = C.uint(len(goRes.Hits))
+	result.result.hits_length = C.size_t(len(goRes.Hits))
 	result.result.total = C.uint(goRes.Total)
 	if goRes.ScrollId != "" {
-		result.result.scrollId = C.CString(goRes.ScrollId)
+		result.result.scroll_id = C.CString(goRes.ScrollId)
 	}
 
 	if len(goRes.Hits) > 0 {
@@ -528,9 +528,12 @@ func goToCSpecificationSearchResult(goRes *types.SpecificationSearchResult, err 
 	}
 
 	result.result = (*C.specification_search)(C.calloc(1, C.sizeof_specification_search))
-	result.result.length = C.uint(len(goRes.Hits))
+	result.result.hits_length = C.size_t(len(goRes.Hits))
 	result.result.total = C.uint(goRes.Total)
-	result.result.scrollId = C.CString(goRes.ScrollId)
+
+	if goRes.ScrollId != "" {
+		result.result.scroll_id = C.CString(goRes.ScrollId)
+	}
 
 	if len(goRes.Hits) > 0 {
 		result.result.hits = (*C.specification_entry)(C.calloc(C.size_t(len(goRes.Hits)), C.sizeof_specification_entry))
@@ -588,9 +591,9 @@ func goToCJsonArrayResult(goRes []interface{}, err error) *C.json_array_result {
 		return result
 	}
 
-	result.length = C.uint(len(goRes))
+	result.result_length = C.size_t(len(goRes))
 	if goRes != nil {
-		result.result = (**C.json_object)(C.calloc(C.size_t(result.length), C.sizeof_json_object_ptr))
+		result.result = (**C.json_object)(C.calloc(result.result_length, C.sizeof_json_object_ptr))
 		cArray := (*[1<<30 - 1]*C.json_object)(unsafe.Pointer(result.result))[:len(goRes):len(goRes)]
 
 		for i, res := range goRes {
@@ -632,7 +635,7 @@ func goToCUserData(data *types.UserData) (*C.user_data, error) {
 	}
 
 	if data.ProfileIds != nil {
-		cdata.profile_ids_length = C.uint(len(data.ProfileIds))
+		cdata.profile_ids_length = C.size_t(len(data.ProfileIds))
 		cdata.profile_ids = (**C.char)(C.calloc(C.size_t(len(data.ProfileIds)), C.sizeof_char_ptr))
 		carray := (*[1<<30 - 1]*C.char)(unsafe.Pointer(cdata.profile_ids))[:len(data.ProfileIds):len(data.ProfileIds)]
 
@@ -668,7 +671,7 @@ func goToCUser(k *C.kuzzle, user *security.User, dest *C.user) (*C.user, error) 
 	}
 
 	if user.ProfileIds != nil {
-		cuser.profile_ids_length = C.uint(len(user.ProfileIds))
+		cuser.profile_ids_length = C.size_t(len(user.ProfileIds))
 		cuser.profile_ids = (**C.char)(C.calloc(C.size_t(len(user.ProfileIds)), C.sizeof_char_ptr))
 		carray := (*[1<<30 - 1]*C.char)(unsafe.Pointer(cuser.profile_ids))[:len(user.ProfileIds):len(user.ProfileIds)]
 
@@ -705,7 +708,7 @@ func goToCProfilesResult(k *C.kuzzle, profiles []*security.Profile, err error) *
 		return result
 	}
 
-	result.profiles_length = C.uint(len(profiles))
+	result.profiles_length = C.size_t(len(profiles))
 
 	if profiles != nil {
 		result.profiles = (*C.profile)(C.calloc(C.size_t(len(profiles)), C.sizeof_profile))
@@ -747,7 +750,7 @@ func goToCUserRightsResult(rights []*types.UserRights, err error) *C.user_rights
 		return result
 	}
 
-	result.user_rights_length = C.uint(len(rights))
+	result.user_rights_length = C.size_t(len(rights))
 	if rights != nil {
 		result.user_rights = (*C.user_right)(C.calloc(C.size_t(len(rights)), C.sizeof_user_right))
 		carray := (*[1<<30 - 1]C.user_right)(unsafe.Pointer(result.user_rights))[:len(rights):len(rights)]
@@ -769,10 +772,10 @@ func goToCUserSearchResult(k *C.kuzzle, res *security.UserSearchResult, err erro
 	}
 
 	result.result = (*C.user_search)(C.calloc(1, C.sizeof_user_search))
-	result.result.length = C.uint(len(res.Hits))
+	result.result.hits_length = C.size_t(len(res.Hits))
 	result.result.total = C.uint(res.Total)
 	if res.ScrollId != "" {
-		result.result.scrollId = C.CString(res.ScrollId)
+		result.result.scroll_id = C.CString(res.ScrollId)
 	}
 
 	if len(res.Hits) > 0 {
@@ -787,10 +790,37 @@ func goToCUserSearchResult(k *C.kuzzle, res *security.UserSearchResult, err erro
 	return result
 }
 
-// Allocates memory
-func goToCStatistics(res *types.Statistics, err error) *C.statistics {
-	result := (*C.statistics)(C.calloc(1, C.sizeof_statistics))
+func fillCollectionList(collection *types.CollectionsList, entry *C.collection_entry) {
+	if collection == nil {
+		return
+	}
 
+	entry.persisted = collection.Type == "persisted"
+	entry.name = C.CString(collection.Name)
+}
+
+func goToCCollectionListResult(collections []*types.CollectionsList, err error) *C.collection_entry_result {
+	result := (*C.collection_entry_result)(C.calloc(1, C.sizeof_collection_entry_result))
+	if err != nil {
+		Set_collection_entry_error(result, err)
+		return result
+	}
+
+	if collections != nil {
+		result.result = (*C.collection_entry)(C.calloc(C.size_t(len(collections)), C.sizeof_collection_entry))
+		result.result_length = C.size_t(len(collections))
+		carray := (*[1<<30 - 1]C.collection_entry)(unsafe.Pointer(result.result))[:len(collections):len(collections)]
+
+		for i, collection := range collections {
+			fillCollectionList(collection, &carray[i])
+		}
+	}
+
+	return result
+}
+
+// Allocates memory
+func fillStatistics(res *types.Statistics, statistics *C.statistics) {
 	ongoing, _ := json.Marshal(res.OngoingRequests)
 	completedRequests, _ := json.Marshal(res.CompletedRequests)
 	connections, _ := json.Marshal(res.Connections)
@@ -801,16 +831,26 @@ func goToCStatistics(res *types.Statistics, err error) *C.statistics {
 	cConnections := C.CString(string(connections))
 	cFailedRequests := C.CString(string(failedRequests))
 
-	result.ongoing_requests = C.json_tokener_parse(cOnGoing)
-	result.completed_requests = C.json_tokener_parse(cCompleteRequest)
-	result.connections = C.json_tokener_parse(cConnections)
-	result.failed_requests = C.json_tokener_parse(cFailedRequests)
-	result.timestamp = C.ulonglong(res.Timestamp)
+	statistics.ongoing_requests = C.json_tokener_parse(cOnGoing)
+	statistics.completed_requests = C.json_tokener_parse(cCompleteRequest)
+	statistics.connections = C.json_tokener_parse(cConnections)
+	statistics.failed_requests = C.json_tokener_parse(cFailedRequests)
+	statistics.timestamp = C.ulonglong(res.Timestamp)
 
 	C.free(unsafe.Pointer(cOnGoing))
 	C.free(unsafe.Pointer(cCompleteRequest))
 	C.free(unsafe.Pointer(cConnections))
 	C.free(unsafe.Pointer(cFailedRequests))
+}
+
+// Allocates memory
+func goToCVoidResult(err error) *C.void_result {
+	if err == nil {
+		return nil
+	}
+
+	result := (*C.void_result)(C.calloc(1, C.sizeof_void_result))
+	Set_void_result_error(result, err)
 
 	return result
 }

--- a/internal/wrappers/cgo/kuzzle/go_to_c.go
+++ b/internal/wrappers/cgo/kuzzle/go_to_c.go
@@ -1,0 +1,816 @@
+package main
+
+/*
+	#cgo CFLAGS: -I../../headers
+	#include <string.h>
+	#include <stdlib.h>
+	#include "kuzzlesdk.h"
+	#include "sdk_wrappers_internal.h"
+*/
+import "C"
+import (
+	"encoding/json"
+	"github.com/kuzzleio/sdk-go/collection"
+	"github.com/kuzzleio/sdk-go/security"
+	"github.com/kuzzleio/sdk-go/types"
+	"unsafe"
+)
+
+// Allocates memory
+func goToCMeta(gMeta *types.Meta) *C.meta {
+	if gMeta == nil {
+		return nil
+	}
+
+	result := (*C.meta)(C.calloc(1, C.sizeof_meta))
+	result.author = C.CString(gMeta.Author)
+	result.created_at = C.ulonglong(gMeta.CreatedAt)
+	result.updated_at = C.ulonglong(gMeta.UpdatedAt)
+	result.deleted_at = C.ulonglong(gMeta.DeletedAt)
+	result.updater = C.CString(gMeta.Updater)
+	result.active = C.bool(gMeta.Active)
+
+	return result
+}
+
+// Allocates memory
+func goToCShards(gShards *types.Shards) *C.shards {
+	if gShards == nil {
+		return nil
+	}
+
+	result := (*C.shards)(C.calloc(1, C.sizeof_shards))
+	result.failed = C.int(gShards.Failed)
+	result.successful = C.int(gShards.Successful)
+	result.total = C.int(gShards.Total)
+
+	return result
+}
+
+// Allocates memory
+func goToCDocument(col *C.collection, gDoc *collection.Document, dest *C.document) *C.document {
+	var result *C.document
+	if dest == nil {
+		result = (*C.document)(C.calloc(1, C.sizeof_document))
+	} else {
+		result = dest
+	}
+
+	result.id = C.CString(gDoc.Id)
+	result.index = C.CString(gDoc.Index)
+	result.result = C.CString(gDoc.Result)
+	result.collection = C.CString(gDoc.Collection)
+	result.meta = goToCMeta(gDoc.Meta)
+	result.shards = goToCShards(gDoc.Shards)
+	result._collection = col
+
+	if string(gDoc.Content) != "" {
+		buffer := C.CString(string(gDoc.Content))
+		result.content = C.json_tokener_parse(buffer)
+		C.free(unsafe.Pointer(buffer))
+	} else {
+		result.content = C.json_object_new_object()
+	}
+
+	result.version = C.int(gDoc.Version)
+	result.created = C.bool(gDoc.Created)
+
+	return result
+}
+
+// Allocates memory
+func goToCNotificationContent(gNotifContent *types.NotificationResult) *C.notification_content {
+	result := (*C.notification_content)(C.calloc(1, C.sizeof_notification_content))
+	result.id = C.CString(gNotifContent.Id)
+	result.meta = goToCMeta(gNotifContent.Meta)
+	result.count = C.int(gNotifContent.Count)
+
+	r, _ := json.Marshal(gNotifContent.Content)
+	buffer := C.CString(string(r))
+	result.content = C.json_tokener_parse(buffer)
+	C.free(unsafe.Pointer(buffer))
+
+	return result
+}
+
+// Allocates memory
+func goToCNotificationResult(gNotif *types.KuzzleNotification) *C.notification_result {
+	result := (*C.notification_result)(C.calloc(1, C.sizeof_notification_result))
+
+	if gNotif.Error != nil {
+		Set_notification_result_error(result, gNotif.Error)
+		return result
+	}
+
+	result.request_id = C.CString(gNotif.RequestId)
+	result.result = goToCNotificationContent(gNotif.Result)
+
+	r, _ := json.Marshal(gNotif.Volatile)
+	buffer := C.CString(string(r))
+	result.volatiles = C.json_tokener_parse(buffer)
+	C.free(unsafe.Pointer(buffer))
+
+	result.index = C.CString(gNotif.Index)
+	result.collection = C.CString(gNotif.Collection)
+	result.controller = C.CString(gNotif.Controller)
+	result.action = C.CString(gNotif.Action)
+	result.protocol = C.CString(gNotif.Protocol)
+	result.scope = C.CString(gNotif.Scope)
+	result.state = C.CString(gNotif.State)
+	result.user = C.CString(gNotif.User)
+	result.n_type = C.CString(gNotif.Type)
+	result.room_id = C.CString(gNotif.RoomId)
+	result.timestamp = C.ulonglong(gNotif.Timestamp)
+	result.status = C.int(gNotif.Status)
+
+	return result
+}
+
+func goToCKuzzleResponse(gRes *types.KuzzleResponse) *C.kuzzle_response {
+	result := (*C.kuzzle_response)(C.calloc(1, C.sizeof_kuzzle_response))
+
+	result.request_id = C.CString(gRes.RequestId)
+
+	bufResult := C.CString(string(gRes.Result))
+	result.result = C.json_tokener_parse(bufResult)
+	C.free(unsafe.Pointer(bufResult))
+
+	r, _ := json.Marshal(gRes.Volatile)
+	bufVolatile := C.CString(string(r))
+	result.volatiles = C.json_tokener_parse(bufVolatile)
+	C.free(unsafe.Pointer(bufVolatile))
+
+	result.index = C.CString(gRes.Index)
+	result.collection = C.CString(gRes.Collection)
+	result.controller = C.CString(gRes.Controller)
+	result.action = C.CString(gRes.Action)
+	result.room_id = C.CString(gRes.RoomId)
+	result.channel = C.CString(gRes.Channel)
+	result.status = C.int(gRes.Status)
+
+	if gRes.Error != nil {
+		// The error might be a partial error
+		Set_kuzzle_response_error(result, gRes.Error)
+	}
+
+	return result
+}
+
+// Allocates memory
+func goToCDocumentResult(col *C.collection, goRes *collection.Document, err error) *C.document_result {
+	result := (*C.document_result)(C.calloc(1, C.sizeof_document_result))
+
+	if err != nil {
+		Set_document_error(result, err)
+		return result
+	}
+
+	result.result = goToCDocument(col, goRes, nil)
+
+	return result
+}
+
+func goToCPolicyRestriction(restriction *types.PolicyRestriction, dest *C.policy_restriction) *C.policy_restriction {
+	var crestriction *C.policy_restriction
+	if dest == nil {
+		crestriction = (*C.policy_restriction)(C.calloc(1, C.sizeof_policy_restriction))
+	} else {
+		crestriction = dest
+	}
+	crestriction.index = C.CString(restriction.Index)
+	crestriction.collections_length = C.int(len(restriction.Collections))
+
+	if restriction.Collections != nil {
+		crestriction.collections = (**C.char)(C.calloc(C.size_t(len(restriction.Collections)), C.sizeof_char_ptr))
+		collections := (*[1<<30 - 1]*C.char)(unsafe.Pointer(crestriction.collections))[:len(restriction.Collections)]
+
+		for i, col := range restriction.Collections {
+			collections[i] = C.CString(col)
+		}
+	}
+
+	return crestriction
+}
+
+// Allocates memory
+func goToCStringResult(goRes *string, err error) *C.string_result {
+	result := (*C.string_result)(C.calloc(1, C.sizeof_string_result))
+
+	if err != nil {
+		Set_string_result_error(result, err)
+		return result
+	}
+
+	if goRes != nil {
+		result.result = C.CString(*goRes)
+	}
+
+	return result
+}
+
+func goToCStringArrayResult(goRes []string, err error) *C.string_array_result {
+	result := (*C.string_array_result)(C.calloc(1, C.sizeof_string_array_result))
+
+	if err != nil {
+		Set_string_array_result_error(result, err)
+		return result
+	}
+
+	if goRes != nil {
+		result.result = (**C.char)(C.calloc(C.size_t(len(goRes)), C.sizeof_char_ptr))
+		result.length = C.ulong(len(goRes))
+
+		cArray := (*[1<<30 - 1]*C.char)(unsafe.Pointer(result.result))[:len(goRes):len(goRes)]
+
+		for i, substring := range goRes {
+			cArray[i] = C.CString(substring)
+		}
+	}
+
+	return result
+}
+
+// Allocates memory
+func goToCIntResult(goRes int, err error) *C.int_result {
+	result := (*C.int_result)(C.calloc(1, C.sizeof_int_result))
+
+	if err != nil {
+		Set_int_result_error(result, err)
+		return result
+	}
+
+	result.result = C.longlong(goRes)
+
+	return result
+}
+
+//Allocates memory
+func goToCIntArrayResult(goRes []int, err error) *C.int_array_result {
+	result := (*C.int_array_result)(C.calloc(1, C.sizeof_int_array_result))
+
+	if err != nil {
+		Set_int_array_result_error(result, err)
+		return result
+	}
+
+	if goRes != nil {
+		result.result = (*C.longlong)(C.calloc(C.size_t(len(goRes)), C.sizeof_longlong))
+		result.length = C.uint(len(goRes))
+
+		cArray := (*[1<<20 - 1]C.longlong)(unsafe.Pointer(result.result))[:len(goRes):len(goRes)]
+
+		for i, num := range goRes {
+			cArray[i] = C.longlong(num)
+		}
+	}
+
+	return result
+}
+
+// Allocates memory
+func goToCDoubleResult(goRes float64, err error) *C.double_result {
+	result := (*C.double_result)(C.calloc(1, C.sizeof_double_result))
+
+	if err != nil {
+		Set_double_result_error(result, err)
+		return result
+	}
+
+	result.result = C.double(goRes)
+
+	return result
+}
+
+func goToCPolicy(policy *types.Policy, dest *C.policy) *C.policy {
+	var cpolicy *C.policy
+	if dest == nil {
+		cpolicy = (*C.policy)(C.calloc(1, C.sizeof_policy))
+	} else {
+		cpolicy = dest
+	}
+
+	cpolicy.role_id = C.CString(policy.RoleId)
+	cpolicy.restricted_to_length = C.int(len(policy.RestrictedTo))
+
+	if policy.RestrictedTo != nil {
+		cpolicy.restricted_to = (*C.policy_restriction)(C.calloc(C.size_t(len(policy.RestrictedTo)), C.sizeof_policy_restriction))
+		restrictions := (*[1<<30 - 1]C.policy_restriction)(unsafe.Pointer(cpolicy.restricted_to))[:len(policy.RestrictedTo)]
+
+		for i, restriction := range policy.RestrictedTo {
+			goToCPolicyRestriction(restriction, &restrictions[i])
+		}
+	}
+
+	return cpolicy
+}
+
+func goToCProfile(k *C.kuzzle, profile *security.Profile, dest *C.profile) *C.profile {
+	var cprofile *C.profile
+	if dest == nil {
+		cprofile = (*C.profile)(C.calloc(1, C.sizeof_profile))
+	} else {
+		cprofile = dest
+	}
+
+	cprofile.id = C.CString(profile.Id)
+	cprofile.policies_length = C.int(len(profile.Policies))
+	cprofile.kuzzle = k
+
+	if profile.Policies != nil {
+		cprofile.policies = (*C.policy)(C.calloc(C.size_t(len(profile.Policies)), C.sizeof_policy))
+		policies := (*[1<<30 - 1]C.policy)(unsafe.Pointer(cprofile.policies))[:len(profile.Policies)]
+		for i, policy := range profile.Policies {
+			goToCPolicy(policy, &policies[i])
+		}
+	}
+
+	return cprofile
+}
+
+func goToCProfileSearchResult(k *C.kuzzle, res *security.ProfileSearchResult, err error) *C.search_profiles_result {
+	result := (*C.search_profiles_result)(C.calloc(1, C.sizeof_search_profiles_result))
+
+	if err != nil {
+		Set_search_profiles_result_error(result, err)
+		return result
+	}
+
+	result.result = (*C.profile_search)(C.calloc(1, C.sizeof_profile_search))
+	result.result.length = C.uint(len(res.Hits))
+	result.result.total = C.uint(res.Total)
+	if res.ScrollId != "" {
+		result.result.scrollId = C.CString(res.ScrollId)
+	}
+
+	if len(res.Hits) > 0 {
+		result.result.hits = (*C.profile)(C.calloc(C.size_t(len(res.Hits)), C.sizeof_profile))
+		profiles := (*[1<<30 - 1]C.profile)(unsafe.Pointer(result.result.hits))[:len(res.Hits)]
+
+		for i, profile := range res.Hits {
+			goToCProfile(k, profile, &profiles[i])
+		}
+	}
+
+	return result
+}
+
+func goToCRoleSearchResult(k *C.kuzzle, res *security.RoleSearchResult, err error) *C.search_roles_result {
+	result := (*C.search_roles_result)(C.calloc(1, C.sizeof_search_roles_result))
+
+	if err != nil {
+		Set_search_roles_result_error(result, err)
+		return result
+	}
+
+	result.result = (*C.role_search)(C.calloc(1, C.sizeof_role_search))
+	result.result.length = C.uint(len(res.Hits))
+	result.result.total = C.uint(res.Total)
+
+	if len(res.Hits) > 0 {
+		result.result.hits = (*C.role)(C.calloc(C.size_t(len(res.Hits)), C.sizeof_role))
+		cArray := (*[1<<30 - 1]C.role)(unsafe.Pointer(result.result.hits))[:len(res.Hits):len(res.Hits)]
+
+		for i, role := range res.Hits {
+			goToCRole(k, role, &cArray[i])
+		}
+	}
+
+	return result
+}
+
+// Allocates memory
+func goToCBoolResult(goRes bool, err error) *C.bool_result {
+	result := (*C.bool_result)(C.calloc(1, C.sizeof_bool_result))
+
+	if err != nil {
+		Set_bool_result_error(result, err)
+		return result
+	}
+
+	result.result = C.bool(goRes)
+
+	return result
+}
+
+// Allocates memory
+func goToCSearchResult(col *C.collection, goRes *collection.SearchResult, err error) *C.search_result {
+	result := (*C.search_result)(C.calloc(1, C.sizeof_search_result))
+
+	if err != nil {
+		Set_search_result_error(result, err)
+		return result
+	}
+
+	result.result = (*C.document_search)(C.calloc(1, C.sizeof_document_search))
+	result.result.length = C.uint(len(goRes.Hits))
+	result.result.total = C.uint(goRes.Total)
+	if goRes.ScrollId != "" {
+		result.result.scrollId = C.CString(goRes.ScrollId)
+	}
+
+	if len(goRes.Hits) > 0 {
+		result.result.hits = (*C.document)(C.calloc(C.size_t(len(goRes.Hits)), C.sizeof_document))
+		cArray := (*[1<<30 - 1]C.document)(unsafe.Pointer(result.result.hits))[:len(goRes.Hits):len(goRes.Hits)]
+
+		for i, doc := range goRes.Hits {
+			goToCDocument(col, doc, &cArray[i])
+		}
+	}
+
+	return result
+}
+
+// Allocates memory
+func goToCMapping(c *C.collection, goMapping *collection.Mapping) *C.mapping {
+	result := (*C.mapping)(C.calloc(1, C.sizeof_mapping))
+
+	result.collection = c
+	r, _ := json.Marshal(goMapping.Mapping)
+	buffer := C.CString(string(r))
+	result.mapping = C.json_tokener_parse(buffer)
+	C.free(unsafe.Pointer(buffer))
+
+	return result
+}
+
+// Allocates memory
+func goToCMappingResult(c *C.collection, goRes *collection.Mapping, err error) *C.mapping_result {
+	result := (*C.mapping_result)(C.calloc(1, C.sizeof_mapping_result))
+
+	if err != nil {
+		Set_mapping_result_error(result, err)
+		return result
+	}
+
+	result.result = goToCMapping(c, goRes)
+
+	return result
+}
+
+func goToCRole(k *C.kuzzle, role *security.Role, dest *C.role) *C.role {
+	var crole *C.role
+	if dest == nil {
+		crole = (*C.role)(C.calloc(1, C.sizeof_role))
+	} else {
+		crole = dest
+	}
+
+	crole.id = C.CString(role.Id)
+	crole.kuzzle = k
+
+	if role.Controllers != nil {
+		j, _ := json.Marshal(role.Controllers)
+		buffer := C.CString(string(j))
+		crole.controllers = C.json_tokener_parse(buffer)
+		C.free(unsafe.Pointer(buffer))
+	}
+
+	return crole
+}
+
+// Allocates memory
+func goToCSpecification(goSpec *types.Specification) *C.specification {
+	result := (*C.specification)(C.calloc(1, C.sizeof_specification))
+
+	result.strict = C.bool(goSpec.Strict)
+
+	f, _ := json.Marshal(goSpec.Fields)
+	v, _ := json.Marshal(goSpec.Validators)
+	bufferFields := C.CString(string(f))
+	bufferValidators := C.CString(string(v))
+
+	result.fields = C.json_tokener_parse(bufferFields)
+	result.validators = C.json_tokener_parse(bufferValidators)
+
+	C.free(unsafe.Pointer(bufferFields))
+	C.free(unsafe.Pointer(bufferValidators))
+
+	return result
+}
+
+// Allocates memory
+func goToCSpecificationEntry(goEntry *types.SpecificationEntry, dest *C.specification_entry) *C.specification_entry {
+	var result *C.specification_entry
+	if dest == nil {
+		result = (*C.specification_entry)(C.calloc(1, C.sizeof_specification_entry))
+	} else {
+		result = dest
+	}
+
+	result.index = C.CString(goEntry.Index)
+	result.collection = C.CString(goEntry.Collection)
+	result.validation = goToCSpecification(goEntry.Validation)
+
+	return result
+}
+
+// Allocates memory
+func goToCSpecificationResult(goRes *types.Specification, err error) *C.specification_result {
+	result := (*C.specification_result)(C.calloc(1, C.sizeof_specification_result))
+
+	if err != nil {
+		Set_specification_result_err(result, err)
+		return result
+	}
+
+	result.result = goToCSpecification(goRes)
+
+	return result
+}
+
+// Allocates memory
+func goToCSpecificationSearchResult(goRes *types.SpecificationSearchResult, err error) *C.specification_search_result {
+	result := (*C.specification_search_result)(C.calloc(1, C.sizeof_specification_search_result))
+
+	if err != nil {
+		Set_specification_search_result_error(result, err)
+		return result
+	}
+
+	result.result = (*C.specification_search)(C.calloc(1, C.sizeof_specification_search))
+	result.result.length = C.uint(len(goRes.Hits))
+	result.result.total = C.uint(goRes.Total)
+	result.result.scrollId = C.CString(goRes.ScrollId)
+
+	if len(goRes.Hits) > 0 {
+		result.result.hits = (*C.specification_entry)(C.calloc(C.size_t(len(goRes.Hits)), C.sizeof_specification_entry))
+		cArray := (*[1<<30 - 1]C.specification_entry)(unsafe.Pointer(result.result.hits))[:len(goRes.Hits):len(goRes.Hits)]
+
+		for i, spec := range goRes.Hits {
+			goToCSpecificationEntry(&spec.Source, &cArray[i])
+		}
+	}
+
+	return result
+}
+
+func goToCJson(data interface{}) (*C.json_object, error) {
+	r, err := json.Marshal(data)
+	if err != nil {
+		return nil, types.NewError(err.Error(), 400)
+	}
+
+	buffer := C.CString(string(r))
+	defer C.free(unsafe.Pointer(buffer))
+
+	tok := C.json_tokener_new()
+	j := C.json_tokener_parse_ex(tok, buffer, C.int(C.strlen(buffer)))
+	jerr := C.json_tokener_get_error(tok)
+	if jerr != C.json_tokener_success {
+		return nil, types.NewError(C.GoString(C.json_tokener_error_desc(jerr)), 400)
+	}
+
+	return j, nil
+}
+
+func goToCJsonResult(goRes interface{}, err error) *C.json_result {
+	result := (*C.json_result)(C.calloc(1, C.sizeof_json_result))
+
+	if err != nil {
+		Set_json_result_error(result, err)
+		return result
+	}
+
+	result.result, err = goToCJson(goRes)
+	if err != nil {
+		Set_json_result_error(result, err)
+		return result
+	}
+
+	return result
+}
+
+func goToCJsonArrayResult(goRes []interface{}, err error) *C.json_array_result {
+	result := (*C.json_array_result)(C.calloc(1, C.sizeof_json_array_result))
+
+	if err != nil {
+		Set_json_array_result_error(result, err)
+		return result
+	}
+
+	result.length = C.uint(len(goRes))
+	if goRes != nil {
+		result.result = (**C.json_object)(C.calloc(C.size_t(result.length), C.sizeof_json_object_ptr))
+		cArray := (*[1<<30 - 1]*C.json_object)(unsafe.Pointer(result.result))[:len(goRes):len(goRes)]
+
+		for i, res := range goRes {
+			cArray[i], err = goToCJson(res)
+			if err != nil {
+				Set_json_array_result_error(result, err)
+				return result
+			}
+		}
+	}
+
+	return result
+}
+
+func goToCProfileResult(k *C.kuzzle, res *security.Profile, err error) *C.profile_result {
+	result := (*C.profile_result)(C.calloc(1, C.sizeof_profile_result))
+	if err != nil {
+		Set_profile_result_error(result, err)
+		return result
+	}
+
+	result.profile = goToCProfile(k, res, nil)
+	return result
+}
+
+func goToCUserData(data *types.UserData) (*C.user_data, error) {
+	if data == nil {
+		return nil, nil
+	}
+
+	cdata := (*C.user_data)(C.calloc(1, C.sizeof_user_data))
+
+	if data.Content != nil {
+		jsonO, err := goToCJson(data.Content)
+		if err != nil {
+			return nil, err
+		}
+		cdata.content = jsonO
+	}
+
+	if data.ProfileIds != nil {
+		cdata.profile_ids_length = C.uint(len(data.ProfileIds))
+		cdata.profile_ids = (**C.char)(C.calloc(C.size_t(len(data.ProfileIds)), C.sizeof_char_ptr))
+		carray := (*[1<<30 - 1]*C.char)(unsafe.Pointer(cdata.profile_ids))[:len(data.ProfileIds):len(data.ProfileIds)]
+
+		for i, profileId := range data.ProfileIds {
+			carray[i] = C.CString(profileId)
+		}
+	}
+
+	return cdata, nil
+}
+
+func goToCUser(k *C.kuzzle, user *security.User, dest *C.user) (*C.user, error) {
+	if user == nil {
+		return nil, nil
+	}
+
+	var cuser *C.user
+	if dest == nil {
+		cuser = (*C.user)(C.calloc(1, C.sizeof_user))
+	} else {
+		cuser = dest
+	}
+
+	cuser.id = C.CString(user.Id)
+	cuser.kuzzle = k
+
+	if user.Content != nil {
+		jsonO, err := goToCJson(user.Content)
+		if err != nil {
+			return nil, err
+		}
+		cuser.content = jsonO
+	}
+
+	if user.ProfileIds != nil {
+		cuser.profile_ids_length = C.uint(len(user.ProfileIds))
+		cuser.profile_ids = (**C.char)(C.calloc(C.size_t(len(user.ProfileIds)), C.sizeof_char_ptr))
+		carray := (*[1<<30 - 1]*C.char)(unsafe.Pointer(cuser.profile_ids))[:len(user.ProfileIds):len(user.ProfileIds)]
+
+		for i, profileId := range user.ProfileIds {
+			carray[i] = C.CString(profileId)
+		}
+	}
+
+	return cuser, nil
+}
+
+func goToCUserResult(k *C.kuzzle, user *security.User, err error) *C.user_result {
+	result := (*C.user_result)(C.calloc(1, C.sizeof_user_result))
+	if err != nil {
+		Set_user_result_error(result, err)
+		return result
+	}
+
+	cuser, err := goToCUser(k, user, nil)
+	if err != nil {
+		Set_user_result_error(result, err)
+		return result
+	}
+
+	result.user = cuser
+
+	return result
+}
+
+func goToCProfilesResult(k *C.kuzzle, profiles []*security.Profile, err error) *C.profiles_result {
+	result := (*C.profiles_result)(C.calloc(1, C.sizeof_profiles_result))
+	if err != nil {
+		Set_profiles_result_error(result, err)
+		return result
+	}
+
+	result.profiles_length = C.uint(len(profiles))
+
+	if profiles != nil {
+		result.profiles = (*C.profile)(C.calloc(C.size_t(len(profiles)), C.sizeof_profile))
+		carray := (*[1<<30 - 1]C.profile)(unsafe.Pointer(result.profiles))[:len(profiles):len(profiles)]
+
+		for i, profile := range profiles {
+			goToCProfile(k, profile, &carray[i])
+		}
+	}
+
+	return result
+}
+
+func goToCUserRight(right *types.UserRights, dest *C.user_right) *C.user_right {
+	if right == nil {
+		return nil
+	}
+
+	var cright *C.user_right
+	if dest == nil {
+		cright = (*C.user_right)(C.calloc(1, C.sizeof_user_right))
+	} else {
+		cright = dest
+	}
+
+	cright.controller = C.CString(right.Controller)
+	cright.action = C.CString(right.Action)
+	cright.index = C.CString(right.Index)
+	cright.collection = C.CString(right.Collection)
+	cright.value = C.CString(right.Value)
+
+	return cright
+}
+
+func goToCUserRightsResult(rights []*types.UserRights, err error) *C.user_rights_result {
+	result := (*C.user_rights_result)(C.calloc(1, C.sizeof_user_rights_result))
+	if err != nil {
+		Set_user_rights_error(result, err)
+		return result
+	}
+
+	result.user_rights_length = C.uint(len(rights))
+	if rights != nil {
+		result.user_rights = (*C.user_right)(C.calloc(C.size_t(len(rights)), C.sizeof_user_right))
+		carray := (*[1<<30 - 1]C.user_right)(unsafe.Pointer(result.user_rights))[:len(rights):len(rights)]
+
+		for i, right := range rights {
+			goToCUserRight(right, &carray[i])
+		}
+	}
+
+	return result
+}
+
+func goToCUserSearchResult(k *C.kuzzle, res *security.UserSearchResult, err error) *C.search_users_result {
+	result := (*C.search_users_result)(C.calloc(1, C.sizeof_search_users_result))
+
+	if err != nil {
+		Set_search_users_result_error(result, err)
+		return result
+	}
+
+	result.result = (*C.user_search)(C.calloc(1, C.sizeof_user_search))
+	result.result.length = C.uint(len(res.Hits))
+	result.result.total = C.uint(res.Total)
+	if res.ScrollId != "" {
+		result.result.scrollId = C.CString(res.ScrollId)
+	}
+
+	if len(res.Hits) > 0 {
+		result.result.hits = (*C.user)(C.calloc(C.size_t(len(res.Hits)), C.sizeof_user))
+		users := (*[1<<30 - 1]C.user)(unsafe.Pointer(result.result.hits))[:len(res.Hits)]
+
+		for i, user := range res.Hits {
+			goToCUser(k, user, &users[i])
+		}
+	}
+
+	return result
+}
+
+// Allocates memory
+func goToCStatistics(res *types.Statistics, err error) *C.statistics {
+	result := (*C.statistics)(C.calloc(1, C.sizeof_statistics))
+
+	ongoing, _ := json.Marshal(res.OngoingRequests)
+	completedRequests, _ := json.Marshal(res.CompletedRequests)
+	connections, _ := json.Marshal(res.Connections)
+	failedRequests, _ := json.Marshal(res.FailedRequests)
+
+	cOnGoing := C.CString(string(ongoing))
+	cCompleteRequest := C.CString(string(completedRequests))
+	cConnections := C.CString(string(connections))
+	cFailedRequests := C.CString(string(failedRequests))
+
+	result.ongoing_requests = C.json_tokener_parse(cOnGoing)
+	result.completed_requests = C.json_tokener_parse(cCompleteRequest)
+	result.connections = C.json_tokener_parse(cConnections)
+	result.failed_requests = C.json_tokener_parse(cFailedRequests)
+	result.timestamp = C.ulonglong(res.Timestamp)
+
+	C.free(unsafe.Pointer(cOnGoing))
+	C.free(unsafe.Pointer(cCompleteRequest))
+	C.free(unsafe.Pointer(cConnections))
+	C.free(unsafe.Pointer(cFailedRequests))
+
+	return result
+}

--- a/internal/wrappers/cgo/kuzzle/jsonc_wrapper.go
+++ b/internal/wrappers/cgo/kuzzle/jsonc_wrapper.go
@@ -3,6 +3,8 @@ package main
 /*
 	#cgo CFLAGS: -I../../headers
 	#cgo LDFLAGS: -ljson-c
+
+	#include <json-c/json.h>
 	#include "kuzzlesdk.h"
 */
 import "C"
@@ -141,4 +143,13 @@ func kuzzle_wrapper_json_get_json_object(jobj *C.json_object, key *C.char) *C.js
 
 	C.json_object_object_get_ex(jobj, key, &value)
 	return value
+}
+
+//export kuzzle_wrapper_free_json_object
+func kuzzle_wrapper_free_json_object(jobj *C.json_object) {
+	if jobj != nil {
+		// json_object_put returns 1 when the json object is freed
+		for C.json_object_put(jobj) != 1 {
+		}
+	}
 }

--- a/internal/wrappers/cgo/kuzzle/jsonc_wrapper.go
+++ b/internal/wrappers/cgo/kuzzle/jsonc_wrapper.go
@@ -1,0 +1,144 @@
+package main
+
+/*
+	#cgo CFLAGS: -I../../headers
+	#cgo LDFLAGS: -ljson-c
+	#include "kuzzlesdk.h"
+*/
+import "C"
+import "unsafe"
+
+func JsonCType(jobj *C.json_object) C.json_type {
+	// Returning the value directly results in a type mismatch
+	switch C.json_object_get_type(jobj) {
+	case C.json_type_null:
+		return C.json_type_null
+	case C.json_type_boolean:
+		return C.json_type_boolean
+	case C.json_type_double:
+		return C.json_type_double
+	case C.json_type_int:
+		return C.json_type_int
+	case C.json_type_object:
+		return C.json_type_object
+	case C.json_type_array:
+		return C.json_type_array
+	default:
+		return C.json_type_null
+	}
+}
+
+func JsonCConvert(jobj *C.json_object) interface{} {
+	if jobj == nil {
+		return nil
+	}
+
+	jtype := C.json_object_get_type(jobj)
+
+	switch jtype {
+	case C.json_type_null:
+		return nil
+	case C.json_type_boolean:
+		return int(C.json_object_get_boolean(jobj)) == 1
+	case C.json_type_double:
+		return float64(C.json_object_get_double(jobj))
+	case C.json_type_int:
+		return int(C.json_object_get_int(jobj))
+	case C.json_type_string:
+		return C.GoString(C.json_object_get_string(jobj))
+	case C.json_type_object:
+		table := C.json_object_get_object(jobj)
+		content := make(map[string]interface{})
+
+		if table == nil {
+			return content
+		}
+
+		for field, nextField := table.head, table.head; field != nil; field = nextField {
+			nextField = field.next
+
+			key := (*C.char)(field.k)
+			value := (*C.json_object)(field.v)
+
+			content[C.GoString(key)] = JsonCConvert(value)
+		}
+
+		return content
+	case C.json_type_array:
+		length := int(C.json_object_array_length(jobj))
+		content := make([]interface{}, length)
+
+		for i := 0; i < length; i++ {
+			content[i] = JsonCConvert(C.json_object_array_get_idx(jobj, C.size_t(i)))
+		}
+
+		return content
+	}
+
+	return nil
+}
+
+//export kuzzle_wrapper_json_new
+func kuzzle_wrapper_json_new(jobj *C.json_object) {
+	jobj = C.json_object_new_object()
+}
+
+//export kuzzle_wrapper_json_put
+func kuzzle_wrapper_json_put(jobj *C.json_object, key *C.char, content unsafe.Pointer, kind C.int) {
+	if kind == 0 {
+		//string
+		C.json_object_object_add(jobj, key, C.json_object_new_string((*C.char)(content)))
+	} else if kind == 1 {
+		//int
+		C.json_object_object_add(jobj, key, C.json_object_new_int64((C.int64_t)(*(*C.int)(content))))
+	} else if kind == 2 {
+		//double
+		C.json_object_object_add(jobj, key, C.json_object_new_double(*(*C.double)(content)))
+	} else if kind == 3 {
+		//bool
+		C.json_object_object_add(jobj, key, C.json_object_new_boolean((C.json_bool)(*(*C.uchar)(content))))
+	} else if kind == 4 {
+		//json_object
+		C.json_object_object_add(jobj, key, (*C.json_object)(content))
+	}
+}
+
+//export kuzzle_wrapper_json_get_string
+func kuzzle_wrapper_json_get_string(jobj *C.json_object, key *C.char) *C.char {
+	var value *C.json_object
+	C.json_object_object_get_ex(jobj, key, &value)
+
+	return C.json_object_get_string(value)
+}
+
+//export kuzzle_wrapper_json_get_int
+func kuzzle_wrapper_json_get_int(jobj *C.json_object, key *C.char) C.int {
+	var value *C.json_object
+	C.json_object_object_get_ex(jobj, key, &value)
+
+	return C.int(C.json_object_get_int64(value))
+}
+
+//export kuzzle_wrapper_json_get_double
+func kuzzle_wrapper_json_get_double(jobj *C.json_object, key *C.char) C.double {
+	var value *C.json_object
+	C.json_object_object_get_ex(jobj, key, &value)
+
+	return C.json_object_get_double(value)
+}
+
+//export kuzzle_wrapper_json_get_bool
+func kuzzle_wrapper_json_get_bool(jobj *C.json_object, key *C.char) C.json_bool {
+	var value *C.json_object
+	C.json_object_object_get_ex(jobj, key, &value)
+
+	return C.json_object_get_boolean(value)
+}
+
+//export kuzzle_wrapper_json_get_json_object
+func kuzzle_wrapper_json_get_json_object(jobj *C.json_object, key *C.char) *C.json_object {
+	var value *C.json_object
+
+	C.json_object_object_get_ex(jobj, key, &value)
+	return value
+}

--- a/internal/wrappers/cgo/kuzzle/kuzzle.go
+++ b/internal/wrappers/cgo/kuzzle/kuzzle.go
@@ -81,10 +81,10 @@ func kuzzle_wrapper_get_offline_queue(k *C.kuzzle) *C.offline_queue {
 	result := (*C.offline_queue)(C.calloc(1, C.sizeof_offline_queue))
 
 	offlineQueue := *(*kuzzle.Kuzzle)(k.instance).GetOfflineQueue()
-	result.length = C.ulong(len(offlineQueue))
+	result.queries_length = C.size_t(len(offlineQueue))
 
-	result.queries = (**C.query_object)(C.calloc(C.size_t(len(offlineQueue)), C.sizeof_query_object_ptr))
-	queryObjects := (*[1<<30 - 1]*C.query_object)(unsafe.Pointer(result.queries))[:result.length:result.length]
+	result.queries = (**C.query_object)(C.calloc(result.queries_length, C.sizeof_query_object_ptr))
+	queryObjects := (*[1<<30 - 1]*C.query_object)(unsafe.Pointer(result.queries))[:result.queries_length:result.queries_length]
 
 	idx := 0
 	for _, queryObject := range offlineQueue {

--- a/internal/wrappers/cgo/kuzzle/kuzzle.go
+++ b/internal/wrappers/cgo/kuzzle/kuzzle.go
@@ -1,0 +1,172 @@
+package main
+
+/*
+	#cgo CFLAGS: -I../../headers
+	#include <stdlib.h>
+	#include <string.h>
+	#include "kuzzlesdk.h"
+	#include "sdk_wrappers_internal.h"
+*/
+import "C"
+import (
+	"encoding/json"
+	"github.com/kuzzleio/sdk-go/connection"
+	"github.com/kuzzleio/sdk-go/connection/websocket"
+	"github.com/kuzzleio/sdk-go/kuzzle"
+	"unsafe"
+)
+
+// map which stores instances to keep references in case the gc passes
+var instances map[interface{}]interface{}
+
+// register new instance to the instances map
+func registerKuzzle(instance interface{}) {
+	instances[instance] = nil
+}
+
+// unregister an instance from the instances map
+//export unregisterKuzzle
+func unregisterKuzzle(k *C.kuzzle) {
+	delete(instances, (*kuzzle.Kuzzle)(k.instance))
+}
+
+//export kuzzle_wrapper_new_kuzzle
+func kuzzle_wrapper_new_kuzzle(k *C.kuzzle, host, protocol *C.char, options *C.options) {
+	var c connection.Connection
+
+	if instances == nil {
+		instances = make(map[interface{}]interface{})
+	}
+
+	opts := SetOptions(options)
+
+	if C.GoString(protocol) == "websocket" {
+		c = websocket.NewWebSocket(C.GoString(host), opts)
+	}
+
+	inst, _ := kuzzle.NewKuzzle(c, opts)
+	registerKuzzle(inst)
+
+	k.instance = unsafe.Pointer(inst)
+}
+
+// Allocates memory
+//export kuzzle_wrapper_connect
+func kuzzle_wrapper_connect(k *C.kuzzle) *C.char {
+	err := (*kuzzle.Kuzzle)(k.instance).Connect()
+	if err != nil {
+		return C.CString(err.Error())
+	}
+
+	return nil
+}
+
+//export kuzzle_wrapper_disconnect
+func kuzzle_wrapper_disconnect(k *C.kuzzle) {
+	(*kuzzle.Kuzzle)(k.instance).Disconnect()
+}
+
+//export kuzzle_wrapper_set_default_index
+func kuzzle_wrapper_set_default_index(k *C.kuzzle, index *C.char) C.int {
+	err := (*kuzzle.Kuzzle)(k.instance).SetDefaultIndex(C.GoString(index))
+	if err != nil {
+		return C.int(C.EINVAL)
+	}
+
+	return 0
+}
+
+//export kuzzle_wrapper_get_offline_queue
+func kuzzle_wrapper_get_offline_queue(k *C.kuzzle) *C.offline_queue {
+	result := (*C.offline_queue)(C.calloc(1, C.sizeof_offline_queue))
+
+	offlineQueue := *(*kuzzle.Kuzzle)(k.instance).GetOfflineQueue()
+	result.length = C.ulong(len(offlineQueue))
+
+	result.queries = (**C.query_object)(C.calloc(C.size_t(len(offlineQueue)), C.sizeof_query_object_ptr))
+	queryObjects := (*[1<<30 - 1]*C.query_object)(unsafe.Pointer(result.queries))[:result.length:result.length]
+
+	idx := 0
+	for _, queryObject := range offlineQueue {
+		queryObjects[idx] = (*C.query_object)(C.calloc(1, C.sizeof_query_object))
+		queryObjects[idx].timestamp = C.ulonglong(queryObject.Timestamp.Unix())
+		queryObjects[idx].request_id = C.CString(queryObject.RequestId)
+		mquery, _ := json.Marshal(queryObject.Query)
+
+		buffer := C.CString(string(mquery))
+		queryObjects[idx].query = C.json_tokener_parse(buffer)
+		C.free(unsafe.Pointer(buffer))
+
+		idx += 1
+	}
+
+	return result
+}
+
+//export kuzzle_wrapper_flush_queue
+func kuzzle_wrapper_flush_queue(k *C.kuzzle) {
+	(*kuzzle.Kuzzle)(k.instance).FlushQueue()
+}
+
+//export kuzzle_wrapper_replay_queue
+func kuzzle_wrapper_replay_queue(k *C.kuzzle) {
+	(*kuzzle.Kuzzle)(k.instance).ReplayQueue()
+}
+
+//export kuzzle_wrapper_start_queuing
+func kuzzle_wrapper_start_queuing(k *C.kuzzle) {
+	(*kuzzle.Kuzzle)(k.instance).StartQueuing()
+}
+
+//export kuzzle_wrapper_stop_queuing
+func kuzzle_wrapper_stop_queuing(k *C.kuzzle) {
+	(*kuzzle.Kuzzle)(k.instance).StopQueuing()
+}
+
+//export kuzzle_wrapper_get_headers
+func kuzzle_wrapper_get_headers(k *C.kuzzle) *C.json_object {
+	res := (*kuzzle.Kuzzle)(k.instance).GetHeaders()
+	r, _ := json.Marshal(res)
+
+	buffer := C.CString(string(r))
+	defer C.free(unsafe.Pointer(buffer))
+
+	return C.json_tokener_parse(buffer)
+}
+
+//export kuzzle_wrapper_set_headers
+func kuzzle_wrapper_set_headers(k *C.kuzzle, content *C.json_object, replace C.uint) {
+	if JsonCType(content) == C.json_type_object {
+		r := replace != 0
+		(*kuzzle.Kuzzle)(k.instance).SetHeaders(JsonCConvert(content).(map[string]interface{}), r)
+	}
+}
+
+//export kuzzle_wrapper_add_listener
+// TODO loop and close on Unsubscribe
+func kuzzle_wrapper_add_listener(k *C.kuzzle, e C.int, cb unsafe.Pointer) {
+	c := make(chan interface{})
+
+	kuzzle.AddListener((*kuzzle.Kuzzle)(k.instance), int(e), c)
+	go func() {
+		res := <-c
+
+		var jsonRes *C.json_object
+		r, _ := json.Marshal(res)
+
+		buffer := C.CString(string(r))
+		jsonRes = C.json_tokener_parse(buffer)
+		C.free(unsafe.Pointer(buffer))
+
+		C.call(cb, jsonRes)
+	}()
+}
+
+//export kuzzle_wrapper_remove_listener
+func kuzzle_wrapper_remove_listener(k *C.kuzzle, event C.int) {
+	(*kuzzle.Kuzzle)(k.instance).RemoveListener(int(event))
+}
+
+func main() {
+
+}

--- a/internal/wrappers/cgo/kuzzle/memory_storage.go
+++ b/internal/wrappers/cgo/kuzzle/memory_storage.go
@@ -1,0 +1,1316 @@
+package main
+
+/*
+  #cgo CFLAGS: -I../../headers
+  #cgo LDFLAGS: -ljson-c
+
+  #include <stdlib.h>
+  #include <string.h>
+  #include <json-c/json.h>
+  #include "kuzzlesdk.h"
+  #include "sdk_wrappers_internal.h"
+
+  static void assign_geopos(double (*ptr)[2], int idx, double lon, double lat) {
+    ptr[idx][0] = lon;
+    ptr[idx][1] = lat;
+  }
+*/
+import "C"
+import (
+	"encoding/json"
+	"github.com/kuzzleio/sdk-go/kuzzle"
+	"github.com/kuzzleio/sdk-go/types"
+	"unsafe"
+)
+
+//export kuzzle_wrapper_ms_append
+func kuzzle_wrapper_ms_append(k *C.kuzzle, key *C.char, value *C.char, options *C.query_options) *C.int_result {
+	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Append(
+		C.GoString(key),
+		C.GoString(value),
+		SetQueryOptions(options))
+
+	return goToCIntResult(res, err)
+}
+
+//export kuzzle_wrapper_ms_bitcount
+func kuzzle_wrapper_ms_bitcount(k *C.kuzzle, key *C.char, options *C.query_options) *C.int_result {
+	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Bitcount(
+		C.GoString(key),
+		SetQueryOptions(options))
+
+	return goToCIntResult(res, err)
+}
+
+//export kuzzle_wrapper_ms_bitop
+func kuzzle_wrapper_ms_bitop(k *C.kuzzle, key *C.char, operation *C.char, keys **C.char, klen C.uint, options *C.query_options) *C.int_result {
+	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Bitop(
+		C.GoString(key),
+		C.GoString(operation),
+		cToGoStrings(keys, klen),
+		SetQueryOptions(options))
+
+	return goToCIntResult(res, err)
+}
+
+//export kuzzle_wrapper_ms_bitpos
+func kuzzle_wrapper_ms_bitpos(k *C.kuzzle, key *C.char, bit C.uchar, options *C.query_options) *C.int_result {
+	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Bitpos(
+		C.GoString(key),
+		int(bit),
+		SetQueryOptions(options))
+
+	return goToCIntResult(res, err)
+}
+
+//export kuzzle_wrapper_ms_dbsize
+func kuzzle_wrapper_ms_dbsize(k *C.kuzzle, options *C.query_options) *C.int_result {
+	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Dbsize(SetQueryOptions(options))
+
+	return goToCIntResult(res, err)
+}
+
+//export kuzzle_wrapper_ms_decr
+func kuzzle_wrapper_ms_decr(k *C.kuzzle, key *C.char, options *C.query_options) *C.int_result {
+	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Decr(
+		C.GoString(key),
+		SetQueryOptions(options))
+
+	return goToCIntResult(res, err)
+}
+
+//export kuzzle_wrapper_ms_decrby
+func kuzzle_wrapper_ms_decrby(k *C.kuzzle, key *C.char, value C.int, options *C.query_options) *C.int_result {
+	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Decrby(
+		C.GoString(key),
+		int(value),
+		SetQueryOptions(options))
+
+	return goToCIntResult(res, err)
+}
+
+//export kuzzle_wrapper_ms_del
+func kuzzle_wrapper_ms_del(k *C.kuzzle, keys **C.char, klen C.uint, options *C.query_options) *C.int_result {
+	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Del(
+		cToGoStrings(keys, klen),
+		SetQueryOptions(options))
+
+	return goToCIntResult(res, err)
+}
+
+//export kuzzle_wrapper_ms_exists
+func kuzzle_wrapper_ms_exists(k *C.kuzzle, keys **C.char, klen C.uint, options *C.query_options) *C.int_result {
+	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Exists(
+		cToGoStrings(keys, klen),
+		SetQueryOptions(options))
+
+	return goToCIntResult(res, err)
+}
+
+//export kuzzle_wrapper_ms_expire
+func kuzzle_wrapper_ms_expire(k *C.kuzzle, key *C.char, seconds C.ulong, options *C.query_options) *C.int_result {
+	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Expire(
+		C.GoString(key),
+		int(seconds),
+		SetQueryOptions(options))
+
+	return goToCIntResult(res, err)
+}
+
+//export kuzzle_wrapper_ms_expireat
+func kuzzle_wrapper_ms_expireat(k *C.kuzzle, key *C.char, ts C.ulonglong, options *C.query_options) *C.int_result {
+	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Expireat(
+		C.GoString(key),
+		int(ts),
+		SetQueryOptions(options))
+
+	return goToCIntResult(res, err)
+}
+
+//export kuzzle_wrapper_ms_flushdb
+func kuzzle_wrapper_ms_flushdb(k *C.kuzzle, options *C.query_options) *C.string_result {
+	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Flushdb(SetQueryOptions(options))
+
+	return goToCStringResult(&res, err)
+}
+
+//export kuzzle_wrapper_ms_geoadd
+func kuzzle_wrapper_ms_geoadd(k *C.kuzzle, key *C.char, points **C.json_object, plen C.uint, options *C.query_options) *C.int_result {
+	wrapped := (*[1 << 20]*C.json_object)(unsafe.Pointer(points))[:plen:plen]
+	gopoints := make([]*types.GeoPoint, int(plen))
+
+	for i, jobj := range wrapped {
+		stringified := C.json_object_to_json_string(jobj)
+		gobytes := C.GoBytes(unsafe.Pointer(stringified), C.int(C.strlen(stringified)))
+		json.Unmarshal(gobytes, gopoints[i])
+	}
+
+	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Geoadd(
+		C.GoString(key),
+		gopoints,
+		SetQueryOptions(options))
+
+	return goToCIntResult(res, err)
+}
+
+//export kuzzle_wrapper_ms_geodist
+func kuzzle_wrapper_ms_geodist(k *C.kuzzle, key *C.char, member1 *C.char, member2 *C.char, options *C.query_options) *C.double_result {
+	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Geodist(
+		C.GoString(key),
+		C.GoString(member1),
+		C.GoString(member2),
+		SetQueryOptions(options))
+
+	return goToCDoubleResult(res, err)
+}
+
+//export kuzzle_wrapper_ms_geohash
+func kuzzle_wrapper_ms_geohash(k *C.kuzzle, key *C.char, members **C.char, mlen C.uint, options *C.query_options) *C.string_array_result {
+	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Geohash(
+		C.GoString(key),
+		cToGoStrings(members, mlen),
+		SetQueryOptions(options))
+
+	return goToCStringArrayResult(res, err)
+}
+
+//export kuzzle_wrapper_ms_geopos
+func kuzzle_wrapper_ms_geopos(k *C.kuzzle, key *C.char, members **C.char, mlen C.uint, options *C.query_options) *C.geopos_result {
+	result := (*C.geopos_result)(C.calloc(1, C.sizeof_geopos_result))
+
+	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Geopos(
+		C.GoString(key),
+		cToGoStrings(members, mlen),
+		SetQueryOptions(options))
+
+	if err != nil {
+		kuzzleError := err.(*types.KuzzleError)
+		result.status = C.int(kuzzleError.Status)
+		result.error = C.CString(kuzzleError.Message)
+
+		if len(kuzzleError.Stack) > 0 {
+			result.stack = C.CString(kuzzleError.Stack)
+		}
+		return result
+	}
+
+	result.length = C.uint(len(res))
+	result.result = (*[2]C.double)(C.calloc(C.size_t(result.length), C.sizeof_geopos_arr))
+
+	for i, pos := range res {
+		C.assign_geopos(result.result, C.int(i), C.double(pos.Lon), C.double(pos.Lat))
+	}
+
+	return result
+}
+
+//export kuzzle_wrapper_ms_georadius
+func kuzzle_wrapper_ms_georadius(k *C.kuzzle, key *C.char, lon C.double, lat C.double, dist C.double, unit *C.char, options *C.query_options) *C.json_array_result {
+	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Georadius(
+		C.GoString(key),
+		float64(lon),
+		float64(lat),
+		float64(dist),
+		C.GoString(unit),
+		SetQueryOptions(options))
+
+	var ires []interface{}
+	if err == nil {
+		ires = make([]interface{}, len(res))
+		for i, d := range res {
+			ires[i] = d
+		}
+	}
+
+	return goToCJsonArrayResult(ires, err)
+}
+
+//export kuzzle_wrapper_ms_georadiusbymember
+func kuzzle_wrapper_ms_georadiusbymember(k *C.kuzzle, key *C.char, member *C.char, dist C.double, unit *C.char, options *C.query_options) *C.json_array_result {
+	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Georadiusbymember(
+		C.GoString(key),
+		C.GoString(member),
+		float64(dist),
+		C.GoString(unit),
+		SetQueryOptions(options))
+
+	var ires []interface{}
+	if err == nil {
+		ires = make([]interface{}, len(res))
+		for i, d := range res {
+			ires[i] = d
+		}
+	}
+
+	return goToCJsonArrayResult(ires, err)
+}
+
+//export kuzzle_wrapper_ms_get
+func kuzzle_wrapper_ms_get(k *C.kuzzle, key *C.char, options *C.query_options) *C.string_result {
+	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Get(
+		C.GoString(key),
+		SetQueryOptions(options))
+
+	return goToCStringResult(res, err)
+}
+
+//export kuzzle_wrapper_ms_getbit
+func kuzzle_wrapper_ms_getbit(k *C.kuzzle, key *C.char, offset C.int, options *C.query_options) *C.int_result {
+	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Getbit(
+		C.GoString(key),
+		int(offset),
+		SetQueryOptions(options))
+
+	return goToCIntResult(res, err)
+}
+
+//export kuzzle_wrapper_ms_getrange
+func kuzzle_wrapper_ms_getrange(k *C.kuzzle, key *C.char, start C.int, end C.int, options *C.query_options) *C.string_result {
+	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Getrange(
+		C.GoString(key),
+		int(start),
+		int(end),
+		SetQueryOptions(options))
+
+	return goToCStringResult(&res, err)
+}
+
+//export kuzzle_wrapper_ms_getset
+func kuzzle_wrapper_ms_getset(k *C.kuzzle, key *C.char, value *C.char, options *C.query_options) *C.string_result {
+	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Getset(
+		C.GoString(key),
+		C.GoString(value),
+		SetQueryOptions(options))
+
+	return goToCStringResult(res, err)
+}
+
+//export kuzzle_wrapper_ms_hdel
+func kuzzle_wrapper_ms_hdel(k *C.kuzzle, key *C.char, fields **C.char, flen C.uint, options *C.query_options) *C.int_result {
+	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Hdel(
+		C.GoString(key),
+		cToGoStrings(fields, flen),
+		SetQueryOptions(options))
+
+	return goToCIntResult(res, err)
+}
+
+//export kuzzle_wrapper_ms_hexists
+func kuzzle_wrapper_ms_hexists(k *C.kuzzle, key *C.char, field *C.char, options *C.query_options) *C.int_result {
+	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Hexists(
+		C.GoString(key),
+		C.GoString(field),
+		SetQueryOptions(options))
+
+	return goToCIntResult(res, err)
+}
+
+//export kuzzle_wrapper_ms_hget
+func kuzzle_wrapper_ms_hget(k *C.kuzzle, key *C.char, field *C.char, options *C.query_options) *C.string_result {
+	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Hget(
+		C.GoString(key),
+		C.GoString(field),
+		SetQueryOptions(options))
+
+	return goToCStringResult(res, err)
+}
+
+//export kuzzle_wrapper_ms_hgetall
+func kuzzle_wrapper_ms_hgetall(k *C.kuzzle, key *C.char, options *C.query_options) *C.json_result {
+	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Hgetall(
+		C.GoString(key),
+		SetQueryOptions(options))
+
+	return goToCJsonResult(res, err)
+}
+
+//export kuzzle_wrapper_ms_hincrby
+func kuzzle_wrapper_ms_hincrby(k *C.kuzzle, key *C.char, field *C.char, value C.long, options *C.query_options) *C.int_result {
+	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Hincrby(
+		C.GoString(key),
+		C.GoString(field),
+		int(value),
+		SetQueryOptions(options))
+
+	return goToCIntResult(res, err)
+}
+
+//export kuzzle_wrapper_ms_hincrbyfloat
+func kuzzle_wrapper_ms_hincrbyfloat(k *C.kuzzle, key *C.char, field *C.char, value C.double, options *C.query_options) *C.double_result {
+	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Hincrbyfloat(
+		C.GoString(key),
+		C.GoString(field),
+		float64(value),
+		SetQueryOptions(options))
+
+	return goToCDoubleResult(res, err)
+}
+
+//export kuzzle_wrapper_ms_hkeys
+func kuzzle_wrapper_ms_hkeys(k *C.kuzzle, key *C.char, options *C.query_options) *C.string_array_result {
+	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Hkeys(
+		C.GoString(key),
+		SetQueryOptions(options))
+
+	return goToCStringArrayResult(res, err)
+}
+
+//export kuzzle_wrapper_ms_hlen
+func kuzzle_wrapper_ms_hlen(k *C.kuzzle, key *C.char, options *C.query_options) *C.int_result {
+	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Hlen(
+		C.GoString(key),
+		SetQueryOptions(options))
+
+	return goToCIntResult(res, err)
+}
+
+//export kuzzle_wrapper_ms_hmget
+func kuzzle_wrapper_ms_hmget(k *C.kuzzle, key *C.char, fields **C.char, flen C.uint, options *C.query_options) *C.string_array_result {
+	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Hmget(
+		C.GoString(key),
+		cToGoStrings(fields, flen),
+		SetQueryOptions(options))
+
+	// Ms.Hmget returns a []*string value and goToCStringArrayResult
+	// only accept a []string one
+	var converted []string
+
+	if err == nil {
+		converted = make([]string, len(res), len(res))
+
+		for i, val := range res {
+			converted[i] = *val
+		}
+	}
+
+	return goToCStringArrayResult(converted, err)
+}
+
+//export kuzzle_wrapper_ms_hmset
+func kuzzle_wrapper_ms_hmset(k *C.kuzzle, key *C.char, entries **C.json_object, elen C.uint, options *C.query_options) *C.string_result {
+	wrapped := (*[1 << 20]*C.json_object)(unsafe.Pointer(entries))[:elen:elen]
+	goentries := make([]*types.MsHashField, int(elen))
+
+	for i, jobj := range wrapped {
+		stringified := C.json_object_to_json_string(jobj)
+		gobytes := C.GoBytes(unsafe.Pointer(stringified), C.int(C.strlen(stringified)))
+		json.Unmarshal(gobytes, goentries[i])
+	}
+
+	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Hmset(
+		C.GoString(key),
+		goentries,
+		SetQueryOptions(options))
+
+	return goToCStringResult(&res, err)
+}
+
+//export kuzzle_wrapper_ms_hscan
+func kuzzle_wrapper_ms_hscan(k *C.kuzzle, key *C.char, cursor C.int, options *C.query_options) *C.json_result {
+	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Hscan(
+		C.GoString(key),
+		int(cursor),
+		SetQueryOptions(options))
+
+	return goToCJsonResult(res, err)
+}
+
+//export kuzzle_wrapper_ms_hset
+func kuzzle_wrapper_ms_hset(k *C.kuzzle, key *C.char, field *C.char, value *C.char, options *C.query_options) *C.int_result {
+	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Hset(
+		C.GoString(key),
+		C.GoString(field),
+		C.GoString(value),
+		SetQueryOptions(options))
+
+	return goToCIntResult(res, err)
+}
+
+//export kuzzle_wrapper_ms_hsetnx
+func kuzzle_wrapper_ms_hsetnx(k *C.kuzzle, key *C.char, field *C.char, value *C.char, options *C.query_options) *C.int_result {
+	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Hsetnx(
+		C.GoString(key),
+		C.GoString(field),
+		C.GoString(value),
+		SetQueryOptions(options))
+
+	return goToCIntResult(res, err)
+}
+
+//export kuzzle_wrapper_ms_hstrlen
+func kuzzle_wrapper_ms_hstrlen(k *C.kuzzle, key *C.char, field *C.char, options *C.query_options) *C.int_result {
+	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Hstrlen(
+		C.GoString(key),
+		C.GoString(field),
+		SetQueryOptions(options))
+
+	return goToCIntResult(res, err)
+}
+
+//export kuzzle_wrapper_ms_hvals
+func kuzzle_wrapper_ms_hvals(k *C.kuzzle, key *C.char, options *C.query_options) *C.string_array_result {
+	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Hvals(
+		C.GoString(key),
+		SetQueryOptions(options))
+
+	return goToCStringArrayResult(res, err)
+}
+
+//export kuzzle_wrapper_ms_incr
+func kuzzle_wrapper_ms_incr(k *C.kuzzle, key *C.char, options *C.query_options) *C.int_result {
+	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Incr(
+		C.GoString(key),
+		SetQueryOptions(options))
+
+	return goToCIntResult(res, err)
+}
+
+//export kuzzle_wrapper_ms_incrby
+func kuzzle_wrapper_ms_incrby(k *C.kuzzle, key *C.char, value C.long, options *C.query_options) *C.int_result {
+	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Incrby(
+		C.GoString(key),
+		int(value),
+		SetQueryOptions(options))
+
+	return goToCIntResult(res, err)
+}
+
+//export kuzzle_wrapper_ms_incrbyfloat
+func kuzzle_wrapper_ms_incrbyfloat(k *C.kuzzle, key *C.char, value C.double, options *C.query_options) *C.double_result {
+	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Incrbyfloat(
+		C.GoString(key),
+		float64(value),
+		SetQueryOptions(options))
+
+	return goToCDoubleResult(res, err)
+}
+
+//export kuzzle_wrapper_ms_keys
+func kuzzle_wrapper_ms_keys(k *C.kuzzle, pattern *C.char, options *C.query_options) *C.string_array_result {
+	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Keys(
+		C.GoString(pattern),
+		SetQueryOptions(options))
+
+	return goToCStringArrayResult(res, err)
+}
+
+//export kuzzle_wrapper_ms_lindex
+func kuzzle_wrapper_ms_lindex(k *C.kuzzle, key *C.char, index C.long, options *C.query_options) *C.string_result {
+	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Lindex(
+		C.GoString(key),
+		int(index),
+		SetQueryOptions(options))
+
+	return goToCStringResult(res, err)
+}
+
+//export kuzzle_wrapper_ms_linsert
+func kuzzle_wrapper_ms_linsert(k *C.kuzzle, key *C.char, position *C.char, pivot *C.char, value *C.char, options *C.query_options) *C.int_result {
+	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Linsert(
+		C.GoString(key),
+		C.GoString(position),
+		C.GoString(pivot),
+		C.GoString(value),
+		SetQueryOptions(options))
+
+	return goToCIntResult(res, err)
+}
+
+//export kuzzle_wrapper_ms_llen
+func kuzzle_wrapper_ms_llen(k *C.kuzzle, key *C.char, options *C.query_options) *C.int_result {
+	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Llen(
+		C.GoString(key),
+		SetQueryOptions(options))
+
+	return goToCIntResult(res, err)
+}
+
+//export kuzzle_wrapper_ms_lpop
+func kuzzle_wrapper_ms_lpop(k *C.kuzzle, key *C.char, options *C.query_options) *C.string_result {
+	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Lpop(
+		C.GoString(key),
+		SetQueryOptions(options))
+
+	return goToCStringResult(res, err)
+}
+
+//export kuzzle_wrapper_ms_lpush
+func kuzzle_wrapper_ms_lpush(k *C.kuzzle, key *C.char, values **C.char, vlen C.uint, options *C.query_options) *C.int_result {
+	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Lpush(
+		C.GoString(key),
+		cToGoStrings(values, vlen),
+		SetQueryOptions(options))
+
+	return goToCIntResult(res, err)
+}
+
+//export kuzzle_wrapper_ms_lpushx
+func kuzzle_wrapper_ms_lpushx(k *C.kuzzle, key *C.char, value *C.char, options *C.query_options) *C.int_result {
+	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Lpushx(
+		C.GoString(key),
+		C.GoString(value),
+		SetQueryOptions(options))
+
+	return goToCIntResult(res, err)
+}
+
+//export kuzzle_wrapper_ms_lrange
+func kuzzle_wrapper_ms_lrange(k *C.kuzzle, key *C.char, start C.long, stop C.long, options *C.query_options) *C.string_array_result {
+	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Lrange(
+		C.GoString(key),
+		int(start),
+		int(stop),
+		SetQueryOptions(options))
+
+	return goToCStringArrayResult(res, err)
+}
+
+//export kuzzle_wrapper_ms_lrem
+func kuzzle_wrapper_ms_lrem(k *C.kuzzle, key *C.char, count C.long, value *C.char, options *C.query_options) *C.int_result {
+	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Lrem(
+		C.GoString(key),
+		int(count),
+		C.GoString(value),
+		SetQueryOptions(options))
+
+	return goToCIntResult(res, err)
+}
+
+//export kuzzle_wrapper_ms_lset
+func kuzzle_wrapper_ms_lset(k *C.kuzzle, key *C.char, index C.long, value *C.char, options *C.query_options) *C.string_result {
+	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Lset(
+		C.GoString(key),
+		int(index),
+		C.GoString(value),
+		SetQueryOptions(options))
+
+	return goToCStringResult(&res, err)
+}
+
+//export kuzzle_wrapper_ms_ltrim
+func kuzzle_wrapper_ms_ltrim(k *C.kuzzle, key *C.char, start C.long, stop C.long, options *C.query_options) *C.string_result {
+	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Ltrim(
+		C.GoString(key),
+		int(start),
+		int(stop),
+		SetQueryOptions(options))
+
+	return goToCStringResult(&res, err)
+}
+
+//export kuzzle_wrapper_ms_mget
+func kuzzle_wrapper_ms_mget(k *C.kuzzle, keys **C.char, klen C.uint, options *C.query_options) *C.string_array_result {
+	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Mget(
+		cToGoStrings(keys, klen),
+		SetQueryOptions(options))
+
+	var converted []string
+
+	if err == nil {
+		converted = make([]string, len(res), len(res))
+
+		for i, val := range res {
+			converted[i] = *val
+		}
+	}
+
+	return goToCStringArrayResult(converted, err)
+}
+
+//export kuzzle_wrapper_ms_mset
+func kuzzle_wrapper_ms_mset(k *C.kuzzle, entries **C.json_object, elen C.uint, options *C.query_options) *C.string_result {
+	wrapped := (*[1 << 20]*C.json_object)(unsafe.Pointer(entries))[:elen:elen]
+	goentries := make([]*types.MSKeyValue, int(elen))
+
+	for i, jobj := range wrapped {
+		stringified := C.json_object_to_json_string(jobj)
+		gobytes := C.GoBytes(unsafe.Pointer(stringified), C.int(C.strlen(stringified)))
+		json.Unmarshal(gobytes, goentries[i])
+	}
+
+	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Mset(
+		goentries,
+		SetQueryOptions(options))
+
+	return goToCStringResult(&res, err)
+}
+
+//export kuzzle_wrapper_ms_msetnx
+func kuzzle_wrapper_ms_msetnx(k *C.kuzzle, entries **C.json_object, elen C.uint, options *C.query_options) *C.int_result {
+	wrapped := (*[1 << 20]*C.json_object)(unsafe.Pointer(entries))[:elen:elen]
+	goentries := make([]*types.MSKeyValue, int(elen))
+
+	for i, jobj := range wrapped {
+		stringified := C.json_object_to_json_string(jobj)
+		gobytes := C.GoBytes(unsafe.Pointer(stringified), C.int(C.strlen(stringified)))
+		json.Unmarshal(gobytes, goentries[i])
+	}
+
+	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Msetnx(
+		goentries,
+		SetQueryOptions(options))
+
+	return goToCIntResult(res, err)
+}
+
+//export kuzzle_wrapper_ms_object
+func kuzzle_wrapper_ms_object(k *C.kuzzle, key *C.char, subcommand *C.char, options *C.query_options) *C.string_result {
+	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Object(
+		C.GoString(key),
+		C.GoString(subcommand),
+		SetQueryOptions(options))
+
+	return goToCStringResult(res, err)
+}
+
+//export kuzzle_wrapper_ms_persist
+func kuzzle_wrapper_ms_persist(k *C.kuzzle, key *C.char, options *C.query_options) *C.int_result {
+	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Persist(
+		C.GoString(key),
+		SetQueryOptions(options))
+
+	return goToCIntResult(res, err)
+}
+
+//export kuzzle_wrapper_ms_pexpire
+func kuzzle_wrapper_ms_pexpire(k *C.kuzzle, key *C.char, ttl C.ulong, options *C.query_options) *C.int_result {
+	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Pexpire(
+		C.GoString(key),
+		int(ttl),
+		SetQueryOptions(options))
+
+	return goToCIntResult(res, err)
+}
+
+//export kuzzle_wrapper_ms_pexpireat
+func kuzzle_wrapper_ms_pexpireat(k *C.kuzzle, key *C.char, ts C.ulonglong, options *C.query_options) *C.int_result {
+	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Pexpireat(
+		C.GoString(key),
+		int(ts),
+		SetQueryOptions(options))
+
+	return goToCIntResult(res, err)
+}
+
+//export kuzzle_wrapper_ms_pfadd
+func kuzzle_wrapper_ms_pfadd(k *C.kuzzle, key *C.char, elements **C.char, elen C.uint, options *C.query_options) *C.int_result {
+	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Pfadd(
+		C.GoString(key),
+		cToGoStrings(elements, elen),
+		SetQueryOptions(options))
+
+	return goToCIntResult(res, err)
+}
+
+//export kuzzle_wrapper_ms_pfcount
+func kuzzle_wrapper_ms_pfcount(k *C.kuzzle, keys **C.char, klen C.uint, options *C.query_options) *C.int_result {
+	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Pfcount(
+		cToGoStrings(keys, klen),
+		SetQueryOptions(options))
+
+	return goToCIntResult(res, err)
+}
+
+//export kuzzle_wrapper_ms_pfmerge
+func kuzzle_wrapper_ms_pfmerge(k *C.kuzzle, key *C.char, sources **C.char, slen C.uint, options *C.query_options) *C.string_result {
+	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Pfmerge(
+		C.GoString(key),
+		cToGoStrings(sources, slen),
+		SetQueryOptions(options))
+
+	return goToCStringResult(&res, err)
+}
+
+//export kuzzle_wrapper_ms_ping
+func kuzzle_wrapper_ms_ping(k *C.kuzzle, options *C.query_options) *C.string_result {
+	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Ping(
+		SetQueryOptions(options))
+
+	return goToCStringResult(&res, err)
+}
+
+//export kuzzle_wrapper_ms_psetex
+func kuzzle_wrapper_ms_psetex(k *C.kuzzle, key *C.char, value *C.char, ttl C.ulong, options *C.query_options) *C.string_result {
+	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Psetex(
+		C.GoString(key),
+		C.GoString(value),
+		int(ttl),
+		SetQueryOptions(options))
+
+	return goToCStringResult(&res, err)
+}
+
+//export kuzzle_wrapper_ms_pttl
+func kuzzle_wrapper_ms_pttl(k *C.kuzzle, key *C.char, options *C.query_options) *C.int_result {
+	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Pttl(
+		C.GoString(key),
+		SetQueryOptions(options))
+
+	return goToCIntResult(res, err)
+}
+
+//export kuzzle_wrapper_ms_randomkey
+func kuzzle_wrapper_ms_randomkey(k *C.kuzzle, options *C.query_options) *C.string_result {
+	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Randomkey(
+		SetQueryOptions(options))
+
+	return goToCStringResult(res, err)
+}
+
+//export kuzzle_wrapper_ms_rename
+func kuzzle_wrapper_ms_rename(k *C.kuzzle, key *C.char, newkey *C.char, options *C.query_options) *C.string_result {
+	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Rename(
+		C.GoString(key),
+		C.GoString(newkey),
+		SetQueryOptions(options))
+
+	return goToCStringResult(&res, err)
+}
+
+//export kuzzle_wrapper_ms_renamenx
+func kuzzle_wrapper_ms_renamenx(k *C.kuzzle, key *C.char, newkey *C.char, options *C.query_options) *C.int_result {
+	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Renamenx(
+		C.GoString(key),
+		C.GoString(newkey),
+		SetQueryOptions(options))
+
+	return goToCIntResult(res, err)
+}
+
+//export kuzzle_wrapper_ms_rpop
+func kuzzle_wrapper_ms_rpop(k *C.kuzzle, key *C.char, options *C.query_options) *C.string_result {
+	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Rpop(
+		C.GoString(key),
+		SetQueryOptions(options))
+
+	return goToCStringResult(res, err)
+}
+
+//export kuzzle_wrapper_ms_rpoplpush
+func kuzzle_wrapper_ms_rpoplpush(k *C.kuzzle, key *C.char, dest *C.char, options *C.query_options) *C.string_result {
+	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Rpoplpush(
+		C.GoString(key),
+		C.GoString(dest),
+		SetQueryOptions(options))
+
+	return goToCStringResult(res, err)
+}
+
+//export kuzzle_wrapper_ms_rpush
+func kuzzle_wrapper_ms_rpush(k *C.kuzzle, key *C.char, values **C.char, vlen C.uint, options *C.query_options) *C.int_result {
+	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Rpush(
+		C.GoString(key),
+		cToGoStrings(values, vlen),
+		SetQueryOptions(options))
+
+	return goToCIntResult(res, err)
+}
+
+//export kuzzle_wrapper_ms_rpushx
+func kuzzle_wrapper_ms_rpushx(k *C.kuzzle, key *C.char, value *C.char, options *C.query_options) *C.int_result {
+	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Rpushx(
+		C.GoString(key),
+		C.GoString(value),
+		SetQueryOptions(options))
+
+	return goToCIntResult(res, err)
+}
+
+//export kuzzle_wrapper_ms_sadd
+func kuzzle_wrapper_ms_sadd(k *C.kuzzle, key *C.char, members **C.char, mlen C.uint, options *C.query_options) *C.int_result {
+	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Sadd(
+		C.GoString(key),
+		cToGoStrings(members, mlen),
+		SetQueryOptions(options))
+
+	return goToCIntResult(res, err)
+}
+
+//export kuzzle_wrapper_ms_scan
+func kuzzle_wrapper_ms_scan(k *C.kuzzle, cursor C.int, options *C.query_options) *C.json_result {
+	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Scan(
+		int(cursor),
+		SetQueryOptions(options))
+
+	return goToCJsonResult(res, err)
+}
+
+//export kuzzle_wrapper_ms_scard
+func kuzzle_wrapper_ms_scard(k *C.kuzzle, key *C.char, options *C.query_options) *C.int_result {
+	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Scard(
+		C.GoString(key),
+		SetQueryOptions(options))
+
+	return goToCIntResult(res, err)
+}
+
+//export kuzzle_wrapper_ms_sdiff
+func kuzzle_wrapper_ms_sdiff(k *C.kuzzle, key *C.char, keys **C.char, klen C.uint, options *C.query_options) *C.string_array_result {
+	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Sdiff(
+		C.GoString(key),
+		cToGoStrings(keys, klen),
+		SetQueryOptions(options))
+
+	return goToCStringArrayResult(res, err)
+}
+
+//export kuzzle_wrapper_ms_sdiffstore
+func kuzzle_wrapper_ms_sdiffstore(k *C.kuzzle, key *C.char, keys **C.char, klen C.uint, dest *C.char, options *C.query_options) *C.int_result {
+	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Sdiffstore(
+		C.GoString(key),
+		cToGoStrings(keys, klen),
+		C.GoString(dest),
+		SetQueryOptions(options))
+
+	return goToCIntResult(res, err)
+}
+
+//export kuzzle_wrapper_ms_set
+func kuzzle_wrapper_ms_set(k *C.kuzzle, key *C.char, value *C.char, options *C.query_options) *C.string_result {
+	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Set(
+		C.GoString(key),
+		C.GoString(value),
+		SetQueryOptions(options))
+
+	return goToCStringResult(&res, err)
+}
+
+//export kuzzle_wrapper_ms_setex
+func kuzzle_wrapper_ms_setex(k *C.kuzzle, key *C.char, value *C.char, ttl C.ulong, options *C.query_options) *C.string_result {
+	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Setex(
+		C.GoString(key),
+		C.GoString(value),
+		int(ttl),
+		SetQueryOptions(options))
+
+	return goToCStringResult(&res, err)
+}
+
+//export kuzzle_wrapper_ms_setnx
+func kuzzle_wrapper_ms_setnx(k *C.kuzzle, key *C.char, value *C.char, options *C.query_options) *C.int_result {
+	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Setnx(
+		C.GoString(key),
+		C.GoString(value),
+		SetQueryOptions(options))
+
+	return goToCIntResult(res, err)
+}
+
+//export kuzzle_wrapper_ms_sinter
+func kuzzle_wrapper_ms_sinter(k *C.kuzzle, keys **C.char, klen C.uint, options *C.query_options) *C.string_array_result {
+	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Sinter(
+		cToGoStrings(keys, klen),
+		SetQueryOptions(options))
+
+	return goToCStringArrayResult(res, err)
+}
+
+//export kuzzle_wrapper_ms_sinterstore
+func kuzzle_wrapper_ms_sinterstore(k *C.kuzzle, dest *C.char, keys **C.char, klen C.uint, options *C.query_options) *C.int_result {
+	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Sinterstore(
+		C.GoString(dest),
+		cToGoStrings(keys, klen),
+		SetQueryOptions(options))
+
+	return goToCIntResult(res, err)
+}
+
+//export kuzzle_wrapper_ms_sismember
+func kuzzle_wrapper_ms_sismember(k *C.kuzzle, key *C.char, member *C.char, options *C.query_options) *C.int_result {
+	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Sismember(
+		C.GoString(key),
+		C.GoString(member),
+		SetQueryOptions(options))
+
+	return goToCIntResult(res, err)
+}
+
+//export kuzzle_wrapper_ms_smembers
+func kuzzle_wrapper_ms_smembers(k *C.kuzzle, key *C.char, options *C.query_options) *C.string_array_result {
+	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Smembers(
+		C.GoString(key),
+		SetQueryOptions(options))
+
+	return goToCStringArrayResult(res, err)
+}
+
+//export kuzzle_wrapper_ms_smove
+func kuzzle_wrapper_ms_smove(k *C.kuzzle, key *C.char, dest *C.char, member *C.char, options *C.query_options) *C.int_result {
+	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Smove(
+		C.GoString(key),
+		C.GoString(dest),
+		C.GoString(member),
+		SetQueryOptions(options))
+
+	return goToCIntResult(res, err)
+}
+
+//export kuzzle_wrapper_ms_sort
+func kuzzle_wrapper_ms_sort(k *C.kuzzle, key *C.char, options *C.query_options) *C.string_array_result {
+	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Sort(
+		C.GoString(key),
+		SetQueryOptions(options))
+
+	return goToCStringArrayResult(res, err)
+}
+
+//export kuzzle_wrapper_ms_spop
+func kuzzle_wrapper_ms_spop(k *C.kuzzle, key *C.char, options *C.query_options) *C.string_array_result {
+	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Spop(
+		C.GoString(key),
+		SetQueryOptions(options))
+
+	return goToCStringArrayResult(res, err)
+}
+
+//export kuzzle_wrapper_ms_srandmember
+func kuzzle_wrapper_ms_srandmember(k *C.kuzzle, key *C.char, options *C.query_options) *C.string_array_result {
+	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Srandmember(
+		C.GoString(key),
+		SetQueryOptions(options))
+
+	return goToCStringArrayResult(res, err)
+}
+
+//export kuzzle_wrapper_ms_srem
+func kuzzle_wrapper_ms_srem(k *C.kuzzle, key *C.char, members **C.char, mlen C.uint, options *C.query_options) *C.int_result {
+	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Srem(
+		C.GoString(key),
+		cToGoStrings(members, mlen),
+		SetQueryOptions(options))
+
+	return goToCIntResult(res, err)
+}
+
+//export kuzzle_wrapper_ms_sscan
+func kuzzle_wrapper_ms_sscan(k *C.kuzzle, key *C.char, cursor C.int, options *C.query_options) *C.json_result {
+	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Sscan(
+		C.GoString(key),
+		int(cursor),
+		SetQueryOptions(options))
+
+	return goToCJsonResult(res, err)
+}
+
+//export kuzzle_wrapper_ms_strlen
+func kuzzle_wrapper_ms_strlen(k *C.kuzzle, key *C.char, options *C.query_options) *C.int_result {
+	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Strlen(
+		C.GoString(key),
+		SetQueryOptions(options))
+
+	return goToCIntResult(res, err)
+}
+
+//export kuzzle_wrapper_ms_sunion
+func kuzzle_wrapper_ms_sunion(k *C.kuzzle, keys **C.char, klen C.uint, options *C.query_options) *C.string_array_result {
+	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Sunion(
+		cToGoStrings(keys, klen),
+		SetQueryOptions(options))
+
+	return goToCStringArrayResult(res, err)
+}
+
+//export kuzzle_wrapper_ms_sunionstore
+func kuzzle_wrapper_ms_sunionstore(k *C.kuzzle, dest *C.char, keys **C.char, klen C.uint, options *C.query_options) *C.int_result {
+	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Sunionstore(
+		C.GoString(dest),
+		cToGoStrings(keys, klen),
+		SetQueryOptions(options))
+
+	return goToCIntResult(res, err)
+}
+
+//export kuzzle_wrapper_ms_time
+func kuzzle_wrapper_ms_time(k *C.kuzzle, options *C.query_options) *C.int_array_result {
+	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Time(
+		SetQueryOptions(options))
+
+	return goToCIntArrayResult(res, err)
+}
+
+//export kuzzle_wrapper_ms_touch
+func kuzzle_wrapper_ms_touch(k *C.kuzzle, keys **C.char, klen C.unsigned, options *C.query_options) *C.int_result {
+	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Touch(
+		cToGoStrings(keys, klen),
+		SetQueryOptions(options))
+
+	return goToCIntResult(res, err)
+}
+
+//export kuzzle_wrapper_ms_ttl
+func kuzzle_wrapper_ms_ttl(k *C.kuzzle, key *C.char, options *C.query_options) *C.int_result {
+	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Ttl(
+		C.GoString(key),
+		SetQueryOptions(options))
+
+	return goToCIntResult(res, err)
+}
+
+//export kuzzle_wrapper_ms_type
+func kuzzle_wrapper_ms_type(k *C.kuzzle, key *C.char, options *C.query_options) *C.string_result {
+	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Type(
+		C.GoString(key),
+		SetQueryOptions(options))
+
+	return goToCStringResult(&res, err)
+}
+
+//export kuzzle_wrapper_ms_zadd
+func kuzzle_wrapper_ms_zadd(k *C.kuzzle, key *C.char, elements **C.json_object, elen C.uint, options *C.query_options) *C.int_result {
+	wrapped := (*[1 << 20]*C.json_object)(unsafe.Pointer(elements))[:elen:elen]
+	goelements := make([]*types.MSSortedSet, int(elen))
+
+	for i, jobj := range wrapped {
+		stringified := C.json_object_to_json_string(jobj)
+		gobytes := C.GoBytes(unsafe.Pointer(stringified), C.int(C.strlen(stringified)))
+		json.Unmarshal(gobytes, goelements[i])
+	}
+
+	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Zadd(
+		C.GoString(key),
+		goelements,
+		SetQueryOptions(options))
+
+	return goToCIntResult(res, err)
+}
+
+//export kuzzle_wrapper_ms_zcard
+func kuzzle_wrapper_ms_zcard(k *C.kuzzle, key *C.char, options *C.query_options) *C.int_result {
+	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Zcard(
+		C.GoString(key),
+		SetQueryOptions(options))
+
+	return goToCIntResult(res, err)
+}
+
+//export kuzzle_wrapper_ms_zcount
+func kuzzle_wrapper_ms_zcount(k *C.kuzzle, key *C.char, min C.long, max C.long, options *C.query_options) *C.int_result {
+	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Zcount(
+		C.GoString(key),
+		int(min),
+		int(max),
+		SetQueryOptions(options))
+
+	return goToCIntResult(res, err)
+}
+
+//export kuzzle_wrapper_ms_zincrby
+func kuzzle_wrapper_ms_zincrby(k *C.kuzzle, key *C.char, member *C.char, incr C.double, options *C.query_options) *C.double_result {
+	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Zincrby(
+		C.GoString(key),
+		C.GoString(member),
+		float64(incr),
+		SetQueryOptions(options))
+
+	return goToCDoubleResult(res, err)
+}
+
+//export kuzzle_wrapper_ms_zinterstore
+func kuzzle_wrapper_ms_zinterstore(k *C.kuzzle, dest *C.char, keys **C.char, klen C.uint, options *C.query_options) *C.int_result {
+	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Zinterstore(
+		C.GoString(dest),
+		cToGoStrings(keys, klen),
+		SetQueryOptions(options))
+
+	return goToCIntResult(res, err)
+}
+
+//export kuzzle_wrapper_ms_zlexcount
+func kuzzle_wrapper_ms_zlexcount(k *C.kuzzle, key *C.char, min *C.char, max *C.char, options *C.query_options) *C.int_result {
+	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Zlexcount(
+		C.GoString(key),
+		C.GoString(min),
+		C.GoString(max),
+		SetQueryOptions(options))
+
+	return goToCIntResult(res, err)
+}
+
+//export kuzzle_wrapper_ms_zrange
+func kuzzle_wrapper_ms_zrange(k *C.kuzzle, key *C.char, start C.long, stop C.long, options *C.query_options) *C.json_array_result {
+	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Zrange(
+		C.GoString(key),
+		int(start),
+		int(stop),
+		SetQueryOptions(options))
+
+	var converted []interface{}
+
+	if res != nil {
+		converted = make([]interface{}, len(res), len(res))
+
+		for i, val := range res {
+			converted[i] = *val
+		}
+	}
+
+	return goToCJsonArrayResult(converted, err)
+}
+
+//export kuzzle_wrapper_ms_zrangebylex
+func kuzzle_wrapper_ms_zrangebylex(k *C.kuzzle, key *C.char, min *C.char, max *C.char, options *C.query_options) *C.string_array_result {
+	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Zrangebylex(
+		C.GoString(key),
+		C.GoString(min),
+		C.GoString(max),
+		SetQueryOptions(options))
+
+	return goToCStringArrayResult(res, err)
+}
+
+//export kuzzle_wrapper_ms_zrangebyscore
+func kuzzle_wrapper_ms_zrangebyscore(k *C.kuzzle, key *C.char, min C.double, max C.double, options *C.query_options) *C.json_array_result {
+	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Zrangebyscore(
+		C.GoString(key),
+		float64(min),
+		float64(max),
+		SetQueryOptions(options))
+
+	var converted []interface{}
+
+	if res != nil {
+		converted = make([]interface{}, len(res), len(res))
+
+		for i, val := range res {
+			converted[i] = *val
+		}
+	}
+
+	return goToCJsonArrayResult(converted, err)
+}
+
+//export kuzzle_wrapper_ms_zrank
+func kuzzle_wrapper_ms_zrank(k *C.kuzzle, key *C.char, member *C.char, options *C.query_options) *C.int_result {
+	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Zrank(
+		C.GoString(key),
+		C.GoString(member),
+		SetQueryOptions(options))
+
+	return goToCIntResult(res, err)
+}
+
+//export kuzzle_wrapper_ms_zrem
+func kuzzle_wrapper_ms_zrem(k *C.kuzzle, key *C.char, members **C.char, mlen C.uint, options *C.query_options) *C.int_result {
+	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Zrem(
+		C.GoString(key),
+		cToGoStrings(members, mlen),
+		SetQueryOptions(options))
+
+	return goToCIntResult(res, err)
+}
+
+//export kuzzle_wrapper_ms_zremrangebylex
+func kuzzle_wrapper_ms_zremrangebylex(k *C.kuzzle, key *C.char, min *C.char, max *C.char, options *C.query_options) *C.int_result {
+	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Zremrangebylex(
+		C.GoString(key),
+		C.GoString(min),
+		C.GoString(max),
+		SetQueryOptions(options))
+
+	return goToCIntResult(res, err)
+}
+
+//export kuzzle_wrapper_ms_zremrangebyrank
+func kuzzle_wrapper_ms_zremrangebyrank(k *C.kuzzle, key *C.char, min C.long, max C.long, options *C.query_options) *C.int_result {
+	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Zremrangebyrank(
+		C.GoString(key),
+		int(min),
+		int(max),
+		SetQueryOptions(options))
+
+	return goToCIntResult(res, err)
+}
+
+//export kuzzle_wrapper_ms_zremrangebyscore
+func kuzzle_wrapper_ms_zremrangebyscore(k *C.kuzzle, key *C.char, min C.double, max C.double, options *C.query_options) *C.int_result {
+	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Zremrangebyscore(
+		C.GoString(key),
+		float64(min),
+		float64(max),
+		SetQueryOptions(options))
+
+	return goToCIntResult(res, err)
+}
+
+//export kuzzle_wrapper_ms_zrevrange
+func kuzzle_wrapper_ms_zrevrange(k *C.kuzzle, key *C.char, start C.long, stop C.long, options *C.query_options) *C.json_array_result {
+	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Zrevrange(
+		C.GoString(key),
+		int(start),
+		int(stop),
+		SetQueryOptions(options))
+
+	var converted []interface{}
+
+	if res != nil {
+		converted = make([]interface{}, len(res), len(res))
+
+		for i, val := range res {
+			converted[i] = *val
+		}
+	}
+
+	return goToCJsonArrayResult(converted, err)
+}
+
+//export kuzzle_wrapper_ms_zrevrangebylex
+func kuzzle_wrapper_ms_zrevrangebylex(k *C.kuzzle, key *C.char, min *C.char, max *C.char, options *C.query_options) *C.string_array_result {
+	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Zrevrangebylex(
+		C.GoString(key),
+		C.GoString(min),
+		C.GoString(max),
+		SetQueryOptions(options))
+
+	return goToCStringArrayResult(res, err)
+}
+
+//export kuzzle_wrapper_ms_zrevrangebyscore
+func kuzzle_wrapper_ms_zrevrangebyscore(k *C.kuzzle, key *C.char, min C.double, max C.double, options *C.query_options) *C.json_array_result {
+	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Zrevrangebyscore(
+		C.GoString(key),
+		float64(min),
+		float64(max),
+		SetQueryOptions(options))
+
+	var converted []interface{}
+
+	if res != nil {
+		converted = make([]interface{}, len(res), len(res))
+
+		for i, val := range res {
+			converted[i] = *val
+		}
+	}
+
+	return goToCJsonArrayResult(converted, err)
+}
+
+//export kuzzle_wrapper_ms_zrevrank
+func kuzzle_wrapper_ms_zrevrank(k *C.kuzzle, key *C.char, member *C.char, options *C.query_options) *C.int_result {
+	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Zrevrank(
+		C.GoString(key),
+		C.GoString(member),
+		SetQueryOptions(options))
+
+	return goToCIntResult(res, err)
+}
+
+//export kuzzle_wrapper_ms_zscan
+func kuzzle_wrapper_ms_zscan(k *C.kuzzle, key *C.char, cursor C.int, options *C.query_options) *C.json_result {
+	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Zscan(
+		C.GoString(key),
+		int(cursor),
+		SetQueryOptions(options))
+
+	return goToCJsonResult(res, err)
+}
+
+//export kuzzle_wrapper_ms_zscore
+func kuzzle_wrapper_ms_zscore(k *C.kuzzle, key *C.char, member *C.char, options *C.query_options) *C.double_result {
+	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Zscore(
+		C.GoString(key),
+		C.GoString(member),
+		SetQueryOptions(options))
+
+	return goToCDoubleResult(res, err)
+}

--- a/internal/wrappers/cgo/kuzzle/memory_storage.go
+++ b/internal/wrappers/cgo/kuzzle/memory_storage.go
@@ -43,7 +43,7 @@ func kuzzle_wrapper_ms_bitcount(k *C.kuzzle, key *C.char, options *C.query_optio
 }
 
 //export kuzzle_wrapper_ms_bitop
-func kuzzle_wrapper_ms_bitop(k *C.kuzzle, key *C.char, operation *C.char, keys **C.char, klen C.uint, options *C.query_options) *C.int_result {
+func kuzzle_wrapper_ms_bitop(k *C.kuzzle, key *C.char, operation *C.char, keys **C.char, klen C.size_t, options *C.query_options) *C.int_result {
 	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Bitop(
 		C.GoString(key),
 		C.GoString(operation),
@@ -90,7 +90,7 @@ func kuzzle_wrapper_ms_decrby(k *C.kuzzle, key *C.char, value C.int, options *C.
 }
 
 //export kuzzle_wrapper_ms_del
-func kuzzle_wrapper_ms_del(k *C.kuzzle, keys **C.char, klen C.uint, options *C.query_options) *C.int_result {
+func kuzzle_wrapper_ms_del(k *C.kuzzle, keys **C.char, klen C.size_t, options *C.query_options) *C.int_result {
 	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Del(
 		cToGoStrings(keys, klen),
 		SetQueryOptions(options))
@@ -99,7 +99,7 @@ func kuzzle_wrapper_ms_del(k *C.kuzzle, keys **C.char, klen C.uint, options *C.q
 }
 
 //export kuzzle_wrapper_ms_exists
-func kuzzle_wrapper_ms_exists(k *C.kuzzle, keys **C.char, klen C.uint, options *C.query_options) *C.int_result {
+func kuzzle_wrapper_ms_exists(k *C.kuzzle, keys **C.char, klen C.size_t, options *C.query_options) *C.int_result {
 	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Exists(
 		cToGoStrings(keys, klen),
 		SetQueryOptions(options))
@@ -108,34 +108,34 @@ func kuzzle_wrapper_ms_exists(k *C.kuzzle, keys **C.char, klen C.uint, options *
 }
 
 //export kuzzle_wrapper_ms_expire
-func kuzzle_wrapper_ms_expire(k *C.kuzzle, key *C.char, seconds C.ulong, options *C.query_options) *C.int_result {
+func kuzzle_wrapper_ms_expire(k *C.kuzzle, key *C.char, seconds C.ulong, options *C.query_options) *C.bool_result {
 	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Expire(
 		C.GoString(key),
 		int(seconds),
 		SetQueryOptions(options))
 
-	return goToCIntResult(res, err)
+	return goToCBoolResult(res, err)
 }
 
 //export kuzzle_wrapper_ms_expireat
-func kuzzle_wrapper_ms_expireat(k *C.kuzzle, key *C.char, ts C.ulonglong, options *C.query_options) *C.int_result {
+func kuzzle_wrapper_ms_expireat(k *C.kuzzle, key *C.char, ts C.ulonglong, options *C.query_options) *C.bool_result {
 	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Expireat(
 		C.GoString(key),
 		int(ts),
 		SetQueryOptions(options))
 
-	return goToCIntResult(res, err)
+	return goToCBoolResult(res, err)
 }
 
 //export kuzzle_wrapper_ms_flushdb
-func kuzzle_wrapper_ms_flushdb(k *C.kuzzle, options *C.query_options) *C.string_result {
-	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Flushdb(SetQueryOptions(options))
+func kuzzle_wrapper_ms_flushdb(k *C.kuzzle, options *C.query_options) *C.void_result {
+	err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Flushdb(SetQueryOptions(options))
 
-	return goToCStringResult(&res, err)
+	return goToCVoidResult(err)
 }
 
 //export kuzzle_wrapper_ms_geoadd
-func kuzzle_wrapper_ms_geoadd(k *C.kuzzle, key *C.char, points **C.json_object, plen C.uint, options *C.query_options) *C.int_result {
+func kuzzle_wrapper_ms_geoadd(k *C.kuzzle, key *C.char, points **C.json_object, plen C.size_t, options *C.query_options) *C.int_result {
 	wrapped := (*[1 << 20]*C.json_object)(unsafe.Pointer(points))[:plen:plen]
 	gopoints := make([]*types.GeoPoint, int(plen))
 
@@ -165,7 +165,7 @@ func kuzzle_wrapper_ms_geodist(k *C.kuzzle, key *C.char, member1 *C.char, member
 }
 
 //export kuzzle_wrapper_ms_geohash
-func kuzzle_wrapper_ms_geohash(k *C.kuzzle, key *C.char, members **C.char, mlen C.uint, options *C.query_options) *C.string_array_result {
+func kuzzle_wrapper_ms_geohash(k *C.kuzzle, key *C.char, members **C.char, mlen C.size_t, options *C.query_options) *C.string_array_result {
 	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Geohash(
 		C.GoString(key),
 		cToGoStrings(members, mlen),
@@ -175,7 +175,7 @@ func kuzzle_wrapper_ms_geohash(k *C.kuzzle, key *C.char, members **C.char, mlen 
 }
 
 //export kuzzle_wrapper_ms_geopos
-func kuzzle_wrapper_ms_geopos(k *C.kuzzle, key *C.char, members **C.char, mlen C.uint, options *C.query_options) *C.geopos_result {
+func kuzzle_wrapper_ms_geopos(k *C.kuzzle, key *C.char, members **C.char, mlen C.size_t, options *C.query_options) *C.geopos_result {
 	result := (*C.geopos_result)(C.calloc(1, C.sizeof_geopos_result))
 
 	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Geopos(
@@ -194,8 +194,8 @@ func kuzzle_wrapper_ms_geopos(k *C.kuzzle, key *C.char, members **C.char, mlen C
 		return result
 	}
 
-	result.length = C.uint(len(res))
-	result.result = (*[2]C.double)(C.calloc(C.size_t(result.length), C.sizeof_geopos_arr))
+	result.result_length = C.size_t(len(res))
+	result.result = (*[2]C.double)(C.calloc(result.result_length, C.sizeof_geopos_arr))
 
 	for i, pos := range res {
 		C.assign_geopos(result.result, C.int(i), C.double(pos.Lon), C.double(pos.Lat))
@@ -286,7 +286,7 @@ func kuzzle_wrapper_ms_getset(k *C.kuzzle, key *C.char, value *C.char, options *
 }
 
 //export kuzzle_wrapper_ms_hdel
-func kuzzle_wrapper_ms_hdel(k *C.kuzzle, key *C.char, fields **C.char, flen C.uint, options *C.query_options) *C.int_result {
+func kuzzle_wrapper_ms_hdel(k *C.kuzzle, key *C.char, fields **C.char, flen C.size_t, options *C.query_options) *C.int_result {
 	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Hdel(
 		C.GoString(key),
 		cToGoStrings(fields, flen),
@@ -296,13 +296,13 @@ func kuzzle_wrapper_ms_hdel(k *C.kuzzle, key *C.char, fields **C.char, flen C.ui
 }
 
 //export kuzzle_wrapper_ms_hexists
-func kuzzle_wrapper_ms_hexists(k *C.kuzzle, key *C.char, field *C.char, options *C.query_options) *C.int_result {
+func kuzzle_wrapper_ms_hexists(k *C.kuzzle, key *C.char, field *C.char, options *C.query_options) *C.bool_result {
 	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Hexists(
 		C.GoString(key),
 		C.GoString(field),
 		SetQueryOptions(options))
 
-	return goToCIntResult(res, err)
+	return goToCBoolResult(res, err)
 }
 
 //export kuzzle_wrapper_ms_hget
@@ -365,7 +365,7 @@ func kuzzle_wrapper_ms_hlen(k *C.kuzzle, key *C.char, options *C.query_options) 
 }
 
 //export kuzzle_wrapper_ms_hmget
-func kuzzle_wrapper_ms_hmget(k *C.kuzzle, key *C.char, fields **C.char, flen C.uint, options *C.query_options) *C.string_array_result {
+func kuzzle_wrapper_ms_hmget(k *C.kuzzle, key *C.char, fields **C.char, flen C.size_t, options *C.query_options) *C.string_array_result {
 	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Hmget(
 		C.GoString(key),
 		cToGoStrings(fields, flen),
@@ -387,7 +387,7 @@ func kuzzle_wrapper_ms_hmget(k *C.kuzzle, key *C.char, fields **C.char, flen C.u
 }
 
 //export kuzzle_wrapper_ms_hmset
-func kuzzle_wrapper_ms_hmset(k *C.kuzzle, key *C.char, entries **C.json_object, elen C.uint, options *C.query_options) *C.string_result {
+func kuzzle_wrapper_ms_hmset(k *C.kuzzle, key *C.char, entries **C.json_object, elen C.size_t, options *C.query_options) *C.void_result {
 	wrapped := (*[1 << 20]*C.json_object)(unsafe.Pointer(entries))[:elen:elen]
 	goentries := make([]*types.MsHashField, int(elen))
 
@@ -397,12 +397,12 @@ func kuzzle_wrapper_ms_hmset(k *C.kuzzle, key *C.char, entries **C.json_object, 
 		json.Unmarshal(gobytes, goentries[i])
 	}
 
-	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Hmset(
+	err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Hmset(
 		C.GoString(key),
 		goentries,
 		SetQueryOptions(options))
 
-	return goToCStringResult(&res, err)
+	return goToCVoidResult(err)
 }
 
 //export kuzzle_wrapper_ms_hscan
@@ -416,25 +416,25 @@ func kuzzle_wrapper_ms_hscan(k *C.kuzzle, key *C.char, cursor C.int, options *C.
 }
 
 //export kuzzle_wrapper_ms_hset
-func kuzzle_wrapper_ms_hset(k *C.kuzzle, key *C.char, field *C.char, value *C.char, options *C.query_options) *C.int_result {
+func kuzzle_wrapper_ms_hset(k *C.kuzzle, key *C.char, field *C.char, value *C.char, options *C.query_options) *C.bool_result {
 	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Hset(
 		C.GoString(key),
 		C.GoString(field),
 		C.GoString(value),
 		SetQueryOptions(options))
 
-	return goToCIntResult(res, err)
+	return goToCBoolResult(res, err)
 }
 
 //export kuzzle_wrapper_ms_hsetnx
-func kuzzle_wrapper_ms_hsetnx(k *C.kuzzle, key *C.char, field *C.char, value *C.char, options *C.query_options) *C.int_result {
+func kuzzle_wrapper_ms_hsetnx(k *C.kuzzle, key *C.char, field *C.char, value *C.char, options *C.query_options) *C.bool_result {
 	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Hsetnx(
 		C.GoString(key),
 		C.GoString(field),
 		C.GoString(value),
 		SetQueryOptions(options))
 
-	return goToCIntResult(res, err)
+	return goToCBoolResult(res, err)
 }
 
 //export kuzzle_wrapper_ms_hstrlen
@@ -535,7 +535,7 @@ func kuzzle_wrapper_ms_lpop(k *C.kuzzle, key *C.char, options *C.query_options) 
 }
 
 //export kuzzle_wrapper_ms_lpush
-func kuzzle_wrapper_ms_lpush(k *C.kuzzle, key *C.char, values **C.char, vlen C.uint, options *C.query_options) *C.int_result {
+func kuzzle_wrapper_ms_lpush(k *C.kuzzle, key *C.char, values **C.char, vlen C.size_t, options *C.query_options) *C.int_result {
 	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Lpush(
 		C.GoString(key),
 		cToGoStrings(values, vlen),
@@ -577,29 +577,29 @@ func kuzzle_wrapper_ms_lrem(k *C.kuzzle, key *C.char, count C.long, value *C.cha
 }
 
 //export kuzzle_wrapper_ms_lset
-func kuzzle_wrapper_ms_lset(k *C.kuzzle, key *C.char, index C.long, value *C.char, options *C.query_options) *C.string_result {
-	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Lset(
+func kuzzle_wrapper_ms_lset(k *C.kuzzle, key *C.char, index C.long, value *C.char, options *C.query_options) *C.void_result {
+	err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Lset(
 		C.GoString(key),
 		int(index),
 		C.GoString(value),
 		SetQueryOptions(options))
 
-	return goToCStringResult(&res, err)
+	return goToCVoidResult(err)
 }
 
 //export kuzzle_wrapper_ms_ltrim
-func kuzzle_wrapper_ms_ltrim(k *C.kuzzle, key *C.char, start C.long, stop C.long, options *C.query_options) *C.string_result {
-	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Ltrim(
+func kuzzle_wrapper_ms_ltrim(k *C.kuzzle, key *C.char, start C.long, stop C.long, options *C.query_options) *C.void_result {
+	err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Ltrim(
 		C.GoString(key),
 		int(start),
 		int(stop),
 		SetQueryOptions(options))
 
-	return goToCStringResult(&res, err)
+	return goToCVoidResult(err)
 }
 
 //export kuzzle_wrapper_ms_mget
-func kuzzle_wrapper_ms_mget(k *C.kuzzle, keys **C.char, klen C.uint, options *C.query_options) *C.string_array_result {
+func kuzzle_wrapper_ms_mget(k *C.kuzzle, keys **C.char, klen C.size_t, options *C.query_options) *C.string_array_result {
 	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Mget(
 		cToGoStrings(keys, klen),
 		SetQueryOptions(options))
@@ -618,7 +618,7 @@ func kuzzle_wrapper_ms_mget(k *C.kuzzle, keys **C.char, klen C.uint, options *C.
 }
 
 //export kuzzle_wrapper_ms_mset
-func kuzzle_wrapper_ms_mset(k *C.kuzzle, entries **C.json_object, elen C.uint, options *C.query_options) *C.string_result {
+func kuzzle_wrapper_ms_mset(k *C.kuzzle, entries **C.json_object, elen C.size_t, options *C.query_options) *C.void_result {
 	wrapped := (*[1 << 20]*C.json_object)(unsafe.Pointer(entries))[:elen:elen]
 	goentries := make([]*types.MSKeyValue, int(elen))
 
@@ -628,15 +628,15 @@ func kuzzle_wrapper_ms_mset(k *C.kuzzle, entries **C.json_object, elen C.uint, o
 		json.Unmarshal(gobytes, goentries[i])
 	}
 
-	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Mset(
+	err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Mset(
 		goentries,
 		SetQueryOptions(options))
 
-	return goToCStringResult(&res, err)
+	return goToCVoidResult(err)
 }
 
 //export kuzzle_wrapper_ms_msetnx
-func kuzzle_wrapper_ms_msetnx(k *C.kuzzle, entries **C.json_object, elen C.uint, options *C.query_options) *C.int_result {
+func kuzzle_wrapper_ms_msetnx(k *C.kuzzle, entries **C.json_object, elen C.size_t, options *C.query_options) *C.bool_result {
 	wrapped := (*[1 << 20]*C.json_object)(unsafe.Pointer(entries))[:elen:elen]
 	goentries := make([]*types.MSKeyValue, int(elen))
 
@@ -650,7 +650,7 @@ func kuzzle_wrapper_ms_msetnx(k *C.kuzzle, entries **C.json_object, elen C.uint,
 		goentries,
 		SetQueryOptions(options))
 
-	return goToCIntResult(res, err)
+	return goToCBoolResult(res, err)
 }
 
 //export kuzzle_wrapper_ms_object
@@ -664,46 +664,46 @@ func kuzzle_wrapper_ms_object(k *C.kuzzle, key *C.char, subcommand *C.char, opti
 }
 
 //export kuzzle_wrapper_ms_persist
-func kuzzle_wrapper_ms_persist(k *C.kuzzle, key *C.char, options *C.query_options) *C.int_result {
+func kuzzle_wrapper_ms_persist(k *C.kuzzle, key *C.char, options *C.query_options) *C.bool_result {
 	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Persist(
 		C.GoString(key),
 		SetQueryOptions(options))
 
-	return goToCIntResult(res, err)
+	return goToCBoolResult(res, err)
 }
 
 //export kuzzle_wrapper_ms_pexpire
-func kuzzle_wrapper_ms_pexpire(k *C.kuzzle, key *C.char, ttl C.ulong, options *C.query_options) *C.int_result {
+func kuzzle_wrapper_ms_pexpire(k *C.kuzzle, key *C.char, ttl C.ulong, options *C.query_options) *C.bool_result {
 	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Pexpire(
 		C.GoString(key),
 		int(ttl),
 		SetQueryOptions(options))
 
-	return goToCIntResult(res, err)
+	return goToCBoolResult(res, err)
 }
 
 //export kuzzle_wrapper_ms_pexpireat
-func kuzzle_wrapper_ms_pexpireat(k *C.kuzzle, key *C.char, ts C.ulonglong, options *C.query_options) *C.int_result {
+func kuzzle_wrapper_ms_pexpireat(k *C.kuzzle, key *C.char, ts C.ulonglong, options *C.query_options) *C.bool_result {
 	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Pexpireat(
 		C.GoString(key),
 		int(ts),
 		SetQueryOptions(options))
 
-	return goToCIntResult(res, err)
+	return goToCBoolResult(res, err)
 }
 
 //export kuzzle_wrapper_ms_pfadd
-func kuzzle_wrapper_ms_pfadd(k *C.kuzzle, key *C.char, elements **C.char, elen C.uint, options *C.query_options) *C.int_result {
+func kuzzle_wrapper_ms_pfadd(k *C.kuzzle, key *C.char, elements **C.char, elen C.size_t, options *C.query_options) *C.bool_result {
 	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Pfadd(
 		C.GoString(key),
 		cToGoStrings(elements, elen),
 		SetQueryOptions(options))
 
-	return goToCIntResult(res, err)
+	return goToCBoolResult(res, err)
 }
 
 //export kuzzle_wrapper_ms_pfcount
-func kuzzle_wrapper_ms_pfcount(k *C.kuzzle, keys **C.char, klen C.uint, options *C.query_options) *C.int_result {
+func kuzzle_wrapper_ms_pfcount(k *C.kuzzle, keys **C.char, klen C.size_t, options *C.query_options) *C.int_result {
 	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Pfcount(
 		cToGoStrings(keys, klen),
 		SetQueryOptions(options))
@@ -712,13 +712,13 @@ func kuzzle_wrapper_ms_pfcount(k *C.kuzzle, keys **C.char, klen C.uint, options 
 }
 
 //export kuzzle_wrapper_ms_pfmerge
-func kuzzle_wrapper_ms_pfmerge(k *C.kuzzle, key *C.char, sources **C.char, slen C.uint, options *C.query_options) *C.string_result {
-	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Pfmerge(
+func kuzzle_wrapper_ms_pfmerge(k *C.kuzzle, key *C.char, sources **C.char, slen C.size_t, options *C.query_options) *C.void_result {
+	err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Pfmerge(
 		C.GoString(key),
 		cToGoStrings(sources, slen),
 		SetQueryOptions(options))
 
-	return goToCStringResult(&res, err)
+	return goToCVoidResult(err)
 }
 
 //export kuzzle_wrapper_ms_ping
@@ -730,14 +730,14 @@ func kuzzle_wrapper_ms_ping(k *C.kuzzle, options *C.query_options) *C.string_res
 }
 
 //export kuzzle_wrapper_ms_psetex
-func kuzzle_wrapper_ms_psetex(k *C.kuzzle, key *C.char, value *C.char, ttl C.ulong, options *C.query_options) *C.string_result {
-	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Psetex(
+func kuzzle_wrapper_ms_psetex(k *C.kuzzle, key *C.char, value *C.char, ttl C.ulong, options *C.query_options) *C.void_result {
+	err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Psetex(
 		C.GoString(key),
 		C.GoString(value),
 		int(ttl),
 		SetQueryOptions(options))
 
-	return goToCStringResult(&res, err)
+	return goToCVoidResult(err)
 }
 
 //export kuzzle_wrapper_ms_pttl
@@ -758,23 +758,23 @@ func kuzzle_wrapper_ms_randomkey(k *C.kuzzle, options *C.query_options) *C.strin
 }
 
 //export kuzzle_wrapper_ms_rename
-func kuzzle_wrapper_ms_rename(k *C.kuzzle, key *C.char, newkey *C.char, options *C.query_options) *C.string_result {
-	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Rename(
+func kuzzle_wrapper_ms_rename(k *C.kuzzle, key *C.char, newkey *C.char, options *C.query_options) *C.void_result {
+	err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Rename(
 		C.GoString(key),
 		C.GoString(newkey),
 		SetQueryOptions(options))
 
-	return goToCStringResult(&res, err)
+	return goToCVoidResult(err)
 }
 
 //export kuzzle_wrapper_ms_renamenx
-func kuzzle_wrapper_ms_renamenx(k *C.kuzzle, key *C.char, newkey *C.char, options *C.query_options) *C.int_result {
+func kuzzle_wrapper_ms_renamenx(k *C.kuzzle, key *C.char, newkey *C.char, options *C.query_options) *C.bool_result {
 	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Renamenx(
 		C.GoString(key),
 		C.GoString(newkey),
 		SetQueryOptions(options))
 
-	return goToCIntResult(res, err)
+	return goToCBoolResult(res, err)
 }
 
 //export kuzzle_wrapper_ms_rpop
@@ -797,7 +797,7 @@ func kuzzle_wrapper_ms_rpoplpush(k *C.kuzzle, key *C.char, dest *C.char, options
 }
 
 //export kuzzle_wrapper_ms_rpush
-func kuzzle_wrapper_ms_rpush(k *C.kuzzle, key *C.char, values **C.char, vlen C.uint, options *C.query_options) *C.int_result {
+func kuzzle_wrapper_ms_rpush(k *C.kuzzle, key *C.char, values **C.char, vlen C.size_t, options *C.query_options) *C.int_result {
 	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Rpush(
 		C.GoString(key),
 		cToGoStrings(values, vlen),
@@ -817,7 +817,7 @@ func kuzzle_wrapper_ms_rpushx(k *C.kuzzle, key *C.char, value *C.char, options *
 }
 
 //export kuzzle_wrapper_ms_sadd
-func kuzzle_wrapper_ms_sadd(k *C.kuzzle, key *C.char, members **C.char, mlen C.uint, options *C.query_options) *C.int_result {
+func kuzzle_wrapper_ms_sadd(k *C.kuzzle, key *C.char, members **C.char, mlen C.size_t, options *C.query_options) *C.int_result {
 	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Sadd(
 		C.GoString(key),
 		cToGoStrings(members, mlen),
@@ -845,7 +845,7 @@ func kuzzle_wrapper_ms_scard(k *C.kuzzle, key *C.char, options *C.query_options)
 }
 
 //export kuzzle_wrapper_ms_sdiff
-func kuzzle_wrapper_ms_sdiff(k *C.kuzzle, key *C.char, keys **C.char, klen C.uint, options *C.query_options) *C.string_array_result {
+func kuzzle_wrapper_ms_sdiff(k *C.kuzzle, key *C.char, keys **C.char, klen C.size_t, options *C.query_options) *C.string_array_result {
 	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Sdiff(
 		C.GoString(key),
 		cToGoStrings(keys, klen),
@@ -855,7 +855,7 @@ func kuzzle_wrapper_ms_sdiff(k *C.kuzzle, key *C.char, keys **C.char, klen C.uin
 }
 
 //export kuzzle_wrapper_ms_sdiffstore
-func kuzzle_wrapper_ms_sdiffstore(k *C.kuzzle, key *C.char, keys **C.char, klen C.uint, dest *C.char, options *C.query_options) *C.int_result {
+func kuzzle_wrapper_ms_sdiffstore(k *C.kuzzle, key *C.char, keys **C.char, klen C.size_t, dest *C.char, options *C.query_options) *C.int_result {
 	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Sdiffstore(
 		C.GoString(key),
 		cToGoStrings(keys, klen),
@@ -866,38 +866,38 @@ func kuzzle_wrapper_ms_sdiffstore(k *C.kuzzle, key *C.char, keys **C.char, klen 
 }
 
 //export kuzzle_wrapper_ms_set
-func kuzzle_wrapper_ms_set(k *C.kuzzle, key *C.char, value *C.char, options *C.query_options) *C.string_result {
-	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Set(
+func kuzzle_wrapper_ms_set(k *C.kuzzle, key *C.char, value *C.char, options *C.query_options) *C.void_result {
+	err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Set(
 		C.GoString(key),
 		C.GoString(value),
 		SetQueryOptions(options))
 
-	return goToCStringResult(&res, err)
+	return goToCVoidResult(err)
 }
 
 //export kuzzle_wrapper_ms_setex
-func kuzzle_wrapper_ms_setex(k *C.kuzzle, key *C.char, value *C.char, ttl C.ulong, options *C.query_options) *C.string_result {
-	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Setex(
+func kuzzle_wrapper_ms_setex(k *C.kuzzle, key *C.char, value *C.char, ttl C.ulong, options *C.query_options) *C.void_result {
+	err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Setex(
 		C.GoString(key),
 		C.GoString(value),
 		int(ttl),
 		SetQueryOptions(options))
 
-	return goToCStringResult(&res, err)
+	return goToCVoidResult(err)
 }
 
 //export kuzzle_wrapper_ms_setnx
-func kuzzle_wrapper_ms_setnx(k *C.kuzzle, key *C.char, value *C.char, options *C.query_options) *C.int_result {
+func kuzzle_wrapper_ms_setnx(k *C.kuzzle, key *C.char, value *C.char, options *C.query_options) *C.bool_result {
 	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Setnx(
 		C.GoString(key),
 		C.GoString(value),
 		SetQueryOptions(options))
 
-	return goToCIntResult(res, err)
+	return goToCBoolResult(res, err)
 }
 
 //export kuzzle_wrapper_ms_sinter
-func kuzzle_wrapper_ms_sinter(k *C.kuzzle, keys **C.char, klen C.uint, options *C.query_options) *C.string_array_result {
+func kuzzle_wrapper_ms_sinter(k *C.kuzzle, keys **C.char, klen C.size_t, options *C.query_options) *C.string_array_result {
 	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Sinter(
 		cToGoStrings(keys, klen),
 		SetQueryOptions(options))
@@ -906,7 +906,7 @@ func kuzzle_wrapper_ms_sinter(k *C.kuzzle, keys **C.char, klen C.uint, options *
 }
 
 //export kuzzle_wrapper_ms_sinterstore
-func kuzzle_wrapper_ms_sinterstore(k *C.kuzzle, dest *C.char, keys **C.char, klen C.uint, options *C.query_options) *C.int_result {
+func kuzzle_wrapper_ms_sinterstore(k *C.kuzzle, dest *C.char, keys **C.char, klen C.size_t, options *C.query_options) *C.int_result {
 	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Sinterstore(
 		C.GoString(dest),
 		cToGoStrings(keys, klen),
@@ -916,13 +916,13 @@ func kuzzle_wrapper_ms_sinterstore(k *C.kuzzle, dest *C.char, keys **C.char, kle
 }
 
 //export kuzzle_wrapper_ms_sismember
-func kuzzle_wrapper_ms_sismember(k *C.kuzzle, key *C.char, member *C.char, options *C.query_options) *C.int_result {
+func kuzzle_wrapper_ms_sismember(k *C.kuzzle, key *C.char, member *C.char, options *C.query_options) *C.bool_result {
 	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Sismember(
 		C.GoString(key),
 		C.GoString(member),
 		SetQueryOptions(options))
 
-	return goToCIntResult(res, err)
+	return goToCBoolResult(res, err)
 }
 
 //export kuzzle_wrapper_ms_smembers
@@ -935,14 +935,14 @@ func kuzzle_wrapper_ms_smembers(k *C.kuzzle, key *C.char, options *C.query_optio
 }
 
 //export kuzzle_wrapper_ms_smove
-func kuzzle_wrapper_ms_smove(k *C.kuzzle, key *C.char, dest *C.char, member *C.char, options *C.query_options) *C.int_result {
+func kuzzle_wrapper_ms_smove(k *C.kuzzle, key *C.char, dest *C.char, member *C.char, options *C.query_options) *C.bool_result {
 	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Smove(
 		C.GoString(key),
 		C.GoString(dest),
 		C.GoString(member),
 		SetQueryOptions(options))
 
-	return goToCIntResult(res, err)
+	return goToCBoolResult(res, err)
 }
 
 //export kuzzle_wrapper_ms_sort
@@ -973,7 +973,7 @@ func kuzzle_wrapper_ms_srandmember(k *C.kuzzle, key *C.char, options *C.query_op
 }
 
 //export kuzzle_wrapper_ms_srem
-func kuzzle_wrapper_ms_srem(k *C.kuzzle, key *C.char, members **C.char, mlen C.uint, options *C.query_options) *C.int_result {
+func kuzzle_wrapper_ms_srem(k *C.kuzzle, key *C.char, members **C.char, mlen C.size_t, options *C.query_options) *C.int_result {
 	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Srem(
 		C.GoString(key),
 		cToGoStrings(members, mlen),
@@ -1002,7 +1002,7 @@ func kuzzle_wrapper_ms_strlen(k *C.kuzzle, key *C.char, options *C.query_options
 }
 
 //export kuzzle_wrapper_ms_sunion
-func kuzzle_wrapper_ms_sunion(k *C.kuzzle, keys **C.char, klen C.uint, options *C.query_options) *C.string_array_result {
+func kuzzle_wrapper_ms_sunion(k *C.kuzzle, keys **C.char, klen C.size_t, options *C.query_options) *C.string_array_result {
 	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Sunion(
 		cToGoStrings(keys, klen),
 		SetQueryOptions(options))
@@ -1011,7 +1011,7 @@ func kuzzle_wrapper_ms_sunion(k *C.kuzzle, keys **C.char, klen C.uint, options *
 }
 
 //export kuzzle_wrapper_ms_sunionstore
-func kuzzle_wrapper_ms_sunionstore(k *C.kuzzle, dest *C.char, keys **C.char, klen C.uint, options *C.query_options) *C.int_result {
+func kuzzle_wrapper_ms_sunionstore(k *C.kuzzle, dest *C.char, keys **C.char, klen C.size_t, options *C.query_options) *C.int_result {
 	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Sunionstore(
 		C.GoString(dest),
 		cToGoStrings(keys, klen),
@@ -1029,7 +1029,7 @@ func kuzzle_wrapper_ms_time(k *C.kuzzle, options *C.query_options) *C.int_array_
 }
 
 //export kuzzle_wrapper_ms_touch
-func kuzzle_wrapper_ms_touch(k *C.kuzzle, keys **C.char, klen C.unsigned, options *C.query_options) *C.int_result {
+func kuzzle_wrapper_ms_touch(k *C.kuzzle, keys **C.char, klen C.size_t, options *C.query_options) *C.int_result {
 	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Touch(
 		cToGoStrings(keys, klen),
 		SetQueryOptions(options))
@@ -1056,7 +1056,7 @@ func kuzzle_wrapper_ms_type(k *C.kuzzle, key *C.char, options *C.query_options) 
 }
 
 //export kuzzle_wrapper_ms_zadd
-func kuzzle_wrapper_ms_zadd(k *C.kuzzle, key *C.char, elements **C.json_object, elen C.uint, options *C.query_options) *C.int_result {
+func kuzzle_wrapper_ms_zadd(k *C.kuzzle, key *C.char, elements **C.json_object, elen C.size_t, options *C.query_options) *C.int_result {
 	wrapped := (*[1 << 20]*C.json_object)(unsafe.Pointer(elements))[:elen:elen]
 	goelements := make([]*types.MSSortedSet, int(elen))
 
@@ -1106,7 +1106,7 @@ func kuzzle_wrapper_ms_zincrby(k *C.kuzzle, key *C.char, member *C.char, incr C.
 }
 
 //export kuzzle_wrapper_ms_zinterstore
-func kuzzle_wrapper_ms_zinterstore(k *C.kuzzle, dest *C.char, keys **C.char, klen C.uint, options *C.query_options) *C.int_result {
+func kuzzle_wrapper_ms_zinterstore(k *C.kuzzle, dest *C.char, keys **C.char, klen C.size_t, options *C.query_options) *C.int_result {
 	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Zinterstore(
 		C.GoString(dest),
 		cToGoStrings(keys, klen),
@@ -1190,7 +1190,7 @@ func kuzzle_wrapper_ms_zrank(k *C.kuzzle, key *C.char, member *C.char, options *
 }
 
 //export kuzzle_wrapper_ms_zrem
-func kuzzle_wrapper_ms_zrem(k *C.kuzzle, key *C.char, members **C.char, mlen C.uint, options *C.query_options) *C.int_result {
+func kuzzle_wrapper_ms_zrem(k *C.kuzzle, key *C.char, members **C.char, mlen C.size_t, options *C.query_options) *C.int_result {
 	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Zrem(
 		C.GoString(key),
 		cToGoStrings(members, mlen),

--- a/internal/wrappers/cgo/kuzzle/options.go
+++ b/internal/wrappers/cgo/kuzzle/options.go
@@ -119,7 +119,7 @@ func SetRoomOptions(options *C.room_options) (opts types.RoomOptions) {
 	opts.SetState(C.GoString(options.state))
 	opts.SetUsers(C.GoString(options.user))
 
-	opts.SetSubscribeToSelf(options.subscribe_to_self == 1)
+	opts.SetSubscribeToSelf(bool(options.subscribe_to_self))
 
 	if options.volatiles != nil {
 		opts.SetVolatile(JsonCConvert(options.volatiles).(map[string]interface{}))

--- a/internal/wrappers/cgo/kuzzle/options.go
+++ b/internal/wrappers/cgo/kuzzle/options.go
@@ -1,0 +1,129 @@
+package main
+
+/*
+	#cgo CFLAGS: -I../../headers
+	#include <stdlib.h>
+	#include "kuzzlesdk.h"
+*/
+import "C"
+import (
+	"encoding/json"
+	"github.com/kuzzleio/sdk-go/types"
+	"time"
+	"unsafe"
+)
+
+//export kuzzle_wrapper_new_options
+func kuzzle_wrapper_new_options() *C.options {
+	copts := (*C.options)(C.calloc(1, C.sizeof_options))
+	opts := types.NewOptions()
+
+	copts.queue_ttl = C.uint(opts.GetQueueTTL())
+	copts.queue_max_size = C.ulong(opts.GetQueueMaxSize())
+	copts.offline_mode = C.uchar(opts.GetOfflineMode())
+
+	if opts.GetAutoQueue() {
+		copts.auto_queue = 1
+	}
+
+	if opts.GetAutoReconnect() {
+		copts.auto_reconnect = 1
+	}
+
+	if opts.GetAutoReplay() {
+		copts.auto_replay = 1
+	}
+
+	if opts.GetAutoResubscribe() {
+		copts.auto_resubscribe = 1
+	}
+
+	copts.reconnection_delay = C.ulong(opts.GetReconnectionDelay())
+	copts.replay_interval = C.ulong(opts.GetReplayInterval())
+
+	if opts.GetConnect() == 1 {
+		copts.connect = C.MANUAL
+	} else {
+		copts.connect = C.AUTO
+	}
+
+	refresh := opts.GetRefresh()
+	if len(refresh) > 0 {
+		copts.refresh = C.CString(refresh)
+	}
+
+	defaultIndex := opts.GetDefaultIndex()
+	if len(defaultIndex) > 0 {
+		copts.default_index = C.CString(defaultIndex)
+	}
+
+	r, _ := json.Marshal(opts.GetHeaders())
+	buffer := C.CString(string(r))
+	copts.headers = C.json_tokener_parse(buffer)
+	C.free(unsafe.Pointer(buffer))
+
+	return copts
+}
+
+func SetQueryOptions(options *C.query_options) (opts types.QueryOptions) {
+	if options == nil {
+		return
+	}
+
+	opts = types.NewQueryOptions()
+
+	opts.SetQueuable(bool(options.queuable))
+	opts.SetWithdist(bool(options.withdist))
+	opts.SetWithcoord(bool(options.withcoord))
+	opts.SetFrom(int(options.from))
+	opts.SetSize(int(options.size))
+	opts.SetScroll(C.GoString(options.scroll))
+	opts.SetScrollId(C.GoString(options.scroll_id))
+	opts.SetRefresh(C.GoString(options.refresh))
+	opts.SetIfExist(C.GoString(options.if_exist))
+	opts.SetRetryOnConflict(int(options.retry_on_conflict))
+	opts.SetVolatile(JsonCConvert(options.volatiles).(map[string]interface{}))
+
+	return
+}
+
+func SetOptions(options *C.options) (opts types.Options) {
+	if options == nil {
+		return
+	}
+
+	opts = types.NewOptions()
+
+	opts.SetQueueTTL(time.Duration(uint16(options.queue_ttl)))
+	opts.SetQueueMaxSize(int(options.queue_max_size))
+	opts.SetOfflineMode(int(options.offline_mode))
+
+	opts.SetAutoQueue(options.auto_queue != 0)
+	opts.SetAutoReconnect(options.auto_reconnect != 0)
+	opts.SetAutoReplay(options.auto_replay != 0)
+	opts.SetAutoResubscribe(options.auto_resubscribe != 0)
+	opts.SetReconnectionDelay(time.Duration(int(options.reconnection_delay)))
+	opts.SetReplayInterval(time.Duration(int(options.replay_interval)))
+	opts.SetConnect(int(options.connect))
+	opts.SetRefresh(C.GoString(options.refresh))
+	opts.SetDefaultIndex(C.GoString(options.default_index))
+	opts.SetHeaders(JsonCConvert(options.headers).(map[string]interface{}))
+
+	return
+}
+
+func SetRoomOptions(options *C.room_options) (opts types.RoomOptions) {
+	opts = types.NewRoomOptions()
+
+	opts.SetScope(C.GoString(options.scope))
+	opts.SetState(C.GoString(options.state))
+	opts.SetUsers(C.GoString(options.user))
+
+	opts.SetSubscribeToSelf(options.subscribe_to_self == 1)
+
+	if options.volatiles != nil {
+		opts.SetVolatile(JsonCConvert(options.volatiles).(map[string]interface{}))
+	}
+
+	return
+}

--- a/internal/wrappers/cgo/kuzzle/query.go
+++ b/internal/wrappers/cgo/kuzzle/query.go
@@ -1,0 +1,78 @@
+package main
+
+/*
+	#cgo CFLAGS: -I../../headers
+	#include <stdlib.h>
+	#include "kuzzlesdk.h"
+*/
+import "C"
+import (
+	"github.com/kuzzleio/sdk-go/kuzzle"
+	"github.com/kuzzleio/sdk-go/types"
+)
+
+//export kuzzle_wrapper_query
+func kuzzle_wrapper_query(k *C.kuzzle, request *C.kuzzle_request, options *C.query_options) *C.kuzzle_response {
+	opts := SetQueryOptions(options)
+
+	req := types.KuzzleRequest{
+		RequestId:  C.GoString(request.request_id),
+		Controller: C.GoString(request.controller),
+		Action:     C.GoString(request.action),
+		Index:      C.GoString(request.index),
+		Collection: C.GoString(request.collection),
+		Id:         C.GoString(request.id),
+		From:       int(request.from),
+		Size:       int(request.size),
+		Scroll:     C.GoString(request.scroll),
+		ScrollId:   C.GoString(request.scroll_id),
+		Strategy:   C.GoString(request.strategy),
+		ExpiresIn:  int(request.expires_in),
+		Scope:      C.GoString(request.scope),
+		State:      C.GoString(request.state),
+		Users:      C.GoString(request.user),
+		Start:      int(request.start),
+		Stop:       int(request.stop),
+		End:        int(request.end),
+		Bit:        int(request.bit),
+		Member:     C.GoString(request.member),
+		Member1:    C.GoString(request.member1),
+		Member2:    C.GoString(request.member2),
+		Lon:        float64(request.lon),
+		Lat:        float64(request.lat),
+		Distance:   float64(request.distance),
+		Unit:       C.GoString(request.unit),
+		Cursor:     int(request.cursor),
+		Offset:     int(request.offset),
+		Field:      C.GoString(request.field),
+		Subcommand: C.GoString(request.subcommand),
+		Pattern:    C.GoString(request.pattern),
+		Idx:        int(request.idx),
+		Min:        C.GoString(request.min),
+		Max:        C.GoString(request.max),
+		Limit:      C.GoString(request.limit),
+		Count:      int(request.count),
+		Match:      C.GoString(request.match),
+	}
+
+	if request.body != nil {
+		req.Body = JsonCConvert(request.body)
+	}
+
+	if request.volatiles != nil {
+		req.Volatile = JsonCConvert(request.volatiles).(map[string]interface{})
+	}
+
+	start := int(request.start)
+	req.Start = start
+	req.Members = cToGoStrings(request.members, request.members_length)
+	req.Keys = cToGoStrings(request.keys, request.keys_length)
+	req.Fields = cToGoStrings(request.fields, request.fields_length)
+
+	resC := make(chan *types.KuzzleResponse)
+	(*kuzzle.Kuzzle)(k.instance).Query(&req, opts, resC)
+
+	res := <-resC
+
+	return goToCKuzzleResponse(res)
+}

--- a/internal/wrappers/cgo/kuzzle/root_api.go
+++ b/internal/wrappers/cgo/kuzzle/root_api.go
@@ -1,0 +1,129 @@
+package main
+
+/*
+  #cgo CFLAGS: -I../../headers
+  #cgo LDFLAGS: -ljson-c
+
+  #include <stdlib.h>
+  #include "kuzzlesdk.h"
+  #include "sdk_wrappers_internal.h"
+*/
+import "C"
+import (
+	"github.com/kuzzleio/sdk-go/kuzzle"
+	"strconv"
+	"time"
+	"unsafe"
+)
+
+//export kuzzle_wrapper_list_collections
+func kuzzle_wrapper_list_collections(k *C.kuzzle, index *C.char, options *C.query_options) *C.json_result {
+	res, err := (*kuzzle.Kuzzle)(k.instance).ListCollections(
+		C.GoString(index),
+		SetQueryOptions(options))
+
+	return goToCJsonResult(res, err)
+}
+
+//export kuzzle_wrapper_list_indexes
+func kuzzle_wrapper_list_indexes(k *C.kuzzle, options *C.query_options) *C.string_array_result {
+	res, err := (*kuzzle.Kuzzle)(k.instance).ListIndexes(SetQueryOptions(options))
+
+	return goToCStringArrayResult(res, err)
+}
+
+//export kuzzle_wrapper_create_index
+func kuzzle_wrapper_create_index(k *C.kuzzle, index *C.char, options *C.query_options) *C.bool_result {
+	res, err := (*kuzzle.Kuzzle)(k.instance).CreateIndex(
+		C.GoString(index),
+		SetQueryOptions(options))
+
+	return goToCBoolResult(res, err)
+}
+
+//export kuzzle_wrapper_refresh_index
+func kuzzle_wrapper_refresh_index(k *C.kuzzle, index *C.char, options *C.query_options) *C.shards_result {
+	result := (*C.shards_result)(C.calloc(1, C.sizeof_shards_result))
+	opts := SetQueryOptions(options)
+
+	shards, err := (*kuzzle.Kuzzle)(k.instance).RefreshIndex(C.GoString(index), opts)
+	if err != nil {
+		Set_shards_result_error(result, err)
+		return result
+	}
+
+	result.result = goToCShards(shards)
+
+	return result
+}
+
+//export kuzzle_wrapper_set_auto_refresh
+func kuzzle_wrapper_set_auto_refresh(k *C.kuzzle, index *C.char, auto_refresh C.bool, options *C.query_options) *C.bool_result {
+	res, err := (*kuzzle.Kuzzle)(k.instance).SetAutoRefresh(
+		C.GoString(index),
+		bool(auto_refresh),
+		SetQueryOptions(options))
+
+	return goToCBoolResult(res, err)
+}
+
+//export kuzzle_wrapper_get_auto_refresh
+func kuzzle_wrapper_get_auto_refresh(k *C.kuzzle, index *C.char, options *C.query_options) *C.bool_result {
+	res, err := (*kuzzle.Kuzzle)(k.instance).GetAutoRefresh(
+		C.GoString(index),
+		SetQueryOptions(options))
+
+	return goToCBoolResult(res, err)
+}
+
+//export kuzzle_wrapper_get_server_info
+func kuzzle_wrapper_get_server_info(k *C.kuzzle, options *C.query_options) *C.json_result {
+	res, err := (*kuzzle.Kuzzle)(k.instance).GetServerInfo(SetQueryOptions(options))
+
+	return goToCJsonResult(res, err)
+}
+
+//export kuzzle_wrapper_get_all_statistics
+func kuzzle_wrapper_get_all_statistics(k *C.kuzzle, options *C.query_options) *C.all_statistics_result {
+	result := (*C.all_statistics_result)(C.calloc(1, C.sizeof_statistics_result))
+	opts := SetQueryOptions(options)
+
+	stats, err := (*kuzzle.Kuzzle)(k.instance).GetAllStatistics(opts)
+
+	if err != nil {
+		Set_all_statistics_error(result, err)
+		return result
+	}
+
+	result.res = (*C.statistics)(C.calloc(C.size_t(len(stats)), C.sizeof_statistics_ptr))
+	result.res_size = C.int(len(stats) - 1)
+	statistics := (*[1<<30 - 1]*C.statistics)(unsafe.Pointer(result.res))[:len(stats)]
+
+	for i, stat := range stats {
+		statistics[i] = goToCStatistics(stat, err)
+	}
+
+	return result
+}
+
+//export kuzzle_wrapper_get_statistics
+func kuzzle_wrapper_get_statistics(k *C.kuzzle, timestamp C.time_t, options *C.query_options) *C.statistics_result {
+	result := (*C.statistics_result)(C.calloc(1, C.sizeof_statistics_result))
+	opts := SetQueryOptions(options)
+
+	t, _ := strconv.ParseInt(C.GoString(C.ctime(&timestamp)), 10, 64)
+	tm := time.Unix(t, 0)
+
+	res, err := (*kuzzle.Kuzzle)(k.instance).GetStatistics(&tm, opts)
+
+	result.result = goToCStatistics(res, err)
+
+	return result
+}
+
+//export kuzzle_wrapper_now
+func kuzzle_wrapper_now(k *C.kuzzle, options *C.query_options) *C.int_result {
+	time, err := (*kuzzle.Kuzzle)(k.instance).Now(SetQueryOptions(options))
+
+	return goToCIntResult(time, err)
+}

--- a/internal/wrappers/cgo/kuzzle/security.go
+++ b/internal/wrappers/cgo/kuzzle/security.go
@@ -19,7 +19,7 @@ import (
 // --- profile
 
 //export kuzzle_wrapper_security_new_profile
-func kuzzle_wrapper_security_new_profile(k *C.kuzzle, id *C.char, policies *C.policy, policies_length C.int) *C.profile {
+func kuzzle_wrapper_security_new_profile(k *C.kuzzle, id *C.char, policies *C.policy, policies_length C.size_t) *C.profile {
 	cprofile := (*C.profile)(C.calloc(1, C.sizeof_profile))
 	cprofile.id = id
 	cprofile.policies = policies

--- a/internal/wrappers/cgo/kuzzle/security.go
+++ b/internal/wrappers/cgo/kuzzle/security.go
@@ -1,0 +1,365 @@
+package main
+
+/*
+	#cgo CFLAGS: -I../../headers
+	#include <errno.h>
+	#include <stdlib.h>
+	#include "kuzzlesdk.h"
+	#include "sdk_wrappers_internal.h"
+*/
+import "C"
+
+import (
+	"github.com/kuzzleio/sdk-go/kuzzle"
+	"github.com/kuzzleio/sdk-go/security"
+	"github.com/kuzzleio/sdk-go/types"
+	"unsafe"
+)
+
+// --- profile
+
+//export kuzzle_wrapper_security_new_profile
+func kuzzle_wrapper_security_new_profile(k *C.kuzzle, id *C.char, policies *C.policy, policies_length C.int) *C.profile {
+	cprofile := (*C.profile)(C.calloc(1, C.sizeof_profile))
+	cprofile.id = id
+	cprofile.policies = policies
+	cprofile.policies_length = policies_length
+	cprofile.kuzzle = k
+
+	return cprofile
+}
+
+//export kuzzle_wrapper_security_destroy_profile
+func kuzzle_wrapper_security_destroy_profile(p *C.profile) {
+	if p == nil {
+		return
+	}
+
+	if p.policies != nil {
+		size := int(p.policies_length)
+		policies := (*[1<<30 - 1]*C.policy)(unsafe.Pointer(p.policies))[:size:size]
+		for _, policy := range policies {
+			C.free(unsafe.Pointer(policy.role_id))
+			size = int(policy.restricted_to_length)
+			restrictions := (*[1<<30 - 1]*C.policy_restriction)(unsafe.Pointer(policy.restricted_to))[:size:size]
+			for _, restriction := range restrictions {
+				C.free(unsafe.Pointer(restriction.index))
+				size = int(restriction.collections_length)
+				collections := (*[1<<30 - 1]*C.char)(unsafe.Pointer(restriction.collections))[:size:size]
+				for _, collection := range collections {
+					C.free(unsafe.Pointer(collection))
+				}
+				C.free(unsafe.Pointer(restriction.collections))
+			}
+			C.free(unsafe.Pointer(policy.restricted_to))
+		}
+		C.free(unsafe.Pointer(p.policies))
+	}
+
+	C.free(unsafe.Pointer(p))
+}
+
+//export kuzzle_wrapper_security_fetch_profile
+func kuzzle_wrapper_security_fetch_profile(k *C.kuzzle, id *C.char, o *C.query_options) *C.profile_result {
+	result := (*C.profile_result)(C.calloc(1, C.sizeof_profile_result))
+	options := SetQueryOptions(o)
+
+	profile, err := (*kuzzle.Kuzzle)(k.instance).Security.FetchProfile(C.GoString(id), options)
+	if err != nil {
+		Set_profile_result_error(result, err)
+		return result
+	}
+
+	result.profile = goToCProfile(k, profile, nil)
+
+	return result
+}
+
+//export kuzzle_wrapper_security_scroll_profiles
+func kuzzle_wrapper_security_scroll_profiles(k *C.kuzzle, s *C.char, o *C.query_options) *C.search_profiles_result {
+	options := SetQueryOptions(o)
+	res, err := (*kuzzle.Kuzzle)(k.instance).Security.ScrollProfiles(C.GoString(s), options)
+
+	return goToCProfileSearchResult(k, res, err)
+}
+
+//export kuzzle_wrapper_security_search_profiles
+func kuzzle_wrapper_security_search_profiles(k *C.kuzzle, f *C.search_filters, o *C.query_options) *C.search_profiles_result {
+	options := SetQueryOptions(o)
+	res, err := (*kuzzle.Kuzzle)(k.instance).Security.SearchProfiles(cToGoSearchFilters(f), options)
+
+	return goToCProfileSearchResult(k, res, err)
+}
+
+//export kuzzle_wrapper_security_profile_add_policy
+func kuzzle_wrapper_security_profile_add_policy(p *C.profile, policy *C.policy) *C.profile {
+	profile := cToGoProfile(p).AddPolicy(cToGoPolicy(policy))
+
+	// @TODO: check if this method is useful and if so, the original pointer to p should be returned instead of a new allocated struct
+	return goToCProfile(p.kuzzle, profile, nil)
+}
+
+//export kuzzle_wrapper_security_profile_delete
+func kuzzle_wrapper_security_profile_delete(p *C.profile, o *C.query_options) *C.string_result {
+	options := SetQueryOptions(o)
+	profile := cToGoProfile(p)
+
+	res, err := profile.Delete(options)
+
+	return goToCStringResult(&res, err)
+}
+
+//export kuzzle_wrapper_security_profile_save
+func kuzzle_wrapper_security_profile_save(p *C.profile, o *C.query_options) *C.profile_result {
+	options := SetQueryOptions(o)
+	res, err := cToGoProfile(p).Save(options)
+
+	return goToCProfileResult(p.kuzzle, res, err)
+}
+
+// --- role
+
+//export kuzzle_wrapper_security_new_role
+func kuzzle_wrapper_security_new_role(k *C.kuzzle, id *C.char, c *C.controllers) *C.role {
+	crole := (*C.role)(C.calloc(1, C.sizeof_role))
+	crole.id = id
+	crole.controllers = c
+	crole.kuzzle = k
+
+	_, err := cToGoRole(crole)
+	if err != nil {
+		C.set_errno(C.ENOKEY)
+		return nil
+	}
+
+	return crole
+}
+
+//export kuzzle_wrapper_security_destroy_role
+func kuzzle_wrapper_security_destroy_role(r *C.role) {
+	if r == nil {
+		return
+	}
+
+	C.json_object_put(r.controllers)
+	C.free(unsafe.Pointer(r))
+}
+
+//export kuzzle_wrapper_security_fetch_role
+func kuzzle_wrapper_security_fetch_role(k *C.kuzzle, id *C.char, o *C.query_options) *C.role_result {
+	result := (*C.role_result)(C.calloc(1, C.sizeof_role_result))
+	options := SetQueryOptions(o)
+
+	role, err := (*kuzzle.Kuzzle)(k.instance).Security.FetchRole(C.GoString(id), options)
+	if err != nil {
+		Set_role_result_error(result, err)
+		return result
+	}
+
+	result.role = goToCRole(k, role, nil)
+
+	return result
+}
+
+//export kuzzle_wrapper_security_search_roles
+func kuzzle_wrapper_security_search_roles(k *C.kuzzle, f *C.search_filters, o *C.query_options) *C.search_roles_result {
+	options := SetQueryOptions(o)
+	res, err := (*kuzzle.Kuzzle)(k.instance).Security.SearchRoles(cToGoSearchFilters(f), options)
+
+	return goToCRoleSearchResult(k, res, err)
+}
+
+//export kuzzle_wrapper_security_role_delete
+func kuzzle_wrapper_security_role_delete(r *C.role, o *C.query_options) *C.string_result {
+	result := (*C.string_result)(C.calloc(1, C.sizeof_string_result))
+	opts := SetQueryOptions(o)
+
+	role, err := cToGoRole(r)
+	if err != nil {
+		Set_string_result_error(result, err)
+		return result
+	}
+	res, err := role.Delete(opts)
+
+	return goToCStringResult(&res, err)
+}
+
+//export kuzzle_wrapper_security_role_save
+func kuzzle_wrapper_security_role_save(r *C.role, o *C.query_options) *C.role_result {
+	result := (*C.role_result)(C.calloc(1, C.sizeof_role_result))
+	options := SetQueryOptions(o)
+
+	role, err := cToGoRole(r)
+	if err != nil {
+		Set_role_result_error(result, err)
+		return result
+	}
+	res, err := role.Save(options)
+	if err != nil {
+		Set_role_result_error(result, err)
+		return result
+	}
+
+	result.role = goToCRole(r.kuzzle, res, nil)
+
+	return result
+}
+
+// --- user
+
+//export kuzzle_wrapper_security_new_user
+func kuzzle_wrapper_security_new_user(k *C.kuzzle, id *C.char, d *C.user_data) *C.user {
+	cuser := (*C.user)(C.calloc(1, C.sizeof_user))
+
+	cuser.id = id
+	cuser.kuzzle = k
+
+	if d != nil {
+		cuser.content = d.content
+		cuser.profile_ids = d.profile_ids
+		cuser.profile_ids_length = d.profile_ids_length
+	}
+
+	return cuser
+}
+
+//export kuzzle_wrapper_security_destroy_user
+func kuzzle_wrapper_security_destroy_user(u *C.user) {
+	if u == nil {
+		return
+	}
+
+	if u.id != nil {
+		C.free(unsafe.Pointer(u.id))
+	}
+	if u.content != nil {
+		C.json_object_put(u.content)
+	}
+	if u.profile_ids != nil {
+		size := int(u.profile_ids_length)
+		carray := (*[1<<30 - 1]*C.char)(unsafe.Pointer(u.profile_ids))[:size:size]
+
+		for i := 0; i < size; i++ {
+			C.free(unsafe.Pointer(carray[i]))
+		}
+		C.free(unsafe.Pointer(u.profile_ids))
+	}
+
+	C.free(unsafe.Pointer(u))
+}
+
+//export kuzzle_wrapper_security_fetch_user
+func kuzzle_wrapper_security_fetch_user(k *C.kuzzle, id *C.char, o *C.query_options) *C.user_result {
+	res, err := (*kuzzle.Kuzzle)(k.instance).Security.FetchUser(C.GoString(id), SetQueryOptions(o))
+	return goToCUserResult(k, res, err)
+}
+
+//export kuzzle_wrapper_security_scroll_users
+func kuzzle_wrapper_security_scroll_users(k *C.kuzzle, s *C.char, o *C.query_options) *C.search_users_result {
+	res, err := (*kuzzle.Kuzzle)(k.instance).Security.ScrollUsers(C.GoString(s), SetQueryOptions(o))
+	return goToCUserSearchResult(k, res, err)
+}
+
+//export kuzzle_wrapper_security_search_users
+func kuzzle_wrapper_security_search_users(k *C.kuzzle, f *C.search_filters, o *C.query_options) *C.search_users_result {
+	res, err := (*kuzzle.Kuzzle)(k.instance).Security.SearchUsers(cToGoSearchFilters(f), SetQueryOptions(o))
+	return goToCUserSearchResult(k, res, err)
+}
+
+//export kuzzle_wrapper_security_user_create
+func kuzzle_wrapper_security_user_create(u *C.user, o *C.query_options) *C.user_result {
+	res, err := cToGoUser(u).Create(SetQueryOptions(o))
+	return goToCUserResult(u.kuzzle, res, err)
+}
+
+//export kuzzle_wrapper_security_user_create_credentials
+func kuzzle_wrapper_security_user_create_credentials(u *C.user, cstrategy *C.char, ccredentials *C.json_object, o *C.query_options) *C.json_result {
+	strategy := C.GoString(cstrategy)
+	credentials := JsonCConvert(ccredentials)
+	res, err := cToGoUser(u).CreateCredentials(strategy, credentials, SetQueryOptions(o))
+
+	return goToCJsonResult(res, err)
+}
+
+//export kuzzle_wrapper_security_user_create_with_credentials
+func kuzzle_wrapper_security_user_create_with_credentials(u *C.user, ccredentials *C.json_object, o *C.query_options) *C.user_result {
+	credentials, ok := JsonCConvert(ccredentials).(types.Credentials)
+	if !ok {
+		return goToCUserResult(u.kuzzle, nil, types.NewError("Invalid credentials given", 400))
+	}
+
+	res, err := cToGoUser(u).CreateWithCredentials(credentials, SetQueryOptions(o))
+
+	return goToCUserResult(u.kuzzle, res, err)
+}
+
+//export kuzzle_wrapper_security_user_delete
+func kuzzle_wrapper_security_user_delete(u *C.user, o *C.query_options) *C.string_result {
+	res, err := cToGoUser(u).Delete(SetQueryOptions(o))
+	return goToCStringResult(&res, err)
+}
+
+//export kuzzle_wrapper_security_user_delete_credentials
+func kuzzle_wrapper_security_user_delete_credentials(u *C.user, strategy *C.char, o *C.query_options) *C.bool_result {
+	res, err := cToGoUser(u).DeleteCredentials(C.GoString(strategy), SetQueryOptions(o))
+	return goToCBoolResult(res, err)
+}
+
+//export kuzzle_wrapper_security_user_get_credentials_info
+func kuzzle_wrapper_security_user_get_credentials_info(u *C.user, strategy *C.char, o *C.query_options) *C.json_result {
+	res, err := cToGoUser(u).GetCredentialsInfo(C.GoString(strategy), SetQueryOptions(o))
+	return goToCJsonResult(res, err)
+}
+
+//export kuzzle_wrapper_security_user_get_profiles
+func kuzzle_wrapper_security_user_get_profiles(u *C.user, o *C.query_options) *C.profiles_result {
+	res, err := cToGoUser(u).GetProfiles(SetQueryOptions(o))
+	return goToCProfilesResult(u.kuzzle, res, err)
+}
+
+//export kuzzle_wrapper_security_user_get_rights
+func kuzzle_wrapper_security_user_get_rights(u *C.user, o *C.query_options) *C.user_rights_result {
+	res, err := cToGoUser(u).GetRights(SetQueryOptions(o))
+	return goToCUserRightsResult(res, err)
+}
+
+//export kuzzle_wrapper_security_user_has_credentials
+func kuzzle_wrapper_security_user_has_credentials(u *C.user, strategy *C.char, o *C.query_options) *C.bool_result {
+	res, err := cToGoUser(u).HasCredentials(C.GoString(strategy), SetQueryOptions(o))
+	return goToCBoolResult(res, err)
+}
+
+//export kuzzle_wrapper_security_user_replace
+func kuzzle_wrapper_security_user_replace(u *C.user, o *C.query_options) *C.user_result {
+	res, err := cToGoUser(u).Replace(SetQueryOptions(o))
+	return goToCUserResult(u.kuzzle, res, err)
+}
+
+func kuzzle_wrapper_security_save_restricted(u *C.user, ccredentials *C.json_object, o *C.query_options) *C.user_result {
+	credentials, ok := JsonCConvert(ccredentials).(types.Credentials)
+	if !ok {
+		return goToCUserResult(u.kuzzle, nil, types.NewError("Invalid credentials", 400))
+	}
+
+	res, err := cToGoUser(u).SaveRestricted(credentials, SetQueryOptions(o))
+	return goToCUserResult(u.kuzzle, res, err)
+}
+
+//export kuzzle_wrapper_security_update_credentials
+func kuzzle_wrapper_security_update_credentials(u *C.user, strategy *C.char, credentials *C.json_object, o *C.query_options) *C.json_result {
+	res, err := cToGoUser(u).UpdateCredentials(C.GoString(strategy), JsonCConvert(credentials), SetQueryOptions(o))
+	return goToCJsonResult(res, err)
+}
+
+//export kuzzle_wrapper_security_is_action_allowed
+func kuzzle_wrapper_security_is_action_allowed(crights **C.user_right, crights_length C.uint, controller *C.char, action *C.char, index *C.char, collection *C.char) C.uint {
+	rights := make([]*types.UserRights, int(crights_length))
+
+	carray := (*[1<<30 - 1]*C.user_right)(unsafe.Pointer(crights))[:int(crights_length):int(crights_length)]
+	for i := 0; i < int(crights_length); i++ {
+		rights[i] = cToGoUserRigh(carray[i])
+	}
+
+	res := security.IsActionAllowed(rights, C.GoString(controller), C.GoString(action), C.GoString(index), C.GoString(collection))
+	return C.uint(res)
+}

--- a/internal/wrappers/headers/kuzzlesdk.h
+++ b/internal/wrappers/headers/kuzzlesdk.h
@@ -1,0 +1,554 @@
+#ifndef _KUZZLE_H_
+#define _KUZZLE_H_
+
+#include <json-c/json.h>
+#include <time.h>
+#include <errno.h>
+#include <stdbool.h>
+
+typedef struct {
+    void *instance;
+} kuzzle;
+
+enum {
+    CONNECTED,
+    DISCARDED,
+    DISCONNECTED,
+    LOGIN_ATTEMPT,
+    NETWORK_ERROR,
+    OFFLINE_QUEUE_POP,
+    OFFLINE_QUEUE_PUSH,
+    QUERY_ERROR,
+    RECONNECTED,
+    JWT_EXPIRED,
+    ERROR
+} event;
+
+//define a request
+typedef struct {
+    char *request_id;
+    char *controller;
+    char *action;
+    char *index;
+    char *collection;
+    json_object *body;
+    char *id;
+    long from;
+    long size;
+    char *scroll;
+    char *scroll_id;
+    char *strategy;
+    unsigned long long expires_in;
+    json_object *volatiles;
+    char *scope;
+    char *state;
+    char *user;
+    long start;
+    long stop;
+    long end;
+    unsigned char bit;
+    char *member;
+    char *member1;
+    char *member2;
+    char **members;
+    unsigned members_length;
+    double lon;
+    double lat;
+    double distance;
+    char *unit;
+    json_object *options;
+    char **keys;
+    unsigned keys_length;
+    long cursor;
+    long offset;
+    char *field;
+    char **fields;
+    unsigned fields_length;
+    char *subcommand;
+    char *pattern;
+    long idx;
+    char *min;
+    char *max;
+    char *limit;
+    unsigned long count;
+    char *match;
+} kuzzle_request;
+
+//query object used by query()
+typedef struct {
+    json_object *query;
+    unsigned long long timestamp;
+    char   *request_id;
+} query_object;
+
+typedef struct {
+    query_object **queries;
+    unsigned long length;
+} offline_queue;
+
+//options passed to query()
+typedef struct {
+    bool queuable;
+    bool withdist;
+    bool withcoord;
+    long from;
+    long size;
+    char *scroll;
+    char *scroll_id;
+    char *refresh;
+    char *if_exist;
+    int retry_on_conflict;
+    json_object *volatiles;
+} query_options;
+
+//options passed to room constructor
+typedef struct {
+    char *scope;
+    char *state;
+    char *user;
+    int subscribe_to_self;
+    json_object *volatiles;
+} room_options;
+
+enum Mode {AUTO, MANUAL};
+//options passed to the Kuzzle() fct
+typedef struct {
+    unsigned queue_ttl;
+    unsigned long queue_max_size;
+    unsigned char offline_mode;
+    unsigned char auto_queue;
+    unsigned char auto_reconnect;
+    unsigned char auto_replay;
+    unsigned char auto_resubscribe;
+    unsigned long reconnection_delay;
+    unsigned long replay_interval;
+    enum Mode connect;
+    char *refresh;
+    char *default_index;
+    json_object    *headers;
+} options;
+
+//meta of a document
+typedef struct {
+    char *author;
+    unsigned long long created_at;
+    unsigned long long updated_at;
+    char *updater;
+    bool active;
+    unsigned long long deleted_at;
+} meta;
+
+/* === Security === */
+
+typedef json_object controllers;
+
+typedef struct {
+    char *index;
+    char **collections;
+    int collections_length;
+} policy_restriction;
+
+typedef struct {
+    char *role_id;
+    policy_restriction *restricted_to;
+    int restricted_to_length;
+} policy;
+
+typedef struct {
+    char *id;
+    policy *policies;
+    int policies_length;
+    kuzzle *kuzzle;
+} profile;
+
+typedef struct {
+    char *id;
+    json_object *controllers;
+    kuzzle *kuzzle;
+} role;
+
+//kuzzle user
+typedef struct {
+    char *id;
+    json_object *content;
+    char **profile_ids;
+    uint profile_ids_length;
+    kuzzle *kuzzle;
+} user;
+
+// user content passed to user constructor
+typedef struct {
+    json_object *content;
+    char **profile_ids;
+    uint profile_ids_length;
+} user_data;
+
+/* === Dedicated response structures === */
+
+typedef struct {
+  int failed;
+  int successful;
+  int total;
+} shards;
+
+typedef struct {
+    char *index;
+    char *collection;
+    kuzzle *kuzzle;
+} collection;
+
+typedef struct {
+    char *id;
+    char *index;
+    meta *meta;
+    shards *shards;
+    json_object *content;
+    int version;
+    char *result;
+    bool created;
+    char *collection;
+    collection *_collection;
+} document;
+
+typedef struct {
+    document *result;
+    int status;
+    char *error;
+    char *stack;
+} document_result;
+
+typedef struct {
+    char *id;
+    meta *meta;
+    json_object *content;
+    int count;
+} notification_content;
+
+typedef struct {
+    char *request_id;
+    notification_content *result;
+    json_object *volatiles;
+    char *index;
+    char *collection;
+    char *controller;
+    char *action;
+    char *protocol;
+    char *scope;
+    char *state;
+    char *user;
+    char *n_type;
+    char *room_id;
+    unsigned long long timestamp;
+    int status;
+    char *error;
+    char *stack;
+} notification_result;
+
+typedef struct {
+    profile *profile;
+    int status;
+    char *error;
+    char *stack;
+} profile_result;
+
+typedef struct {
+    profile *profiles;
+    uint profiles_length;
+    int status;
+    char *error;
+    char *stack;
+} profiles_result;
+
+typedef struct {
+    role *role;
+    int status;
+    char *error;
+    char *stack;
+} role_result;
+
+typedef struct {
+    char *controller;
+    char *action;
+    char *index;
+    char *collection;
+    char *value;
+} user_right;
+
+typedef struct {
+    user_right *user_rights;
+    uint user_rights_length;
+    int status;
+    char *error;
+    char *stack;
+} user_rights_result;
+
+typedef struct {
+    user *user;
+    int status;
+    char *error;
+    char *stack;
+} user_result;
+
+enum {
+    ALLOWED=0,
+    CONDITIONNAL=1,
+    DENIED=2
+} is_action_allowed;
+
+//statistics
+typedef struct {
+    json_object* completed_requests;
+    json_object* connections;
+    json_object* failed_requests;
+    json_object* ongoing_requests;
+    unsigned long long timestamp;
+} statistics;
+
+typedef struct {
+    statistics* result;
+    int status;
+    char *error;
+    char *stack;
+} statistics_result;
+
+typedef struct {
+    statistics* res;
+    int res_size;
+    int status;
+    char *error;
+    char *stack;
+} all_statistics_result;
+
+// ms.geopos
+typedef struct {
+    double (*result)[2];
+    unsigned length;
+    int status;
+    char *error;
+    char *stack;
+} geopos_result;
+
+//check_token
+typedef struct {
+    bool valid;
+    char *state;
+    unsigned long long expires_at;
+    int status;
+    char *error;
+    char *stack;
+} token_validity;
+
+/* === Generic response structures === */
+
+// raw Kuzzle response
+typedef struct {
+    char *request_id;
+    json_object *result;
+    json_object *volatiles;
+    char *index;
+    char *collection;
+    char *controller;
+    char *action;
+    char *room_id;
+    char *channel;
+    int status;
+    char *error;
+    char *stack;
+} kuzzle_response;
+
+//any json result
+typedef struct {
+    json_object *result;
+    int status;
+    char *error;
+    char *stack;
+} json_result;
+
+//any array of json_object result
+typedef struct {
+    json_object **result;
+    unsigned length;
+    int status;
+    char *error;
+    char *stack;
+} json_array_result;
+
+//any boolean result
+typedef struct {
+    bool result;
+    int status;
+    char *error;
+    char *stack;
+} bool_result;
+
+//any integer result
+typedef struct {
+    long long result;
+    int status;
+    char *error;
+    char *stack;
+} int_result;
+
+//any double result
+typedef struct {
+    double result;
+    int status;
+    char *error;
+    char *stack;
+} double_result;
+
+//any array of integers result
+typedef struct {
+    long long *result;
+    unsigned length;
+    int status;
+    char *error;
+    char*stack;
+} int_array_result;
+
+// any string result
+typedef struct {
+    char *result;
+    int status;
+    char *error;
+    char *stack;
+} string_result;
+
+//any array of strings result
+typedef struct {
+    char **result;
+    unsigned long length;
+    int status;
+    char *error;
+    char *stack;
+} string_array_result;
+
+typedef struct {
+    char* type;
+    json_object* fields;
+} field_mapping;
+
+typedef struct {
+    json_object* query;
+    json_object* sort;
+    json_object* aggregations;
+    json_object* search_after;
+} search_filters;
+
+typedef struct {
+    document *hits;
+    uint length;
+    uint total;
+    char *scrollId;
+} document_search;
+
+typedef struct {
+    profile *hits;
+    uint length;
+    uint total;
+    char *scrollId;
+} profile_search;
+
+typedef struct {
+    role *hits;
+    uint length;
+    uint total;
+} role_search;
+
+typedef struct {
+    user *hits;
+    uint length;
+    uint total;
+    char *scrollId;
+} user_search;
+
+//any delete* function
+typedef struct {
+    bool acknowledged;
+    bool shards_acknowledged;
+    int status;
+    char *error;
+    char *stack;
+} ack_result;
+
+typedef struct {
+    shards *result;
+    int status;
+    char *error;
+    char *stack;
+} shards_result;
+
+typedef struct {
+    bool strict;
+    json_object *fields;
+    json_object *validators;
+} specification;
+
+typedef struct {
+    specification *validation;
+    char *index;
+    char *collection;
+} specification_entry;
+
+typedef struct {
+    specification *result;
+    int status;
+    char *error;
+    char *stack;
+} specification_result;
+
+typedef struct {
+    document_search *result;
+    int status;
+    char *error;
+    char *stack;
+} search_result;
+
+typedef struct {
+    profile_search *result;
+    int status;
+    char *error;
+    char *stack;
+} search_profiles_result;
+
+typedef struct {
+    role_search *result;
+    int status;
+    char *error;
+    char *stack;
+} search_roles_result;
+
+typedef struct {
+    user_search *result;
+    int status;
+    char *error;
+    char *stack;
+} search_users_result;
+
+typedef struct {
+    specification_entry *hits;
+    uint length;
+    uint total;
+    char *scrollId;
+} specification_search;
+
+typedef struct {
+    specification_search *result;
+    int status;
+    char *error;
+    char *stack;
+} specification_search_result;
+
+typedef struct {
+    json_object *mapping;
+    collection *collection;
+} mapping;
+
+typedef struct {
+    mapping *result;
+    int status;
+    char *error;
+    char *stack;
+} mapping_result;
+
+#endif

--- a/internal/wrappers/headers/kuzzlesdk.h
+++ b/internal/wrappers/headers/kuzzlesdk.h
@@ -51,19 +51,19 @@ typedef struct {
     char *member1;
     char *member2;
     char **members;
-    unsigned members_length;
+    size_t members_length;
     double lon;
     double lat;
     double distance;
     char *unit;
     json_object *options;
     char **keys;
-    unsigned keys_length;
+    size_t keys_length;
     long cursor;
     long offset;
     char *field;
     char **fields;
-    unsigned fields_length;
+    size_t fields_length;
     char *subcommand;
     char *pattern;
     long idx;
@@ -83,7 +83,7 @@ typedef struct {
 
 typedef struct {
     query_object **queries;
-    unsigned long length;
+    size_t queries_length;
 } offline_queue;
 
 //options passed to query()
@@ -106,7 +106,7 @@ typedef struct {
     char *scope;
     char *state;
     char *user;
-    int subscribe_to_self;
+    bool subscribe_to_self;
     json_object *volatiles;
 } room_options;
 
@@ -125,7 +125,7 @@ typedef struct {
     enum Mode connect;
     char *refresh;
     char *default_index;
-    json_object    *headers;
+    json_object *headers;
 } options;
 
 //meta of a document
@@ -145,19 +145,19 @@ typedef json_object controllers;
 typedef struct {
     char *index;
     char **collections;
-    int collections_length;
+    size_t collections_length;
 } policy_restriction;
 
 typedef struct {
     char *role_id;
     policy_restriction *restricted_to;
-    int restricted_to_length;
+    size_t restricted_to_length;
 } policy;
 
 typedef struct {
     char *id;
     policy *policies;
-    int policies_length;
+    size_t policies_length;
     kuzzle *kuzzle;
 } profile;
 
@@ -172,7 +172,7 @@ typedef struct {
     char *id;
     json_object *content;
     char **profile_ids;
-    uint profile_ids_length;
+    size_t profile_ids_length;
     kuzzle *kuzzle;
 } user;
 
@@ -180,7 +180,7 @@ typedef struct {
 typedef struct {
     json_object *content;
     char **profile_ids;
-    uint profile_ids_length;
+    size_t profile_ids_length;
 } user_data;
 
 /* === Dedicated response structures === */
@@ -253,7 +253,7 @@ typedef struct {
 
 typedef struct {
     profile *profiles;
-    uint profiles_length;
+    size_t profiles_length;
     int status;
     char *error;
     char *stack;
@@ -276,7 +276,7 @@ typedef struct {
 
 typedef struct {
     user_right *user_rights;
-    uint user_rights_length;
+    size_t user_rights_length;
     int status;
     char *error;
     char *stack;
@@ -311,9 +311,9 @@ typedef struct {
     char *stack;
 } statistics_result;
 
-typedef struct {
-    statistics* res;
-    int res_size;
+typedef struct all_statistics_result {
+    statistics* result;
+    size_t result_length;
     int status;
     char *error;
     char *stack;
@@ -322,7 +322,7 @@ typedef struct {
 // ms.geopos
 typedef struct {
     double (*result)[2];
-    unsigned length;
+    size_t result_length;
     int status;
     char *error;
     char *stack;
@@ -356,6 +356,13 @@ typedef struct {
     char *stack;
 } kuzzle_response;
 
+//any void result
+typedef struct {
+    int status;
+    char *error;
+    char *stack;
+} void_result;
+
 //any json result
 typedef struct {
     json_object *result;
@@ -367,7 +374,7 @@ typedef struct {
 //any array of json_object result
 typedef struct {
     json_object **result;
-    unsigned length;
+    size_t result_length;
     int status;
     char *error;
     char *stack;
@@ -400,7 +407,7 @@ typedef struct {
 //any array of integers result
 typedef struct {
     long long *result;
-    unsigned length;
+    size_t result_length;
     int status;
     char *error;
     char*stack;
@@ -415,18 +422,13 @@ typedef struct {
 } string_result;
 
 //any array of strings result
-typedef struct {
+typedef struct string_array_result {
     char **result;
-    unsigned long length;
+    size_t result_length;
     int status;
     char *error;
     char *stack;
 } string_array_result;
-
-typedef struct {
-    char* type;
-    json_object* fields;
-} field_mapping;
 
 typedef struct {
     json_object* query;
@@ -437,29 +439,29 @@ typedef struct {
 
 typedef struct {
     document *hits;
-    uint length;
-    uint total;
-    char *scrollId;
+    size_t hits_length;
+    unsigned total;
+    char *scroll_id;
 } document_search;
 
 typedef struct {
     profile *hits;
-    uint length;
-    uint total;
-    char *scrollId;
+    size_t hits_length;
+    unsigned total;
+    char *scroll_id;
 } profile_search;
 
 typedef struct {
     role *hits;
-    uint length;
-    uint total;
+    size_t hits_length;
+    unsigned total;
 } role_search;
 
 typedef struct {
     user *hits;
-    uint length;
-    uint total;
-    char *scrollId;
+    size_t hits_length;
+    unsigned total;
+    char *scroll_id;
 } user_search;
 
 //any delete* function
@@ -527,9 +529,9 @@ typedef struct {
 
 typedef struct {
     specification_entry *hits;
-    uint length;
-    uint total;
-    char *scrollId;
+    size_t hits_length;
+    unsigned total;
+    char *scroll_id;
 } specification_search;
 
 typedef struct {
@@ -550,5 +552,18 @@ typedef struct {
     char *error;
     char *stack;
 } mapping_result;
+
+typedef struct  {
+    bool persisted;
+    char* name;
+} collection_entry;
+
+typedef struct collection_entry_result {
+    collection_entry* result;
+    size_t result_length;
+    int status;
+    char* error;
+    char* stack;
+} collection_entry_result;
 
 #endif

--- a/internal/wrappers/headers/sdk_wrappers_internal.h
+++ b/internal/wrappers/headers/sdk_wrappers_internal.h
@@ -15,8 +15,6 @@ static void set_errno(int err) {
   errno = err;
 }
 
-typedef statistics* statistics_ptr;
-
 static void call_notification_result(void* f, notification_result* res) {
     ((void(*)(notification_result*))f)(res);
 }

--- a/internal/wrappers/headers/sdk_wrappers_internal.h
+++ b/internal/wrappers/headers/sdk_wrappers_internal.h
@@ -1,0 +1,28 @@
+#ifndef __SDK_WRAPPERS_INTERNAL
+#define __SDK_WRAPPERS_INTERNAL
+
+typedef char *char_ptr;
+typedef document *document_ptr;
+typedef policy *policy_ptr;
+typedef policy_restriction *policy_restriction_ptr;
+typedef json_object *json_object_ptr;
+typedef query_object *query_object_ptr;
+
+// used by memory_storage.geopos
+typedef double geopos_arr[2];
+
+static void set_errno(int err) {
+  errno = err;
+}
+
+typedef statistics* statistics_ptr;
+
+static void call_notification_result(void* f, notification_result* res) {
+    ((void(*)(notification_result*))f)(res);
+}
+
+static void call(void* f, json_object* res) {
+    ((void(*)(json_object*))f)(res);
+}
+
+#endif

--- a/internal/wrappers/io/kuzzle/sdk/.gitignore
+++ b/internal/wrappers/io/kuzzle/sdk/.gitignore
@@ -1,0 +1,2 @@
+*
+!/.gitignore

--- a/internal/wrappers/kcore.i
+++ b/internal/wrappers/kcore.i
@@ -1,0 +1,17 @@
+/* File : kcore.i */
+
+%module kcore
+%{
+#define _Complex
+#include "kuzzle.h"
+#include "headers/kuzzlesdk.h"
+#include "templates/swig.h"
+
+#include <stdio.h>
+%}
+%define _Complex
+
+%enddef
+
+%include "headers/kuzzlesdk.h"
+%include "kuzzle.h"

--- a/internal/wrappers/templates/java/core.i
+++ b/internal/wrappers/templates/java/core.i
@@ -1,0 +1,235 @@
+%rename(TokenValidity) token_validity;
+%rename(AckResponse) ack_response;
+%rename(queueTTL) queue_ttl;
+%rename(Options) options;
+%rename(Kuzzle) kuzzle;
+%rename(JsonObject) json_object;
+%rename(JsonResult) json_result;
+%rename(LoginResult) login_result;
+%rename(BoolResult) bool_result;
+%rename(Statistics) statistics;
+%rename(AllStatisticsResult) all_statistics_result;
+%rename(StatisticsResult) statistics_result;
+
+%include "typemap.i"
+%include "../../kcore.i"
+//
+//if (strcmp(JSON_C_VERSION, "0.12.99")) {
+//    printf("You version of json-c is not equal to 0.12.99, please ensure to have the right version\n");
+//    exit(1);
+//}
+
+
+%pragma(java) jniclasscode=%{
+  static {
+    try {
+        System.loadLibrary("kuzzle");
+    } catch (UnsatisfiedLinkError e) {
+      System.err.println("Native code library failed to load. \n" + e);
+      System.exit(1);
+    }
+  }
+%}
+
+%extend options {
+    options() {
+        options *o = kuzzle_wrapper_new_options();
+        return o;
+    }
+
+    ~options() {
+        free($self);
+    }
+}
+
+struct json_object { };
+
+%ignore json_object::ptr;
+%extend json_object {
+    json_object() {
+        json_object *j = json_object_new_object();
+        return j;
+    }
+
+    ~json_object() {
+        free($self);
+    }
+
+    json_object* put(char* key, char* content) {
+        kuzzle_wrapper_json_put($self, key, content, 0);
+        return $self;
+    }
+
+    json_object* put(char* key, int content) {
+        kuzzle_wrapper_json_put($self, key, &content, 1);
+        return $self;
+    }
+
+    json_object* put(char* key, double content) {
+        kuzzle_wrapper_json_put($self, key, &content, 2);
+        return $self;
+    }
+
+    json_object* put(char* key, bool content) {
+        kuzzle_wrapper_json_put($self, key, &content, 3);
+        return $self;
+    }
+
+    json_object* put(char* key, json_object* content) {
+        kuzzle_wrapper_json_put($self, key, content, 4);
+        return $self;
+    }
+
+    char* getString(char* key) {
+        return kuzzle_wrapper_json_get_string($self, key);
+    }
+
+    int getInt(char* key) {
+        return kuzzle_wrapper_json_get_int($self, key);
+    }
+
+    double getDouble(char* key) {
+        return kuzzle_wrapper_json_get_double($self, key);
+    }
+
+    bool getBoolean(char* key) {
+        return kuzzle_wrapper_json_get_bool($self, key);
+    }
+
+    json_object* getJsonObject(char* key) {
+        return kuzzle_wrapper_json_get_json_object($self, key);
+    }
+}
+
+%typemap(javaimports) kuzzle "
+/* The type Kuzzle. */"
+
+%extend kuzzle {
+    // ctors && dtor
+    kuzzle(char* host, options *opts) {
+        kuzzle *k = malloc(sizeof(kuzzle));
+        kuzzle_wrapper_new_kuzzle(k, host, "websocket", opts);
+        return k;
+    }
+    kuzzle(char* host) {
+        kuzzle *k;
+        k = malloc(sizeof(kuzzle));
+        kuzzle_wrapper_new_kuzzle(k, host, "websocket", NULL);
+        return k;
+    }
+    ~kuzzle() {
+        unregisterKuzzle($self);
+        free($self);
+    }
+
+    // checkToken
+    token_validity* checkToken(char* token) {
+        return kuzzle_wrapper_check_token($self, token);
+    }
+
+    // connect
+    char* connect() {
+        return kuzzle_wrapper_connect($self);
+    }
+
+    // createIndex
+    bool_result* createIndex(char* index, query_options* options) {
+        return kuzzle_wrapper_create_index($self, index, options);
+    }
+    bool_result* createIndex(char* index) {
+        return kuzzle_wrapper_create_index($self, index, NULL);
+    }
+
+    // createMyCredentials
+    json_result* createMyCredentials(char* strategy, json_object* credentials, query_options* options) {
+        return kuzzle_wrapper_create_my_credentials($self, strategy, credentials, options);
+    }
+    json_result* createMyCredentials(char* strategy, json_object* credentials) {
+        return kuzzle_wrapper_create_my_credentials($self, strategy, credentials, NULL);
+    }
+
+    // deleteMyCredentials
+    bool_result* deleteMyCredentials(char* strategy, query_options *options) {
+        return kuzzle_wrapper_delete_my_credentials($self, strategy, options);
+    }
+    bool_result* deleteMyCredentials(char* strategy) {
+        return kuzzle_wrapper_delete_my_credentials($self, strategy, NULL);
+    }
+
+    // getMyCredentials
+    json_result* getMyCredentials(char *strategy, query_options *options) {
+        return kuzzle_wrapper_get_my_credentials($self, strategy, options);
+    }
+    json_result* getMyCredentials(char *strategy) {
+        return kuzzle_wrapper_get_my_credentials($self, strategy, NULL);
+    }
+
+    // updateMyCredentials
+    json_result* updateMyCredentials(char *strategy, json_object* credentials, query_options *options) {
+        return kuzzle_wrapper_update_my_credentials($self, strategy, credentials, options);
+    }
+    json_result* updateMyCredentials(char *strategy, json_object* credentials) {
+        return kuzzle_wrapper_update_my_credentials($self, strategy, credentials, NULL);
+    }
+
+    // validateMyCredentials
+    bool_result* validateMyCredentials(char *strategy, json_object* credentials, query_options* options) {
+        return kuzzle_wrapper_validate_my_credentials($self, strategy, credentials, options);
+    }
+    bool_result* validateMyCredentials(char *strategy, json_object* credentials) {
+        return kuzzle_wrapper_validate_my_credentials($self, strategy, credentials, NULL);
+    }
+
+    // login
+    string_result* login(char* strategy, json_object* credentials, int expires_in) {
+        return kuzzle_wrapper_login($self, strategy, credentials, &expires_in);
+    }
+    string_result* login(char* strategy, json_object* credentials) {
+        return kuzzle_wrapper_login($self, strategy, credentials, NULL);
+    }
+
+    // getAllStatistics
+    all_statistics_result* getAllStatistics(query_options* options) {
+        return kuzzle_wrapper_get_all_statistics($self, options);
+    }
+    all_statistics_result* getAllStatistics() {
+        return kuzzle_wrapper_get_all_statistics($self, NULL);
+    }
+
+    // getStatistics
+    statistics_result* getStatistics(unsigned long time, query_options* options) {
+        return kuzzle_wrapper_get_statistics($self, time, options);
+    }
+    statistics_result* getStatistics(unsigned long time) {
+        return kuzzle_wrapper_get_statistics($self, time, NULL);
+    }
+
+    // getAutoRefresh
+    bool_result* getAutoRefresh(char* index, query_options* options) {
+        return kuzzle_wrapper_get_auto_refresh($self, index, options);
+    }
+    bool_result* getAutoRefresh(char* index) {
+        return kuzzle_wrapper_get_auto_refresh($self, index, NULL);
+    }
+
+    // getJwt
+    char* getJwt() {
+        return kuzzle_wrapper_get_jwt($self);
+    }
+
+    // getMyRights
+    json_result* getMyRights(query_options* options) {
+        return kuzzle_wrapper_get_my_rights($self, options);
+    }
+    json_result* getMyRights() {
+        return kuzzle_wrapper_get_my_rights($self, NULL);
+    }
+
+    // getServerInfo
+    json_result* getServerInfo(query_options* options) {
+        return kuzzle_wrapper_get_server_info($self, options);
+    }
+    json_result* getServerInfo() {
+        return kuzzle_wrapper_get_server_info($self, NULL);
+    }
+}

--- a/internal/wrappers/templates/java/core.i
+++ b/internal/wrappers/templates/java/core.i
@@ -2,6 +2,7 @@
 %rename(AckResponse) ack_response;
 %rename(queueTTL) queue_ttl;
 %rename(Options) options;
+%rename(QueryOptions) query_options;
 %rename(Kuzzle) kuzzle;
 %rename(JsonObject) json_object;
 %rename(JsonResult) json_result;
@@ -10,15 +11,13 @@
 %rename(Statistics) statistics;
 %rename(AllStatisticsResult) all_statistics_result;
 %rename(StatisticsResult) statistics_result;
+%rename(CollectionsList) collection_entry;
+%rename(CollectionsListResult) collection_entry_result;
+%rename(StringArrayResult) string_array_result;
 
 %include "typemap.i"
+%include "javadoc.i"
 %include "../../kcore.i"
-//
-//if (strcmp(JSON_C_VERSION, "0.12.99")) {
-//    printf("You version of json-c is not equal to 0.12.99, please ensure to have the right version\n");
-//    exit(1);
-//}
-
 
 %pragma(java) jniclasscode=%{
   static {
@@ -187,6 +186,9 @@ struct json_object { };
     string_result* login(char* strategy, json_object* credentials) {
         return kuzzle_wrapper_login($self, strategy, credentials, NULL);
     }
+    string_result* login(char* strategy) {
+        return kuzzle_wrapper_login($self, strategy, NULL, NULL);
+    }
 
     // getAllStatistics
     all_statistics_result* getAllStatistics(query_options* options) {
@@ -231,5 +233,34 @@ struct json_object { };
     }
     json_result* getServerInfo() {
         return kuzzle_wrapper_get_server_info($self, NULL);
+    }
+
+    // listCollections
+    collection_entry_result* listCollections(char *index, query_options* options) {
+        return kuzzle_wrapper_list_collections($self, index, options);
+    }
+    collection_entry_result* listCollections(char *index) {
+        return kuzzle_wrapper_list_collections($self, index, NULL);
+    }
+    collection_entry_result* listCollections() {
+        return kuzzle_wrapper_list_collections($self, NULL, NULL);
+    }
+
+    // listIndexes
+    string_array_result* listIndexes(query_options* options) {
+        return kuzzle_wrapper_list_indexes($self, options);
+    }
+    string_array_result* listIndexes() {
+        return kuzzle_wrapper_list_indexes($self, NULL);
+    }
+
+    // disconnect
+    void disconnect() {
+        kuzzle_wrapper_disconnect($self);
+    }
+
+    // logout
+    void logout() {
+        kuzzle_wrapper_logout($self);
     }
 }

--- a/internal/wrappers/templates/java/javadoc.i
+++ b/internal/wrappers/templates/java/javadoc.i
@@ -1,0 +1,315 @@
+%javamethodmodifiers kuzzle::kuzzle(char*) "
+  /**
+   * Constructor
+   *
+   * @param host - Target Kuzzle host name or IP address
+   */
+  public";
+
+%javamethodmodifiers kuzzle::kuzzle(char*, options*) "
+  /**
+   * Constructor
+   *
+   * @param host - Target Kuzzle host name or IP address
+   * @param options - Request options
+   */
+  public";
+
+%javamethodmodifiers kuzzle::checkToken(char*) "
+  /**
+   * Check an authentication token validity
+   *
+   * @param token - Token to check (JWT)
+   * @return a TokenValidity object
+   */
+  public";
+
+%javamethodmodifiers kuzzle::connect() "
+  /**
+   * Connects to a Kuzzle instance using the provided host and port.
+   *
+   * @return a string which represent an error or null
+   */
+  public";
+
+%javamethodmodifiers kuzzle::createIndex(char*, query_options*) "
+  /**
+   * Create a new data index
+   *
+   * @param index - index name to create
+   * @param options - Request options
+   * @return a BoolResult object
+   */
+  public";
+
+%javamethodmodifiers kuzzle::createIndex(char*) "
+  /**
+   * {@link #createIndex(String, QueryOptions)}
+   */
+  public";
+
+%javamethodmodifiers kuzzle::createMyCredentials(char*, json_object*, query_options*) "
+  /**
+   * Create credentials of the specified strategy for the current user.
+   *
+   * @param strategy - impacted strategy name
+   * @param credentials - credentials to create
+   * @param options - Request options
+   * @return a JsonResult object
+   */
+  public";
+
+%javamethodmodifiers kuzzle::createMyCredentials(char*, json_object*) "
+  /**
+   * {@link #createIndex(String, QueryOptions)}
+   */
+  public";
+
+%javamethodmodifiers kuzzle::deleteMyCredentials(char*, query_options*) "
+  /**
+   * Delete credentials of the specified strategy for the current user.
+   *
+   * @param strategy- Name of the strategy to remove
+   * @param options - Request options
+   * @return a BoolResult object
+   */
+  public";
+
+%javamethodmodifiers kuzzle::deleteMyCredentials(char*) "
+  /**
+   * {@link #deleteMyCredentials(String, QueryOptions)}
+   */
+  public";
+
+%javamethodmodifiers kuzzle::getMyCredentials(char *strategy, query_options *options) "
+  /**
+   * Get credential information of the specified strategy for the current user.
+   *
+   * @param strategy - Strategy name to get
+   * @param options - Request options
+   * @return a JsonResult
+   */
+  public";
+
+%javamethodmodifiers kuzzle::getMyCredentials(char *strategy) "
+  /**
+   * {@link #getMyCredentials(String, QueryOptions, ResponseListener)}
+   */
+  public";
+
+%javamethodmodifiers kuzzle::updateMyCredentials(char *strategy, json_object* credentials, query_options *options) "
+  /**
+   * Update credentials of the specified strategy for the current user.
+   *
+   * @param strategy - Strategy name to update
+   * @param credentials - Updated credentials content
+   * @param options - Request options
+   * @return a JsonResult
+   */
+  public";
+
+%javamethodmodifiers kuzzle::updateMyCredentials(char *strategy, json_object* credentials) "
+  /**
+   * {@link #updateMyCredentials(String, JSONObject, QueryOptions)}
+   */
+  public";
+
+%javamethodmodifiers kuzzle::validateMyCredentials(char *strategy, json_object* credentials, query_options* options) "
+  /**
+   * Validate credentials of the specified strategy for the current user.
+   *
+   * @param strategy - Strategy name to validate
+   * @param credentials - Credentials content
+   * @param options - Request options
+   * @return a Bool result
+   */
+  public";
+
+%javamethodmodifiers kuzzle::validateMyCredentials(char *strategy, json_object* credentials) "
+  /**
+   * {@link #validateMyCredentials(String, JSONObject, QueryOptions)}
+   */
+  public";
+
+%javamethodmodifiers kuzzle::logout() "
+  /**
+   * Logout method
+   *
+   * @param listener - Response callback listener
+   */
+  public";
+
+%javamethodmodifiers kuzzle::login(char*, json_object*, int) "
+  /**
+   * Log-in Strategy name to use for the authentication
+   *
+   * @param strategy - Strategy name to use for the authentication
+   * @param credentials - Login credentials
+   * @param expiresIn - Token expiration delay
+   * @return StringResult
+   */
+  public";
+
+%javamethodmodifiers kuzzle::login(char*, json_object*) "
+  /**
+   * Log-in Strategy name to use for the authentication
+   *
+   * @param strategy - Strategy name to use for the authentication
+   * @param credentials - Login credentials
+   */
+  public";
+
+%javamethodmodifiers kuzzle::login(char*) "
+  /**
+   * Log-in Strategy name to use for the authentication
+   *
+   * @param strategy - Strategy name to use for the authentication
+   */
+  public";
+
+%javamethodmodifiers kuzzle::login(char*) "
+  /**
+   * Get all Kuzzle usage statistics frames
+   *
+   * @param options - Request options
+   * @param listener - Response callback listener
+   */
+  public";
+
+%javamethodmodifiers kuzzle::getAllStatistics(query_options*) "
+  /**
+   * Get all Kuzzle usage statistics frames
+   *
+   * @param options - Request options
+   * @return a AllStatisticsResult
+   */
+  public";
+
+%javamethodmodifiers kuzzle::getAllStatistics() "
+  /**
+   * {@link #getAllStatistics(QueryOptions)}
+   */
+  public";
+
+%javamethodmodifiers kuzzle::getStatistics(unsigned long, query_options*) "
+  /**
+   * Get Kuzzle usage statistics
+   *
+   * @param options - Request options
+   * @return a StatisticsResult
+   */
+  public";
+
+%javamethodmodifiers kuzzle::getStatistics(unsigned long) "
+  /**
+   * {@link #getStatistics(QueryOptions)}
+   */
+  public";
+
+%javamethodmodifiers kuzzle::getAutoRefresh(char*, query_options*) "
+  /**
+   * Gets the autoRefresh value for the provided data index name
+   *
+   * @param index - Data index name
+   * @param options - Request options
+   */
+  public";
+
+%javamethodmodifiers kuzzle::getAutoRefresh(char*) "
+  /**
+   * {@link #getAutoRefresh(String, QueryOptions)}
+   */
+  public";
+
+%javamethodmodifiers kuzzle::getAutoRefresh() "
+  /**
+   * {@link #getAutoRefresh(String, QueryOptions)}
+   */
+  public";
+
+%javamethodmodifiers kuzzle::getJwt() "
+  /**
+   * Authentication token getter
+   *
+   * @return a string which is the jwt
+   */
+  public";
+
+%javamethodmodifiers kuzzle::getMyRights(query_options*) "
+  /**
+   * Gets the rights array for the currently logged user.
+   *
+   * @param options - Request options
+   * @return a JsonResult
+   */
+  public";
+
+%javamethodmodifiers kuzzle::getMyRights() "
+  /**
+   * {@link #getMyRights(QueryOptions)}
+   */
+  public";
+
+%javamethodmodifiers kuzzle::getServerInfo(query_options*) "
+  /**
+   * Gets server info.
+   *
+   * @param options - Request options
+   * #return a JsonResult
+   */
+  public";
+
+%javamethodmodifiers kuzzle::getServerInfo() "
+  /**
+   * {@link #getServerInfo(QueryOptions)}
+   */
+  public";
+
+%javamethodmodifiers kuzzle::listCollections(char *, query_options*) "
+  /**
+   * List data collections
+   *
+   * @param index - Parent data index name
+   * @param options - Request options
+   * @return a CollectionListResult
+   */
+  public";
+
+%javamethodmodifiers kuzzle::listCollections(char *) "
+  /**
+   * {@link #listCollections(String, QueryOptions)}
+   */
+  public";
+
+%javamethodmodifiers kuzzle::listCollections() "
+  /**
+   * {@link #listCollections(String, QueryOptions)}
+   */
+  public";
+
+%javamethodmodifiers kuzzle::listIndexes(query_options*) "
+  /**
+   * List data indexes
+   *
+   * @param options - Request options
+   */
+  public";
+
+%javamethodmodifiers kuzzle::listIndexes() "
+  /**
+   * {@link #listIndexes(QueryOptions)}
+   */
+  public";
+
+%javamethodmodifiers kuzzle::disconnect() "
+  /**
+   * Disconnect from Kuzzle and invalidate this instance.
+   * Does not fire a disconnected event.
+   */
+  public";
+
+%javamethodmodifiers kuzzle::logout() "
+  /**
+   * Logout method
+   */
+  public";

--- a/internal/wrappers/templates/java/typemap.i
+++ b/internal/wrappers/templates/java/typemap.i
@@ -1,8 +1,8 @@
-%ignore all_statistics_result::res;
-
-%typemap(javacode) all_statistics_result %{
+// Statistics[]
+%ignore all_statistics_result::result;
+%typemap(javacode) struct all_statistics_result %{
   public Statistics[] getResult() {
-    Statistics[] result = new Statistics[getRes_size()];
+    Statistics[] result = new Statistics[(int)getResult_length()];
     for (int i = 0; i < result.length; ++i) {
       result[i] = getResult(i);
     }
@@ -13,6 +13,44 @@
 %javamethodmodifiers all_statistics_result::getResult(size_t pos) "private";
 %extend all_statistics_result {
     statistics *getResult(size_t pos) {
-        return $self->res + pos;
+        return $self->result + pos;
+    }
+}
+
+// CollectionsList[]
+%ignore collection_entry_result::result;
+%typemap(javacode) struct collection_entry_result %{
+  public CollectionsList[] getResult() {
+    CollectionsList[] result = new CollectionsList[(int)getResult_length()];
+    for (int i = 0; i < result.length; ++i) {
+      result[i] = getResult(i);
+    }
+    return result;
+  }
+%}
+
+%javamethodmodifiers collection_entry_result::getResult(size_t pos) "private";
+%extend collection_entry_result {
+    collection_entry *getResult(size_t pos) {
+        return $self->result + pos;
+    }
+}
+
+// String[]
+%ignore string_array_result::result;
+%typemap(javacode) struct string_array_result %{
+  public String[] getResult() {
+    String[] result = new String[(int)getLength()];
+    for (int i = 0; i < result.length; ++i) {
+      result[i] = getResult(i);
+    }
+    return result;
+  }
+%}
+
+%javamethodmodifiers string_array_result::getResult(size_t pos) "private";
+%extend string_array_result {
+    char *getResult(size_t pos) {
+        return *$self->result + pos;
     }
 }

--- a/internal/wrappers/templates/java/typemap.i
+++ b/internal/wrappers/templates/java/typemap.i
@@ -1,0 +1,18 @@
+%ignore all_statistics_result::res;
+
+%typemap(javacode) all_statistics_result %{
+  public Statistics[] getResult() {
+    Statistics[] result = new Statistics[getRes_size()];
+    for (int i = 0; i < result.length; ++i) {
+      result[i] = getResult(i);
+    }
+    return result;
+  }
+%}
+
+%javamethodmodifiers all_statistics_result::getResult(size_t pos) "private";
+%extend all_statistics_result {
+    statistics *getResult(size_t pos) {
+        return $self->res + pos;
+    }
+}

--- a/internal/wrappers/templates/swig.h
+++ b/internal/wrappers/templates/swig.h
@@ -1,0 +1,13 @@
+#ifndef SWIG_H_
+#define SWIG_H_
+
+//Json
+extern void kuzzle_wrapper_json_put(json_object*, char*, void*, int);
+extern char* kuzzle_wrapper_json_get_string(json_object*, char*);
+extern int kuzzle_wrapper_json_get_int(json_object*, char*);
+extern double kuzzle_wrapper_json_get_double(json_object*, char*);
+extern json_bool kuzzle_wrapper_json_get_bool(json_object*, char*);
+extern json_object* kuzzle_wrapper_json_get_json_object(json_object*, char*);
+extern void kuzzle_wrapper_json_new(json_object*);
+
+#endif

--- a/test.sh
+++ b/test.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 set -e
 
-workdir=$(pwd)/.cover
+dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+workdir=$dir/.cover
 profile="$workdir/cover.out"
 mode=count
 dirs=(kuzzle connection collection security ms)
@@ -23,7 +24,7 @@ show_cover_report() {
 }
 
 linter_check() {
-    invalid_files=$(gofmt -l .)
+    invalid_files=$(gofmt -l "$1")
 
     if [ -n "${invalid_files}" ]; then
         echo "Lint errors on the following files:"
@@ -32,9 +33,18 @@ linter_check() {
     fi
 }
 
-linter_check
+make_wrappers() {
+		cd "${dir}/internal/wrappers"
+		make all	
+}
+
+cd "$dir"
+
+linter_check .
+linter_check ./internal/wrappers
 generate_cover_data
 show_cover_report func
+make_wrappers
 case "$1" in
 "")
     ;;


### PR DESCRIPTION
This PR puts together the `sdk-go` and `sdk-wrapper` repositories.

The main motivation for this change is the ability to get a test suite covering the codebase from go down to the swig languages implementations, at least during the time a first release is published.

NB: the wrappers version built here is taken from https://github.com/kuzzleio/sdk-wrappers/pull/48, mainly to get the .gitignore version.