### PR TITLE
Tidier build results

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,10 @@ matrix:
       script: 
         - bash ./test.sh
     - language: java
-      jdk:
-        - oraclejdk8
+      addons:
+        apt:
+          packages:
+            - oracle-java8-installer
       script:
         - cd internal/wrappers && make java
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ go:
 install:
   - git clone https://github.com/json-c/json-c.git
   - cd json-c
-  - sudo apt-get install build-essential swig
+  - sudo apt-get install build-essential swig oracle-java8-installer
   - sh autogen.sh
   - ./configure
   - make
@@ -13,14 +13,5 @@ install:
   - go get -t -v ./...
 script: 
   - bash ./test.sh
-matrix:
-  include:
-    - language: java
-      addons:
-        apt:
-          packages:
-            - oracle-java8-installer
-      script:
-        - cd internal/wrappers && make java
 after_success:
   - cd .cover && bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,4 @@
-language: go
-go:
-  - 1.9
+
 install:
   - git clone https://github.com/json-c/json-c.git
   - cd json-c
@@ -11,7 +9,18 @@ install:
   - sudo make install
   - cd -
   - go get -t -v ./...
-script: 
-  - bash ./test.sh
+matrix:
+  include:
+    - language: go
+      go:
+        - 1.9
+      script: 
+        - bash ./test.sh
+    - language: java
+      jdk:
+        - oraclejdk8
+      script:
+        - jdk_switcher use oraclejdk8
+        - cd internal/wrappers && make java
 after_success:
   - cd .cover && bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+language: go
+go:
+  - 1.9
 install:
   - git clone https://github.com/json-c/json-c.git
   - cd json-c
@@ -8,13 +11,10 @@ install:
   - sudo make install
   - cd -
   - go get -t -v ./...
+script: 
+  - bash ./test.sh
 matrix:
   include:
-    - language: go
-      go:
-        - 1.9
-      script: 
-        - bash ./test.sh
     - language: java
       addons:
         apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-
 install:
   - git clone https://github.com/json-c/json-c.git
   - cd json-c
@@ -20,7 +19,6 @@ matrix:
       jdk:
         - oraclejdk8
       script:
-        - jdk_switcher use oraclejdk8
         - cd internal/wrappers && make java
 after_success:
   - cd .cover && bash <(curl -s https://codecov.io/bash)

--- a/internal/wrappers/.gitignore
+++ b/internal/wrappers/.gitignore
@@ -1,17 +1,5 @@
 # IDE
 .idea
 
-# Auto-generated library
-kuzzle.h
-libkuzzlesdk.so
-
-# .out files
-*.out
-
 # build
-/kcore_wrap.c
-/kcore_wrap.o
-/kuzzle.h
-/libkuzzle.so
-/libkuzzlesdk.so
-
+build/

--- a/internal/wrappers/.gitignore
+++ b/internal/wrappers/.gitignore
@@ -1,5 +1,8 @@
 # IDE
 .idea
 
+# swig generated wrapper code
+kcore_wrap.c
+
 # build
 build/

--- a/internal/wrappers/Makefile
+++ b/internal/wrappers/Makefile
@@ -37,7 +37,7 @@ object:
 
 posttask:
 	cp -p $(GOTARGET) $(OUTDIR)
-	rm -f $(OUTDIR)/kcore_wrap.o
+	rm -f $(OUTDIR)/kcore_wrap.*
 
 swig:
 	mkdir -p $(OUTDIR)
@@ -50,7 +50,7 @@ java: SWIGOPTS = -package io.kuzzle.sdk
 java: core swig wrapper object posttask
 	$(JAVAHOME)/bin/javac $(OUTDIR)/*.java
 	$(JAVAHOME)/bin/jar cf $(OUTDIR)/kuzzlesdk.jar $(OUTDIR)/*.class
-	rm -f $(OUTDIR)/*.java $(OUTDIR)/*.class $(OUTDIR)/kcore_wrap.c
+	rm -f $(OUTDIR)/*.java $(OUTDIR)/*.class
 
 csharp: OUTDIR = $(ROOTOUTDIR)/csharp
 csharp: LANGUAGE = csharp
@@ -58,7 +58,7 @@ csharp: SWIGOPTS = -dllimport kuzzlesdk
 csharp: core swig wrapper object posttask
 	mkdir -p $(OUTDIR)
 	mcs -t:library $(OUTDIR)/*.cs -out:$(OUTDIR)/libkuzzle-csharp.so
-	rm -f $(OUTDIR)/*.cs $(OUTDIR)/kcore_wrap.c
+	rm -f $(OUTDIR)/*.cs
 
 clean:
 	rm -rf build

--- a/internal/wrappers/Makefile
+++ b/internal/wrappers/Makefile
@@ -17,7 +17,7 @@ OBJS = $(SRCS:.c=.o)
 
 SWIG = swig
 
-all: java csharp
+all: java
 
 kcore_wrap.o: kcore_wrap.c
 	$(CC) -ggdb -c $< -o $(OUTDIR)/$@ $(CFLAGS) $(LDFLAGS) $(LIBS) $(INCS) $(LANGINCLUDE) 
@@ -37,11 +37,12 @@ object:
 
 posttask:
 	cp -p $(GOTARGET) $(OUTDIR)
-	rm -f $(OUTDIR)/kcore_wrap.*
+	rm -f $(OUTDIR)/kcore_wrap.o
+	rm -f kcore_wrap.c
 
 swig:
 	mkdir -p $(OUTDIR)
-	$(SWIG) -Wall -$(LANGUAGE) $(SWIGOPTS) -outdir $(OUTDIR) -o $(OUTDIR)/kcore_wrap.c $(INCS) $(LANGINCLUDE) templates/$(LANGUAGE)/core.i
+	$(SWIG) -Wall -$(LANGUAGE) $(SWIGOPTS) -outdir $(OUTDIR) -o kcore_wrap.c $(INCS) $(LANGINCLUDE) templates/$(LANGUAGE)/core.i
 
 java: OUTDIR = $(ROOTOUTDIR)/java/io/kuzzle/sdk
 java: LANGINCLUDE = -I$(JAVAHOME)/include -I$(JAVAHOME)/include/linux

--- a/internal/wrappers/Makefile
+++ b/internal/wrappers/Makefile
@@ -61,7 +61,7 @@ csharp: core swig wrapper object posttask
 	rm -f $(OUTDIR)/*.cs $(OUTDIR)/kcore_wrap.c
 
 clean:
-	rm -rf build *.class *.o *.h *.so $(WOUTDIR) *.c *~ *.go
+	rm -rf build
 
 .PHONY: all java csharp wrapper swigjava swigcsharp clean object core
 

--- a/internal/wrappers/Makefile
+++ b/internal/wrappers/Makefile
@@ -63,6 +63,6 @@ csharp: core swig wrapper object posttask
 clean:
 	rm -rf build
 
-.PHONY: all java csharp wrapper swigjava swigcsharp clean object core
+.PHONY: all java csharp wrapper swig clean object core
 
 .DEFAULT_GOAL := all

--- a/internal/wrappers/Makefile
+++ b/internal/wrappers/Makefile
@@ -1,44 +1,68 @@
-CC = gcc
-CFLAGS = -std=c99 -fPIC -I$(PWD)/headers -I${JAVA_HOME}/include -I${JAVA_HOME}/include/linux
-LDFLAGS = -L./
-LIBS = -lkuzzlesdk -ljson-c
-SRCS = kcore_wrap.c
-OBJS = $(SRCS:.c=.o)
-TARGET = libkcore.so
-
+ROOTOUTDIR = ./build
 GOROOT ?= /usr/local
+JAVAHOME ?= /usr/local
 GOCC = $(GOROOT)/bin/go
 GOFLAGS = -buildmode=c-shared
 GOSRC = ./cgo/kuzzle/
-GOTARGET = libkuzzlesdk.so
+GOTARGETDIR = $(ROOTOUTDIR)/c
+GOTARGET = $(GOTARGETDIR)/libkuzzlesdk.so
+
+CC = gcc
+CFLAGS = -std=c99 -fPIC 
+INCS = -I$(PWD)/headers -I$(GOTARGETDIR)
+LDFLAGS = -L$(GOTARGETDIR)
+LIBS = -lkuzzlesdk -ljson-c
+SRCS = kcore_wrap.c
+OBJS = $(SRCS:.c=.o)
 
 SWIG = swig
 
-all: java
+all: java csharp
 
 kcore_wrap.o: kcore_wrap.c
-	$(CC) -ggdb -c $< -o $@ $(CFLAGS) $(LDFLAGS) $(LIBS)
+	$(CC) -ggdb -c $< -o $(OUTDIR)/$@ $(CFLAGS) $(LDFLAGS) $(LIBS) $(INCS) $(LANGINCLUDE) 
 
 core:
 ifeq ($(wildcard $(GOCC)),)
 	$(error "Unable to find go compiler")
 endif
+	mkdir -p $(GOTARGETDIR)
 	$(GOCC) build -o $(GOTARGET) $(GOFLAGS) $(GOSRC)
-	mv -f libkuzzlesdk.h kuzzle.h
+	mv -f $(GOTARGETDIR)/libkuzzlesdk.h $(GOTARGETDIR)/kuzzle.h
 
 wrapper: $(OBJS)
 
 object:
-	gcc -ggdb -shared kcore_wrap.o -o libkuzzle.so $(LDFLAGS) $(LIBS)
+	gcc -ggdb -shared $(OUTDIR)/kcore_wrap.o -o $(OUTDIR)/libkuzzle-wrapper-$(LANGUAGE).so $(LDFLAGS) $(LIBS) $(INCS) $(LANGINCLUDE)
 
-swigjava:
-	$(SWIG) -Wall -java -package io.kuzzle.sdk -outdir ./io/kuzzle/sdk -o kcore_wrap.c -I/usr/local/include templates/java/core.i
+posttask:
+	cp -p $(GOTARGET) $(OUTDIR)
+	rm -f $(OUTDIR)/kcore_wrap.o
 
-java: 	core swigjava wrapper object
+swig:
+	mkdir -p $(OUTDIR)
+	$(SWIG) -Wall -$(LANGUAGE) $(SWIGOPTS) -outdir $(OUTDIR) -o $(OUTDIR)/kcore_wrap.c $(INCS) $(LANGINCLUDE) templates/$(LANGUAGE)/core.i
+
+java: OUTDIR = $(ROOTOUTDIR)/java/io/kuzzle/sdk
+java: LANGINCLUDE = -I$(JAVAHOME)/include -I$(JAVAHOME)/include/linux
+java: LANGUAGE = java
+java: SWIGOPTS = -package io.kuzzle.sdk
+java: core swig wrapper object posttask
+	$(JAVAHOME)/bin/javac $(OUTDIR)/*.java
+	$(JAVAHOME)/bin/jar cf $(OUTDIR)/kuzzlesdk.jar $(OUTDIR)/*.class
+	rm -f $(OUTDIR)/*.java $(OUTDIR)/*.class $(OUTDIR)/kcore_wrap.c
+
+csharp: OUTDIR = $(ROOTOUTDIR)/csharp
+csharp: LANGUAGE = csharp
+csharp: SWIGOPTS = -dllimport kuzzlesdk
+csharp: core swig wrapper object posttask
+	mkdir -p $(OUTDIR)
+	mcs -t:library $(OUTDIR)/*.cs -out:$(OUTDIR)/libkuzzle-csharp.so
+	rm -f $(OUTDIR)/*.cs $(OUTDIR)/kcore_wrap.c
 
 clean:
-	rm -rf build *.class *.o *.h *.so io/kuzzle/sdk/*.java io/kuzzle/sdk/*.class *.c *~ *.go
+	rm -rf build *.class *.o *.h *.so $(WOUTDIR) *.c *~ *.go
 
-.PHONY: all java wrapper swigjava clean object core
+.PHONY: all java csharp wrapper swigjava swigcsharp clean object core
 
 .DEFAULT_GOAL := all

--- a/internal/wrappers/Makefile
+++ b/internal/wrappers/Makefile
@@ -1,6 +1,6 @@
 ROOTOUTDIR = ./build
 GOROOT ?= /usr/local
-JAVAHOME ?= /usr/local
+JAVA_HOME ?= /usr/local
 GOCC = $(GOROOT)/bin/go
 GOFLAGS = -buildmode=c-shared
 GOSRC = ./cgo/kuzzle/
@@ -45,12 +45,12 @@ swig:
 	$(SWIG) -Wall -$(LANGUAGE) $(SWIGOPTS) -outdir $(OUTDIR) -o kcore_wrap.c $(INCS) $(LANGINCLUDE) templates/$(LANGUAGE)/core.i
 
 java: OUTDIR = $(ROOTOUTDIR)/java/io/kuzzle/sdk
-java: LANGINCLUDE = -I$(JAVAHOME)/include -I$(JAVAHOME)/include/linux
+java: LANGINCLUDE = -I$(JAVA_HOME)/include -I$(JAVA_HOME)/include/linux
 java: LANGUAGE = java
 java: SWIGOPTS = -package io.kuzzle.sdk
 java: core swig wrapper object posttask
-	$(JAVAHOME)/bin/javac $(OUTDIR)/*.java
-	$(JAVAHOME)/bin/jar cf $(OUTDIR)/kuzzlesdk.jar $(OUTDIR)/*.class
+	$(JAVA_HOME)/bin/javac $(OUTDIR)/*.java
+	$(JAVA_HOME)/bin/jar cf $(OUTDIR)/kuzzlesdk.jar $(OUTDIR)/*.class
 	rm -f $(OUTDIR)/*.java $(OUTDIR)/*.class
 
 csharp: OUTDIR = $(ROOTOUTDIR)/csharp

--- a/internal/wrappers/io/kuzzle/sdk/.gitignore
+++ b/internal/wrappers/io/kuzzle/sdk/.gitignore
@@ -1,2 +1,0 @@
-*
-!/.gitignore

--- a/internal/wrappers/templates/java/typemap.i
+++ b/internal/wrappers/templates/java/typemap.i
@@ -40,7 +40,7 @@
 %ignore string_array_result::result;
 %typemap(javacode) struct string_array_result %{
   public String[] getResult() {
-    String[] result = new String[(int)getLength()];
+    String[] result = new String[(int)getResult_length()];
     for (int i = 0; i < result.length; ++i) {
       result[i] = getResult(i);
     }

--- a/test.sh
+++ b/test.sh
@@ -44,7 +44,7 @@ linter_check .
 linter_check ./internal/wrappers
 generate_cover_data
 show_cover_report func
-# make_wrappers
+make_wrappers
 case "$1" in
 "")
     ;;

--- a/test.sh
+++ b/test.sh
@@ -44,7 +44,7 @@ linter_check .
 linter_check ./internal/wrappers
 generate_cover_data
 show_cover_report func
-make_wrappers
+# make_wrappers
 case "$1" in
 "")
     ;;


### PR DESCRIPTION
Change the way SDK wrappers are built and were the resulting objects are stored

Results are now put in a `build/<language>` directory

Currently handled languages: C, Java, C#
