### PR TITLE
fix Collection.PublishMessage prototype

### DIFF
--- a/collection/publish_message.go
+++ b/collection/publish_message.go
@@ -9,7 +9,7 @@ import (
 // Takes an optional argument object with the following properties:
 //   - volatile (object, default: null):
 //     Additional information passed to notifications to other users
-func (dc *Collection) PublishMessage(message map[string]interface{}, options types.QueryOptions) (bool, error) {
+func (dc *Collection) PublishMessage(message interface{}, options types.QueryOptions) (bool, error) {
 	ch := make(chan *types.KuzzleResponse)
 
 	query := &types.KuzzleRequest{

--- a/collection/publish_message_test.go
+++ b/collection/publish_message_test.go
@@ -19,9 +19,11 @@ func TestPublishKuzzleError(t *testing.T) {
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)
 
-	message := make(map[string]interface{})
-	message["title"] = interface{}("yolo")
-	_, err := collection.NewCollection(k, "collection", "index").PublishMessage(message, nil)
+	type TestMessageStruct struct {
+		Title string `json:"title"`
+	}
+
+	_, err := collection.NewCollection(k, "collection", "index").PublishMessage(TestMessageStruct{"yolo"}, nil)
 	assert.NotNil(t, err)
 }
 
@@ -45,10 +47,12 @@ func TestPublishMessage(t *testing.T) {
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)
 
-	message := make(map[string]interface{})
-	message["title"] = interface{}("yolo")
+	type TestMessageStruct struct {
+		Title string `json:"title"`
+	}
+
 	coll := collection.NewCollection(k, "collection", "index")
-	res, _ := coll.PublishMessage(message, nil)
+	res, _ := coll.PublishMessage(TestMessageStruct{"yolo"}, nil)
 
 	assert.Equal(t, true, res)
 }
@@ -61,12 +65,13 @@ func ExampleCollection_PublishMessage() {
 	c := &internal.MockedConnection{}
 	k, _ := kuzzle.NewKuzzle(c, nil)
 
-	message := make(map[string]interface{})
-	message["title"] = interface{}("yolo")
-	res, err := collection.NewCollection(k, "collection", "index").PublishMessage(message, nil)
+	type TestMessageStruct struct {
+		Title string `json:"title"`
+	}
+	res, err := collection.NewCollection(k, "collection", "index").PublishMessage(TestMessageStruct{"yolo"}, nil)
 
 	if err != nil {
-		fmt.Println(err.Error())
+		panic(err.Error())
 		return
 	}
 


### PR DESCRIPTION
The current `Collection.PublishMessage` method takes a `map[string]interface{}` argument as a message content, which is impractical.

This PR changes that argument datatype to `interface{}` instead, making it easier to send messages using the GO SDK.

This does not change the C `publish_message` prototype since it takes a `JSONObject*` argument, which translates in a map, and the marshalled result is equivalent