### PR TITLE
Change void_result to error_result

### DIFF
--- a/internal/wrappers/cgo/kuzzle/auth.go
+++ b/internal/wrappers/cgo/kuzzle/auth.go
@@ -96,12 +96,12 @@ func kuzzle_credentials_exist(a *C.auth, strategy *C.char, options *C.query_opti
 }
 
 //export kuzzle_delete_my_credentials
-func kuzzle_delete_my_credentials(a *C.auth, strategy *C.char, options *C.query_options) *C.void_result {
+func kuzzle_delete_my_credentials(a *C.auth, strategy *C.char, options *C.query_options) *C.error_result {
 	err := (*auth.Auth)(a.instance).DeleteMyCredentials(
 		C.GoString(strategy),
 		SetQueryOptions(options))
 
-	return goToCVoidResult(err)
+	return goToCErrorResult(err)
 }
 
 //export kuzzle_get_current_user

--- a/internal/wrappers/cgo/kuzzle/collection.go
+++ b/internal/wrappers/cgo/kuzzle/collection.go
@@ -56,15 +56,15 @@ func kuzzle_new_collection(c *C.collection, k *C.kuzzle) {
 }
 
 //export kuzzle_collection_create
-func kuzzle_collection_create(c *C.collection, index *C.char, col *C.char, options *C.query_options) *C.void_result {
+func kuzzle_collection_create(c *C.collection, index *C.char, col *C.char, options *C.query_options) *C.error_result {
 	err := (*collection.Collection)(c.instance).Create(C.GoString(index), C.GoString(col), SetQueryOptions(options))
-	return goToCVoidResult(err)
+	return goToCErrorResult(err)
 }
 
 //export kuzzle_collection_truncate
-func kuzzle_collection_truncate(c *C.collection, index *C.char, col *C.char, options *C.query_options) *C.void_result {
+func kuzzle_collection_truncate(c *C.collection, index *C.char, col *C.char, options *C.query_options) *C.error_result {
 	err := (*collection.Collection)(c.instance).Truncate(C.GoString(index), C.GoString(col), SetQueryOptions(options))
-	return goToCVoidResult(err)
+	return goToCErrorResult(err)
 }
 
 //export kuzzle_collection_exists
@@ -92,18 +92,18 @@ func kuzzle_collection_get_mapping(c *C.collection, index *C.char, col *C.char, 
 }
 
 //export kuzzle_collection_update_mapping
-func kuzzle_collection_update_mapping(c *C.collection, index *C.char, col *C.char, body *C.char, options *C.query_options) *C.void_result {
+func kuzzle_collection_update_mapping(c *C.collection, index *C.char, col *C.char, body *C.char, options *C.query_options) *C.error_result {
 	newBody, _ := json.Marshal(body)
 	err := (*collection.Collection)(c.instance).UpdateMapping(C.GoString(index), C.GoString(col), newBody, SetQueryOptions(options))
-	return goToCVoidResult(err)
+	return goToCErrorResult(err)
 }
 
 // Specifications
 
 //export kuzzle_collection_delete_specifications
-func kuzzle_collection_delete_specifications(c *C.collection, index *C.char, col *C.char, options *C.query_options) *C.void_result {
+func kuzzle_collection_delete_specifications(c *C.collection, index *C.char, col *C.char, options *C.query_options) *C.error_result {
 	err := (*collection.Collection)(c.instance).DeleteSpecifications(C.GoString(index), C.GoString(col), SetQueryOptions(options))
-	return goToCVoidResult(err)
+	return goToCErrorResult(err)
 }
 
 //export kuzzle_collection_get_specifications

--- a/internal/wrappers/cgo/kuzzle/destructors.go
+++ b/internal/wrappers/cgo/kuzzle/destructors.go
@@ -721,8 +721,8 @@ func kuzzle_free_mapping_result(st *C.mapping_result) {
 	}
 }
 
-//export kuzzle_free_void_result
-func kuzzle_free_void_result(st *C.void_result) {
+//export kuzzle_free_error_result
+func kuzzle_free_error_result(st *C.error_result) {
 	if st != nil {
 		C.free(unsafe.Pointer(st.error))
 		C.free(unsafe.Pointer(st.stack))

--- a/internal/wrappers/cgo/kuzzle/errors.go
+++ b/internal/wrappers/cgo/kuzzle/errors.go
@@ -165,7 +165,7 @@ func Set_collection_entry_error(s *C.collection_entry_result, err error) {
 	setErr(&s.status, &s.error, &s.stack, err)
 }
 
-func Set_void_result_error(s *C.void_result, err error) {
+func Set_error_result_error(s *C.error_result, err error) {
 	setErr(&s.status, &s.error, &s.stack, err)
 }
 

--- a/internal/wrappers/cgo/kuzzle/go_to_c.go
+++ b/internal/wrappers/cgo/kuzzle/go_to_c.go
@@ -744,13 +744,13 @@ func fillStatistics(src *types.Statistics, dest *C.statistics) {
 }
 
 // Allocates memory
-func goToCVoidResult(err error) *C.void_result {
+func goToCErrorResult(err error) *C.error_result {
 	if err == nil {
 		return nil
 	}
 
-	result := (*C.void_result)(C.calloc(1, C.sizeof_void_result))
-	Set_void_result_error(result, err)
+	result := (*C.error_result)(C.calloc(1, C.sizeof_error_result))
+	Set_error_result_error(result, err)
 
 	return result
 }

--- a/internal/wrappers/cgo/kuzzle/index.go
+++ b/internal/wrappers/cgo/kuzzle/index.go
@@ -57,15 +57,15 @@ func kuzzle_new_index(i *C.kuzzle_index, k *C.kuzzle) {
 }
 
 //export kuzzle_index_create
-func kuzzle_index_create(i *C.kuzzle_index, index *C.char, options *C.query_options) *C.void_result {
+func kuzzle_index_create(i *C.kuzzle_index, index *C.char, options *C.query_options) *C.error_result {
 	err := (*indexPkg.Index)(i.instance).Create(C.GoString(index), SetQueryOptions(options))
-	return goToCVoidResult(err)
+	return goToCErrorResult(err)
 }
 
 //export kuzzle_index_delete
-func kuzzle_index_delete(i *C.kuzzle_index, index *C.char, options *C.query_options) *C.void_result {
+func kuzzle_index_delete(i *C.kuzzle_index, index *C.char, options *C.query_options) *C.error_result {
 	err := (*indexPkg.Index)(i.instance).Delete(C.GoString(index), SetQueryOptions(options))
-	return goToCVoidResult(err)
+	return goToCErrorResult(err)
 }
 
 //export kuzzle_index_mdelete
@@ -81,21 +81,21 @@ func kuzzle_index_exists(i *C.kuzzle_index, index *C.char, options *C.query_opti
 }
 
 //export kuzzle_index_refresh
-func kuzzle_index_refresh(i *C.kuzzle_index, index *C.char, options *C.query_options) *C.void_result {
+func kuzzle_index_refresh(i *C.kuzzle_index, index *C.char, options *C.query_options) *C.error_result {
 	err := (*indexPkg.Index)(i.instance).Refresh(C.GoString(index), SetQueryOptions(options))
-	return goToCVoidResult(err)
+	return goToCErrorResult(err)
 }
 
 //export kuzzle_index_refresh_internal
-func kuzzle_index_refresh_internal(i *C.kuzzle_index, options *C.query_options) *C.void_result {
+func kuzzle_index_refresh_internal(i *C.kuzzle_index, options *C.query_options) *C.error_result {
 	err := (*indexPkg.Index)(i.instance).RefreshInternal(SetQueryOptions(options))
-	return goToCVoidResult(err)
+	return goToCErrorResult(err)
 }
 
 //export kuzzle_index_set_auto_refresh
-func kuzzle_index_set_auto_refresh(i *C.kuzzle_index, index *C.char, autoRefresh C.bool, options *C.query_options) *C.void_result {
+func kuzzle_index_set_auto_refresh(i *C.kuzzle_index, index *C.char, autoRefresh C.bool, options *C.query_options) *C.error_result {
 	err := (*indexPkg.Index)(i.instance).SetAutoRefresh(C.GoString(index), bool(autoRefresh), SetQueryOptions(options))
-	return goToCVoidResult(err)
+	return goToCErrorResult(err)
 }
 
 //export kuzzle_index_get_auto_refresh

--- a/internal/wrappers/cgo/kuzzle/memory_storage.go
+++ b/internal/wrappers/cgo/kuzzle/memory_storage.go
@@ -141,10 +141,10 @@ func kuzzle_ms_expireat(k *C.kuzzle, key *C.char, ts C.ulonglong, options *C.que
 }
 
 //export kuzzle_ms_flushdb
-func kuzzle_ms_flushdb(k *C.kuzzle, options *C.query_options) *C.void_result {
+func kuzzle_ms_flushdb(k *C.kuzzle, options *C.query_options) *C.error_result {
 	err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Flushdb(SetQueryOptions(options))
 
-	return goToCVoidResult(err)
+	return goToCErrorResult(err)
 }
 
 //export kuzzle_ms_geoadd
@@ -393,7 +393,7 @@ func kuzzle_ms_hmget(k *C.kuzzle, key *C.char, fields **C.char, flen C.size_t, o
 }
 
 //export kuzzle_ms_hmset
-func kuzzle_ms_hmset(k *C.kuzzle, key *C.char, entries **C.ms_hash_field, elen C.size_t, options *C.query_options) *C.void_result {
+func kuzzle_ms_hmset(k *C.kuzzle, key *C.char, entries **C.ms_hash_field, elen C.size_t, options *C.query_options) *C.error_result {
 	wrapped := (*[1 << 20]*C.ms_hash_field)(unsafe.Pointer(entries))[:elen:elen]
 	goentries := make([]*types.MsHashField, int(elen))
 
@@ -408,7 +408,7 @@ func kuzzle_ms_hmset(k *C.kuzzle, key *C.char, entries **C.ms_hash_field, elen C
 		goentries,
 		SetQueryOptions(options))
 
-	return goToCVoidResult(err)
+	return goToCErrorResult(err)
 }
 
 //export kuzzle_ms_hscan
@@ -586,25 +586,25 @@ func kuzzle_ms_lrem(k *C.kuzzle, key *C.char, count C.long, value *C.char, optio
 }
 
 //export kuzzle_ms_lset
-func kuzzle_ms_lset(k *C.kuzzle, key *C.char, index C.long, value *C.char, options *C.query_options) *C.void_result {
+func kuzzle_ms_lset(k *C.kuzzle, key *C.char, index C.long, value *C.char, options *C.query_options) *C.error_result {
 	err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Lset(
 		C.GoString(key),
 		int(index),
 		C.GoString(value),
 		SetQueryOptions(options))
 
-	return goToCVoidResult(err)
+	return goToCErrorResult(err)
 }
 
 //export kuzzle_ms_ltrim
-func kuzzle_ms_ltrim(k *C.kuzzle, key *C.char, start C.long, stop C.long, options *C.query_options) *C.void_result {
+func kuzzle_ms_ltrim(k *C.kuzzle, key *C.char, start C.long, stop C.long, options *C.query_options) *C.error_result {
 	err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Ltrim(
 		C.GoString(key),
 		int(start),
 		int(stop),
 		SetQueryOptions(options))
 
-	return goToCVoidResult(err)
+	return goToCErrorResult(err)
 }
 
 //export kuzzle_ms_mget
@@ -627,7 +627,7 @@ func kuzzle_ms_mget(k *C.kuzzle, keys **C.char, klen C.size_t, options *C.query_
 }
 
 //export kuzzle_ms_mset
-func kuzzle_ms_mset(k *C.kuzzle, entries **C.ms_key_value, elen C.size_t, options *C.query_options) *C.void_result {
+func kuzzle_ms_mset(k *C.kuzzle, entries **C.ms_key_value, elen C.size_t, options *C.query_options) *C.error_result {
 	wrapped := (*[1 << 20]*C.ms_key_value)(unsafe.Pointer(entries))[:elen:elen]
 	goentries := make([]*types.MSKeyValue, int(elen))
 
@@ -641,7 +641,7 @@ func kuzzle_ms_mset(k *C.kuzzle, entries **C.ms_key_value, elen C.size_t, option
 		goentries,
 		SetQueryOptions(options))
 
-	return goToCVoidResult(err)
+	return goToCErrorResult(err)
 }
 
 //export kuzzle_ms_msetnx
@@ -721,13 +721,13 @@ func kuzzle_ms_pfcount(k *C.kuzzle, keys **C.char, klen C.size_t, options *C.que
 }
 
 //export kuzzle_ms_pfmerge
-func kuzzle_ms_pfmerge(k *C.kuzzle, key *C.char, sources **C.char, slen C.size_t, options *C.query_options) *C.void_result {
+func kuzzle_ms_pfmerge(k *C.kuzzle, key *C.char, sources **C.char, slen C.size_t, options *C.query_options) *C.error_result {
 	err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Pfmerge(
 		C.GoString(key),
 		cToGoStrings(sources, slen),
 		SetQueryOptions(options))
 
-	return goToCVoidResult(err)
+	return goToCErrorResult(err)
 }
 
 //export kuzzle_ms_ping
@@ -739,14 +739,14 @@ func kuzzle_ms_ping(k *C.kuzzle, options *C.query_options) *C.string_result {
 }
 
 //export kuzzle_ms_psetex
-func kuzzle_ms_psetex(k *C.kuzzle, key *C.char, value *C.char, ttl C.ulong, options *C.query_options) *C.void_result {
+func kuzzle_ms_psetex(k *C.kuzzle, key *C.char, value *C.char, ttl C.ulong, options *C.query_options) *C.error_result {
 	err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Psetex(
 		C.GoString(key),
 		C.GoString(value),
 		int(ttl),
 		SetQueryOptions(options))
 
-	return goToCVoidResult(err)
+	return goToCErrorResult(err)
 }
 
 //export kuzzle_ms_pttl
@@ -767,13 +767,13 @@ func kuzzle_ms_randomkey(k *C.kuzzle, options *C.query_options) *C.string_result
 }
 
 //export kuzzle_ms_rename
-func kuzzle_ms_rename(k *C.kuzzle, key *C.char, newkey *C.char, options *C.query_options) *C.void_result {
+func kuzzle_ms_rename(k *C.kuzzle, key *C.char, newkey *C.char, options *C.query_options) *C.error_result {
 	err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Rename(
 		C.GoString(key),
 		C.GoString(newkey),
 		SetQueryOptions(options))
 
-	return goToCVoidResult(err)
+	return goToCErrorResult(err)
 }
 
 //export kuzzle_ms_renamenx
@@ -878,24 +878,24 @@ func kuzzle_ms_sdiffstore(k *C.kuzzle, key *C.char, keys **C.char, klen C.size_t
 }
 
 //export kuzzle_ms_set
-func kuzzle_ms_set(k *C.kuzzle, key *C.char, value *C.char, options *C.query_options) *C.void_result {
+func kuzzle_ms_set(k *C.kuzzle, key *C.char, value *C.char, options *C.query_options) *C.error_result {
 	err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Set(
 		C.GoString(key),
 		C.GoString(value),
 		SetQueryOptions(options))
 
-	return goToCVoidResult(err)
+	return goToCErrorResult(err)
 }
 
 //export kuzzle_ms_setex
-func kuzzle_ms_setex(k *C.kuzzle, key *C.char, value *C.char, ttl C.ulong, options *C.query_options) *C.void_result {
+func kuzzle_ms_setex(k *C.kuzzle, key *C.char, value *C.char, ttl C.ulong, options *C.query_options) *C.error_result {
 	err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Setex(
 		C.GoString(key),
 		C.GoString(value),
 		int(ttl),
 		SetQueryOptions(options))
 
-	return goToCVoidResult(err)
+	return goToCErrorResult(err)
 }
 
 //export kuzzle_ms_setnx

--- a/internal/wrappers/cgo/kuzzle/realtime.go
+++ b/internal/wrappers/cgo/kuzzle/realtime.go
@@ -58,15 +58,15 @@ func kuzzle_realtime_list(rt *C.realtime, index, collection *C.char) *C.string_r
 }
 
 //export kuzzle_realtime_publish
-func kuzzle_realtime_publish(rt *C.realtime, index, collection, body *C.char) *C.void_result {
+func kuzzle_realtime_publish(rt *C.realtime, index, collection, body *C.char) *C.error_result {
 	err := (*realtime.Realtime)(rt.instance).Publish(C.GoString(index), C.GoString(collection), C.GoString(body))
-	return goToCVoidResult(err)
+	return goToCErrorResult(err)
 }
 
 //export kuzzle_realtime_unsubscribe
-func kuzzle_realtime_unsubscribe(rt *C.realtime, roomId *C.char) *C.void_result {
+func kuzzle_realtime_unsubscribe(rt *C.realtime, roomId *C.char) *C.error_result {
 	err := (*realtime.Realtime)(rt.instance).Unsubscribe(C.GoString(roomId))
-	return goToCVoidResult(err)
+	return goToCErrorResult(err)
 }
 
 //export kuzzle_realtime_subscribe
@@ -92,7 +92,7 @@ func kuzzle_realtime_subscribe(rt *C.realtime, index, collection, body *C.char, 
 }
 
 //export kuzzle_realtime_join
-func kuzzle_realtime_join(rt *C.realtime, index, collection, roomId *C.char, options *C.room_options, callback C.kuzzle_notification_listener, data unsafe.Pointer) *C.void_result {
+func kuzzle_realtime_join(rt *C.realtime, index, collection, roomId *C.char, options *C.room_options, callback C.kuzzle_notification_listener, data unsafe.Pointer) *C.error_result {
 	c := make(chan types.KuzzleNotification)
 
 	err := (*realtime.Realtime)(rt.instance).Join(C.GoString(index), C.GoString(collection), C.GoString(roomId), SetRoomOptions(options), c)
@@ -102,7 +102,7 @@ func kuzzle_realtime_join(rt *C.realtime, index, collection, roomId *C.char, opt
 		C.kuzzle_notify(callback, goToCNotificationResult(&res), data)
 	}()
 
-	return goToCVoidResult(err)
+	return goToCErrorResult(err)
 }
 
 //export kuzzle_realtime_validate

--- a/internal/wrappers/cgo/kuzzle/security.go
+++ b/internal/wrappers/cgo/kuzzle/security.go
@@ -293,9 +293,9 @@ func kuzzle_security_delete_user(k *C.kuzzle, id *C.char, o *C.query_options) *C
 }
 
 //export kuzzle_security_delete_credentials
-func kuzzle_security_delete_credentials(k *C.kuzzle, strategy, id *C.char, o *C.query_options) *C.void_result {
+func kuzzle_security_delete_credentials(k *C.kuzzle, strategy, id *C.char, o *C.query_options) *C.error_result {
 	err := (*kuzzle.Kuzzle)(k.instance).Security.DeleteCredentials(C.GoString(strategy), C.GoString(id), SetQueryOptions(o))
-	return goToCVoidResult(err)
+	return goToCErrorResult(err)
 }
 
 //export kuzzle_security_create_profile
@@ -387,9 +387,9 @@ func kuzzle_security_replace_user(k *C.kuzzle, id, content *C.char, o *C.query_o
 }
 
 //export kuzzle_security_update_credentials
-func kuzzle_security_update_credentials(k *C.kuzzle, strategy *C.char, id *C.char, body *C.char, o *C.query_options) *C.void_result {
+func kuzzle_security_update_credentials(k *C.kuzzle, strategy *C.char, id *C.char, body *C.char, o *C.query_options) *C.error_result {
 	err := (*kuzzle.Kuzzle)(k.instance).Security.UpdateCredentials(C.GoString(strategy), C.GoString(id), json.RawMessage(C.GoString(body)), SetQueryOptions(o))
-	return goToCVoidResult(err)
+	return goToCErrorResult(err)
 }
 
 //export kuzzle_security_update_profile
@@ -409,10 +409,10 @@ func kuzzle_security_update_profile(k *C.kuzzle, id *C.char, body *C.char, o *C.
 }
 
 //export kuzzle_security_update_profile_mapping
-func kuzzle_security_update_profile_mapping(k *C.kuzzle, body *C.char, o *C.query_options) *C.void_result {
+func kuzzle_security_update_profile_mapping(k *C.kuzzle, body *C.char, o *C.query_options) *C.error_result {
 	options := SetQueryOptions(o)
 	err := (*kuzzle.Kuzzle)(k.instance).Security.UpdateProfileMapping(json.RawMessage(C.GoString(body)), options)
-	return goToCVoidResult(err)
+	return goToCErrorResult(err)
 }
 
 //export kuzzle_security_update_role
@@ -432,10 +432,10 @@ func kuzzle_security_update_role(k *C.kuzzle, id *C.char, body *C.char, o *C.que
 }
 
 //export kuzzle_security_update_role_mapping
-func kuzzle_security_update_role_mapping(k *C.kuzzle, body *C.char, o *C.query_options) *C.void_result {
+func kuzzle_security_update_role_mapping(k *C.kuzzle, body *C.char, o *C.query_options) *C.error_result {
 	options := SetQueryOptions(o)
 	err := (*kuzzle.Kuzzle)(k.instance).Security.UpdateRoleMapping(json.RawMessage(C.GoString(body)), options)
-	return goToCVoidResult(err)
+	return goToCErrorResult(err)
 }
 
 //export kuzzle_security_update_user
@@ -445,10 +445,10 @@ func kuzzle_security_update_user(k *C.kuzzle, id *C.char, body *C.char, o *C.que
 }
 
 //export kuzzle_security_update_user_mapping
-func kuzzle_security_update_user_mapping(k *C.kuzzle, body *C.char, o *C.query_options) *C.void_result {
+func kuzzle_security_update_user_mapping(k *C.kuzzle, body *C.char, o *C.query_options) *C.error_result {
 	options := SetQueryOptions(o)
 	err := (*kuzzle.Kuzzle)(k.instance).Security.UpdateUserMapping(json.RawMessage(C.GoString(body)), options)
-	return goToCVoidResult(err)
+	return goToCErrorResult(err)
 }
 
 //export kuzzle_security_is_action_allowed

--- a/internal/wrappers/cpp/auth.cpp
+++ b/internal/wrappers/cpp/auth.cpp
@@ -53,7 +53,7 @@ namespace kuzzleio {
   }
 
   void Auth::deleteMyCredentials(const std::string& strategy, query_options *options) Kuz_Throw_KuzzleException {
-    void_result *r = kuzzle_delete_my_credentials(_auth, const_cast<char*>(strategy.c_str()), options);
+    error_result *r = kuzzle_delete_my_credentials(_auth, const_cast<char*>(strategy.c_str()), options);
     if (r != NULL)
         throwExceptionFromStatus(r);
     delete(r);

--- a/internal/wrappers/cpp/collection.cpp
+++ b/internal/wrappers/cpp/collection.cpp
@@ -32,10 +32,10 @@ namespace kuzzleio {
     }
 
     void Collection::create(const std::string& index, const std::string& collection, query_options *options) Kuz_Throw_KuzzleException {
-        void_result *r = kuzzle_collection_create(_collection, const_cast<char*>(index.c_str()), const_cast<char*>(collection.c_str()), options);
+        error_result *r = kuzzle_collection_create(_collection, const_cast<char*>(index.c_str()), const_cast<char*>(collection.c_str()), options);
         if (r != NULL)
             throwExceptionFromStatus(r);
-        kuzzle_free_void_result(r);
+        kuzzle_free_error_result(r);
     }
 
     bool Collection::exists(const std::string& index, const std::string& collection, query_options *options) Kuz_Throw_KuzzleException {
@@ -59,11 +59,11 @@ namespace kuzzleio {
     }
 
     void Collection::truncate(const std::string& index, const std::string& collection, query_options *options) Kuz_Throw_KuzzleException {
-        void_result *r = kuzzle_collection_truncate(_collection, const_cast<char*>(index.c_str()), const_cast<char*>(collection.c_str()), options);
+        error_result *r = kuzzle_collection_truncate(_collection, const_cast<char*>(index.c_str()), const_cast<char*>(collection.c_str()), options);
         if (r != NULL)
             throwExceptionFromStatus(r);
 
-        kuzzle_free_void_result(r);
+        kuzzle_free_error_result(r);
     }
 
     std::string Collection::getMapping(const std::string& index, const std::string& collection, query_options *options) Kuz_Throw_KuzzleException {
@@ -78,11 +78,11 @@ namespace kuzzleio {
     }
 
     void Collection::updateMapping(const std::string& index, const std::string& collection, const std::string& body, query_options *options) Kuz_Throw_KuzzleException {
-        void_result *r = kuzzle_collection_update_mapping(_collection, const_cast<char*>(index.c_str()), const_cast<char*>(collection.c_str()), const_cast<char*>(body.c_str()), options);
+        error_result *r = kuzzle_collection_update_mapping(_collection, const_cast<char*>(index.c_str()), const_cast<char*>(collection.c_str()), const_cast<char*>(body.c_str()), options);
         if (r != NULL)
             throwExceptionFromStatus(r);
 
-        kuzzle_free_void_result(r);
+        kuzzle_free_error_result(r);
     }
 
     std::string Collection::getSpecifications(const std::string& index, const std::string& collection, query_options *options) Kuz_Throw_KuzzleException {
@@ -129,10 +129,10 @@ namespace kuzzleio {
     }
 
     void Collection::deleteSpecifications(const std::string& index, const std::string& collection, query_options *options) Kuz_Throw_KuzzleException {
-        void_result *r = kuzzle_collection_delete_specifications(_collection, const_cast<char*>(index.c_str()), const_cast<char*>(collection.c_str()), options);
+        error_result *r = kuzzle_collection_delete_specifications(_collection, const_cast<char*>(index.c_str()), const_cast<char*>(collection.c_str()), options);
         if (r != NULL)
             throwExceptionFromStatus(r);
 
-        kuzzle_free_void_result(r);
+        kuzzle_free_error_result(r);
     }
 }

--- a/internal/wrappers/cpp/index.cpp
+++ b/internal/wrappers/cpp/index.cpp
@@ -34,17 +34,17 @@ namespace kuzzleio {
     }
 
     void Index::create(const std::string& index, query_options *options) Kuz_Throw_KuzzleException {
-        void_result *r = kuzzle_index_create(_index, const_cast<char*>(index.c_str()), options);
+        error_result *r = kuzzle_index_create(_index, const_cast<char*>(index.c_str()), options);
         if (r != NULL)
             throwExceptionFromStatus(r);
-        kuzzle_free_void_result(r);
+        kuzzle_free_error_result(r);
     }
 
     void Index::delete_(const std::string& index, query_options *options) Kuz_Throw_KuzzleException {
-        void_result *r = kuzzle_index_delete(_index, const_cast<char*>(index.c_str()), options);
+        error_result *r = kuzzle_index_delete(_index, const_cast<char*>(index.c_str()), options);
         if (r != NULL)
             throwExceptionFromStatus(r);
-        kuzzle_free_void_result(r);
+        kuzzle_free_error_result(r);
     }
 
     std::vector<std::string> Index::mDelete(const std::vector<std::string>& indexes, query_options *options) Kuz_Throw_KuzzleException {
@@ -78,24 +78,24 @@ namespace kuzzleio {
     }
 
     void Index::refresh(const std::string& index, query_options *options) Kuz_Throw_KuzzleException {
-        void_result *r = kuzzle_index_refresh(_index, const_cast<char*>(index.c_str()), options);
+        error_result *r = kuzzle_index_refresh(_index, const_cast<char*>(index.c_str()), options);
         if (r != NULL)
             throwExceptionFromStatus(r);
-        kuzzle_free_void_result(r);
+        kuzzle_free_error_result(r);
     }
 
     void Index::refreshInternal(query_options *options) Kuz_Throw_KuzzleException {
-        void_result *r = kuzzle_index_refresh_internal(_index, options);
+        error_result *r = kuzzle_index_refresh_internal(_index, options);
         if (r != NULL)
             throwExceptionFromStatus(r);
-        kuzzle_free_void_result(r);
+        kuzzle_free_error_result(r);
     }
 
     void Index::setAutoRefresh(const std::string& index, bool autoRefresh, query_options *options) Kuz_Throw_KuzzleException {
-      void_result *r = kuzzle_index_set_auto_refresh(_index, const_cast<char*>(index.c_str()), autoRefresh, options);
+      error_result *r = kuzzle_index_set_auto_refresh(_index, const_cast<char*>(index.c_str()), autoRefresh, options);
       if (r != NULL)
           throwExceptionFromStatus(r);
-        kuzzle_free_void_result(r);
+        kuzzle_free_error_result(r);
     }
 
     bool Index::getAutoRefresh(const std::string& index, query_options *options) Kuz_Throw_KuzzleException {

--- a/internal/wrappers/cpp/realtime.cpp
+++ b/internal/wrappers/cpp/realtime.cpp
@@ -34,12 +34,12 @@ namespace kuzzleio {
   }
 
   void Realtime::join(const std::string& index, const std::string collection, const std::string roomId, room_options* options, NotificationListener* cb) Kuz_Throw_KuzzleException {
-    void_result *r = kuzzle_realtime_join(_realtime, const_cast<char*>(index.c_str()), const_cast<char*>(collection.c_str()), const_cast<char*>(roomId.c_str()), options, call_subscribe_cb, this);
+    error_result *r = kuzzle_realtime_join(_realtime, const_cast<char*>(index.c_str()), const_cast<char*>(collection.c_str()), const_cast<char*>(roomId.c_str()), options, call_subscribe_cb, this);
     if (r != NULL)
         throwExceptionFromStatus(r);
 
     _listener_instances[roomId] = cb;
-    kuzzle_free_void_result(r);
+    kuzzle_free_error_result(r);
   }
 
   std::string Realtime::list(const std::string& index, const std::string collection) Kuz_Throw_KuzzleException {
@@ -52,10 +52,10 @@ namespace kuzzleio {
   }
 
   void Realtime::publish(const std::string& index, const std::string collection, const std::string body) Kuz_Throw_KuzzleException {
-    void_result *r = kuzzle_realtime_publish(_realtime, const_cast<char*>(index.c_str()), const_cast<char*>(collection.c_str()), const_cast<char*>(body.c_str()));
+    error_result *r = kuzzle_realtime_publish(_realtime, const_cast<char*>(index.c_str()), const_cast<char*>(collection.c_str()), const_cast<char*>(body.c_str()));
     if (r != NULL)
         throwExceptionFromStatus(r);
-    kuzzle_free_void_result(r);
+    kuzzle_free_error_result(r);
   }
 
   std::string Realtime::subscribe(const std::string& index, const std::string collection, const std::string body, NotificationListener* cb, room_options* options) Kuz_Throw_KuzzleException {
@@ -72,12 +72,12 @@ namespace kuzzleio {
   }
 
   void Realtime::unsubscribe(const std::string& roomId) Kuz_Throw_KuzzleException {
-    void_result *r = kuzzle_realtime_unsubscribe(_realtime, const_cast<char*>(roomId.c_str()));
+    error_result *r = kuzzle_realtime_unsubscribe(_realtime, const_cast<char*>(roomId.c_str()));
     if (r != NULL)
         throwExceptionFromStatus(r);
 
     _listener_instances[roomId] = NULL;
-    kuzzle_free_void_result(r);
+    kuzzle_free_error_result(r);
   }
 
   bool Realtime::validate(const std::string& index, const std::string collection, const std::string body) Kuz_Throw_KuzzleException {

--- a/internal/wrappers/headers/kuzzlesdk.h
+++ b/internal/wrappers/headers/kuzzlesdk.h
@@ -443,11 +443,11 @@ typedef struct kuzzle_response {
 } kuzzle_response;
 
 //any void result
-typedef struct void_result {
+typedef struct error_result {
     int status;
     char *error;
     char *stack;
-} void_result;
+} error_result;
 
 //any json result
 typedef struct json_result {


### PR DESCRIPTION
## What does this PR do ?

fix #148 

Rename `void_result` to `error_result` as it is weird to have a struct named void_result which contains something (errors). 
The error_result will be null if no errors are received otherwise it will be allocated and contain the status, error and stack.

### How should this be manually tested?

See travis report.