### PR TITLE
Remove pointer type on KuzzleError

### DIFF
--- a/auth/checkToken.go
+++ b/auth/checkToken.go
@@ -48,7 +48,7 @@ func (a *Auth) CheckToken(token string) (*TokenValidity, error) {
 
 	res := <-result
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return nil, res.Error
 	}
 

--- a/auth/checkToken_test.go
+++ b/auth/checkToken_test.go
@@ -11,7 +11,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
 package auth_test
 
 import (
@@ -42,7 +41,7 @@ func TestCheckTokenQueryError(t *testing.T) {
 	k, _ := kuzzle.NewKuzzle(c, nil)
 	_, err := k.Auth.CheckToken("token")
 	assert.NotNil(t, err)
-	assert.Equal(t, 123, err.(*types.KuzzleError).Status)
+	assert.Equal(t, 123, err.(types.KuzzleError).Status)
 }
 
 func TestCheckToken(t *testing.T) {

--- a/auth/createMyCredentials.go
+++ b/auth/createMyCredentials.go
@@ -37,7 +37,7 @@ func (a *Auth) CreateMyCredentials(strategy string, credentials json.RawMessage,
 
 	res := <-result
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return nil, res.Error
 	}
 

--- a/auth/createMyCredentials_test.go
+++ b/auth/createMyCredentials_test.go
@@ -33,7 +33,7 @@ func TestCreateMyCredentialsQueryError(t *testing.T) {
 			json.Unmarshal(query, &request)
 			assert.Equal(t, "auth", request.Controller)
 			assert.Equal(t, "createMyCredentials", request.Action)
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)
@@ -44,7 +44,7 @@ func TestCreateMyCredentialsQueryError(t *testing.T) {
 func TestCreateMyCredentialsEmptyStrategy(t *testing.T) {
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "unit test error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "unit test error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/auth/credentialsExist.go
+++ b/auth/credentialsExist.go
@@ -36,7 +36,7 @@ func (a *Auth) CredentialsExist(strategy string, options types.QueryOptions) (bo
 
 	res := <-result
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return false, res.Error
 	}
 

--- a/auth/credentialsExist_test.go
+++ b/auth/credentialsExist_test.go
@@ -41,7 +41,7 @@ func TestCredentialsExistQueryError(t *testing.T) {
 			assert.Equal(t, "auth", request.Controller)
 			assert.Equal(t, "credentialsExist", request.Action)
 
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/auth/deleteMyCredentials.go
+++ b/auth/deleteMyCredentials.go
@@ -39,5 +39,9 @@ func (a *Auth) DeleteMyCredentials(strategy string, options types.QueryOptions) 
 
 	res := <-result
 
-	return res.Error
+	if res.Error.Error() != "" {
+		return res.Error
+	}
+
+	return nil
 }

--- a/auth/deleteMyCredentials_test.go
+++ b/auth/deleteMyCredentials_test.go
@@ -33,7 +33,7 @@ func TestDeleteMyCredentialsQueryError(t *testing.T) {
 			json.Unmarshal(query, &request)
 			assert.Equal(t, "auth", request.Controller)
 			assert.Equal(t, "deleteMyCredentials", request.Action)
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)
@@ -44,7 +44,7 @@ func TestDeleteMyCredentialsQueryError(t *testing.T) {
 func TestDeleteMyCredentialsEmptyStrategy(t *testing.T) {
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "unit test error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "unit test error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/auth/getCurrentUser.go
+++ b/auth/getCurrentUser.go
@@ -34,7 +34,7 @@ func (a *Auth) GetCurrentUser() (*security.User, error) {
 
 	res := <-result
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return nil, res.Error
 	}
 

--- a/auth/getCurrentUser_test.go
+++ b/auth/getCurrentUser_test.go
@@ -34,7 +34,7 @@ func TestGetCurrentUserQueryError(t *testing.T) {
 			json.Unmarshal(query, &request)
 			assert.Equal(t, "auth", request.Controller)
 			assert.Equal(t, "getCurrentUser", request.Action)
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/auth/getMyCredentials.go
+++ b/auth/getMyCredentials.go
@@ -37,7 +37,7 @@ func (a *Auth) GetMyCredentials(strategy string, options types.QueryOptions) (js
 
 	res := <-result
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return nil, res.Error
 	}
 

--- a/auth/getMyCredentials.go
+++ b/auth/getMyCredentials.go
@@ -40,6 +40,5 @@ func (a *Auth) GetMyCredentials(strategy string, options types.QueryOptions) (js
 	if res.Error.Error() != "" {
 		return nil, res.Error
 	}
-
 	return res.Result, nil
 }

--- a/auth/getMyCredentials_test.go
+++ b/auth/getMyCredentials_test.go
@@ -34,7 +34,7 @@ func TestGetMyCredentialsQueryError(t *testing.T) {
 			assert.Equal(t, "auth", request.Controller)
 			assert.Equal(t, "getMyCredentials", request.Action)
 			assert.Equal(t, "local", request.Strategy)
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/auth/getMyRights.go
+++ b/auth/getMyRights.go
@@ -37,7 +37,7 @@ func (a *Auth) GetMyRights(options types.QueryOptions) ([]*types.UserRights, err
 
 	res := <-result
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return nil, res.Error
 	}
 

--- a/auth/getMyRights_test.go
+++ b/auth/getMyRights_test.go
@@ -34,7 +34,7 @@ func TestGetMyRightsQueryError(t *testing.T) {
 			json.Unmarshal(query, &request)
 			assert.Equal(t, "auth", request.Controller)
 			assert.Equal(t, "getMyRights", request.Action)
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/auth/getStrategies.go
+++ b/auth/getStrategies.go
@@ -32,7 +32,7 @@ func (a *Auth) GetStrategies(options types.QueryOptions) ([]string, error) {
 
 	res := <-ch
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return nil, res.Error
 	}
 

--- a/auth/getStrategies_test.go
+++ b/auth/getStrategies_test.go
@@ -33,7 +33,7 @@ func TestGetStrategiesError(t *testing.T) {
 			json.Unmarshal(query, &request)
 			assert.Equal(t, "auth", request.Controller)
 			assert.Equal(t, "getStrategies", request.Action)
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/auth/login.go
+++ b/auth/login.go
@@ -58,7 +58,7 @@ func (a *Auth) Login(strategy string, credentials json.RawMessage, expiresIn *in
 
 	json.Unmarshal(res.Result, &token)
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		a.kuzzle.EmitEvent(event.LoginAttempt, &types.LoginAttempt{Success: false, Error: res.Error})
 		return "", res.Error
 	}

--- a/auth/login_test.go
+++ b/auth/login_test.go
@@ -41,7 +41,7 @@ func TestLoginError(t *testing.T) {
 
 			assert.Equal(t, "auth", request.Controller)
 			assert.Equal(t, "login", request.Action)
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "error"}}
 		},
 		MockEmitEvent: func(e int, arg interface{}) {
 			assert.Equal(t, event.LoginAttempt, e)

--- a/auth/logout.go
+++ b/auth/logout.go
@@ -30,7 +30,7 @@ func (a *Auth) Logout() error {
 
 	res := <-result
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return res.Error
 	}
 

--- a/auth/logout_test.go
+++ b/auth/logout_test.go
@@ -34,7 +34,7 @@ func TestLogoutError(t *testing.T) {
 
 			assert.Equal(t, "auth", request.Controller)
 			assert.Equal(t, "logout", request.Action)
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "error"}}
 		},
 	}
 

--- a/auth/update_my_credentials.go
+++ b/auth/update_my_credentials.go
@@ -38,7 +38,7 @@ func (a *Auth) UpdateMyCredentials(strategy string, credentials json.RawMessage,
 
 	res := <-result
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return nil, res.Error
 	}
 

--- a/auth/update_my_credentials_test.go
+++ b/auth/update_my_credentials_test.go
@@ -33,7 +33,7 @@ func TestUpdateMyCredentialsQueryError(t *testing.T) {
 			json.Unmarshal(query, &request)
 			assert.Equal(t, "auth", request.Controller)
 			assert.Equal(t, "updateMyCredentials", request.Action)
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)
@@ -44,7 +44,7 @@ func TestUpdateMyCredentialsQueryError(t *testing.T) {
 func TestUpdateMyCredentialsEmptyStrategy(t *testing.T) {
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "unit test error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "Unit test error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/auth/update_self.go
+++ b/auth/update_self.go
@@ -38,7 +38,7 @@ func (a *Auth) UpdateSelf(data json.RawMessage, options types.QueryOptions) (*se
 
 	res := <-ch
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return nil, res.Error
 	}
 

--- a/auth/update_self_test.go
+++ b/auth/update_self_test.go
@@ -29,7 +29,7 @@ import (
 func TestUpdateSelfQueryError(t *testing.T) {
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/auth/validate_my_credentials.go
+++ b/auth/validate_my_credentials.go
@@ -35,7 +35,7 @@ func (a *Auth) ValidateMyCredentials(strategy string, credentials json.RawMessag
 
 	res := <-result
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return false, res.Error
 	}
 

--- a/auth/validate_my_credentials_test.go
+++ b/auth/validate_my_credentials_test.go
@@ -34,7 +34,7 @@ func TestValidateMyCredentialsQueryError(t *testing.T) {
 			assert.Equal(t, "auth", request.Controller)
 			assert.Equal(t, "validateMyCredentials", request.Action)
 			assert.Equal(t, "local", request.Strategy)
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/collection/create.go
+++ b/collection/create.go
@@ -40,5 +40,9 @@ func (dc *Collection) Create(index string, collection string, options types.Quer
 
 	res := <-ch
 
+	if res.Error.Error() == "" {
+		return nil
+	}
+
 	return res.Error
 }

--- a/collection/create_test.go
+++ b/collection/create_test.go
@@ -50,7 +50,7 @@ func TestCreateError(t *testing.T) {
 	nc := collection.NewCollection(k)
 	err := nc.Create("index", "collection", nil)
 	assert.NotNil(t, err)
-	assert.Equal(t, "Unit test error", err.(*types.KuzzleError).Message)
+	assert.Equal(t, "Unit test error", err.(types.KuzzleError).Message)
 }
 
 func TestCreate(t *testing.T) {

--- a/collection/delete_specifications.go
+++ b/collection/delete_specifications.go
@@ -38,7 +38,7 @@ func (dc *Collection) DeleteSpecifications(index string, collection string, opti
 
 	res := <-ch
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return res.Error
 	}
 

--- a/collection/delete_specifications_test.go
+++ b/collection/delete_specifications_test.go
@@ -50,7 +50,7 @@ func TestDeleteSpecificationsError(t *testing.T) {
 	nc := collection.NewCollection(k)
 	err := nc.DeleteSpecifications("index", "collection", nil)
 	assert.NotNil(t, err)
-	assert.Equal(t, "Unit test error", err.(*types.KuzzleError).Message)
+	assert.Equal(t, "Unit test error", err.(types.KuzzleError).Message)
 }
 
 func TestDeleteSpecifications(t *testing.T) {

--- a/collection/exists.go
+++ b/collection/exists.go
@@ -43,7 +43,7 @@ func (dc *Collection) Exists(index string, collection string, options types.Quer
 
 	res := <-ch
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return false, res.Error
 	}
 

--- a/collection/exists_test.go
+++ b/collection/exists_test.go
@@ -50,7 +50,7 @@ func TestExistsError(t *testing.T) {
 	nc := collection.NewCollection(k)
 	_, err := nc.Exists("index", "collection", nil)
 	assert.NotNil(t, err)
-	assert.Equal(t, "Unit test error", err.(*types.KuzzleError).Message)
+	assert.Equal(t, "Unit test error", err.(types.KuzzleError).Message)
 }
 
 func TestExists(t *testing.T) {

--- a/collection/get_mapping.go
+++ b/collection/get_mapping.go
@@ -42,7 +42,7 @@ func (dc *Collection) GetMapping(index string, collection string, options types.
 
 	res := <-ch
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return nil, res.Error
 	}
 

--- a/collection/get_mapping_test.go
+++ b/collection/get_mapping_test.go
@@ -51,7 +51,7 @@ func TestGetMappingError(t *testing.T) {
 	nc := collection.NewCollection(k)
 	_, err := nc.GetMapping("index", "collection", nil)
 	assert.NotNil(t, err)
-	assert.Equal(t, "Unit test error", err.(*types.KuzzleError).Message)
+	assert.Equal(t, "Unit test error", err.(types.KuzzleError).Message)
 }
 
 func TestGetMapping(t *testing.T) {

--- a/collection/get_specifications.go
+++ b/collection/get_specifications.go
@@ -42,7 +42,7 @@ func (dc *Collection) GetSpecifications(index string, collection string, options
 
 	res := <-ch
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return nil, res.Error
 	}
 

--- a/collection/get_specifications_test.go
+++ b/collection/get_specifications_test.go
@@ -51,7 +51,7 @@ func TestGetSpecificationsError(t *testing.T) {
 	nc := collection.NewCollection(k)
 	_, err := nc.GetSpecifications("index", "collection", nil)
 	assert.NotNil(t, err)
-	assert.Equal(t, "Unit test error", err.(*types.KuzzleError).Message)
+	assert.Equal(t, "Unit test error", err.(types.KuzzleError).Message)
 }
 
 func TestGetSpecifications(t *testing.T) {

--- a/collection/list.go
+++ b/collection/list.go
@@ -38,7 +38,7 @@ func (dc *Collection) List(index string, options types.QueryOptions) (json.RawMe
 
 	res := <-result
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return nil, res.Error
 	}
 

--- a/collection/list_test.go
+++ b/collection/list_test.go
@@ -46,7 +46,7 @@ func TestListError(t *testing.T) {
 
 	_, err := nc.List("index", nil)
 	assert.NotNil(t, err)
-	assert.Equal(t, "Unit test error", err.(*types.KuzzleError).Message)
+	assert.Equal(t, "Unit test error", err.(types.KuzzleError).Message)
 }
 
 func TestList(t *testing.T) {

--- a/collection/search_specifications.go
+++ b/collection/search_specifications.go
@@ -33,7 +33,7 @@ func (dc *Collection) SearchSpecifications(options types.QueryOptions) (*types.S
 
 	res := <-ch
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return nil, res.Error
 	}
 

--- a/collection/search_specifications_test.go
+++ b/collection/search_specifications_test.go
@@ -29,7 +29,7 @@ import (
 func TestSearchSpecificationsError(t *testing.T) {
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "Unit test error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "Unit test error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/collection/truncate.go
+++ b/collection/truncate.go
@@ -40,7 +40,7 @@ func (dc *Collection) Truncate(index string, collection string, options types.Qu
 
 	res := <-ch
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return res.Error
 	}
 

--- a/collection/truncate_test.go
+++ b/collection/truncate_test.go
@@ -44,7 +44,7 @@ func TestTruncateCollectionNull(t *testing.T) {
 func TestTruncateError(t *testing.T) {
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "Unit test error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "Unit test error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/collection/update_mapping.go
+++ b/collection/update_mapping.go
@@ -47,7 +47,7 @@ func (dc *Collection) UpdateMapping(index string, collection string, body json.R
 
 	res := <-ch
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return res.Error
 	}
 

--- a/collection/update_mapping_test.go
+++ b/collection/update_mapping_test.go
@@ -52,7 +52,7 @@ func TestUpdateMappingBodyNull(t *testing.T) {
 func TestUpdateMappingError(t *testing.T) {
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "Unit test error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "Unit test error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/collection/update_specifications.go
+++ b/collection/update_specifications.go
@@ -47,7 +47,7 @@ func (dc *Collection) UpdateSpecifications(index string, collection string, body
 
 	res := <-ch
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return nil, res.Error
 	}
 

--- a/collection/update_specifications_test.go
+++ b/collection/update_specifications_test.go
@@ -50,7 +50,7 @@ func TestUpdateSpecificationsBodyNull(t *testing.T) {
 func TestUpdateSpecificationsError(t *testing.T) {
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "Unit test error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "Unit test error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/collection/validate_specifications.go
+++ b/collection/validate_specifications.go
@@ -38,7 +38,7 @@ func (dc *Collection) ValidateSpecifications(body json.RawMessage, options types
 
 	res := <-ch
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return false, res.Error
 	}
 

--- a/collection/validate_specifications_test.go
+++ b/collection/validate_specifications_test.go
@@ -38,7 +38,7 @@ func TestValidateSpecificationsBodyNull(t *testing.T) {
 func TestValidateSpecificationsError(t *testing.T) {
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "Unit test error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "Unit test error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/connection/websocket/web_socket.go
+++ b/connection/websocket/web_socket.go
@@ -348,7 +348,7 @@ func (ws *webSocket) listen() {
 			}
 
 		} else if c, found := ws.channelsResult.Load(message.RequestId); found {
-			if message.Error != nil && message.Error.Message == "Token expired" {
+			if message.Error.Error() != "" && message.Error.Message == "Token expired" {
 				ws.EmitEvent(event.TokenExpired, nil)
 			}
 

--- a/document/count.go
+++ b/document/count.go
@@ -51,7 +51,7 @@ func (d *Document) Count(index string, collection string, body json.RawMessage, 
 
 	res := <-ch
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return 0, res.Error
 	}
 

--- a/document/count_test.go
+++ b/document/count_test.go
@@ -56,7 +56,7 @@ func TestCountDocumentError(t *testing.T) {
 	d := document.NewDocument(k)
 	_, err := d.Count("index", "collection", json.RawMessage(`{"foo":"bar"}`), nil)
 	assert.NotNil(t, err)
-	assert.Equal(t, "Unit test error", err.(*types.KuzzleError).Message)
+	assert.Equal(t, "Unit test error", err.(types.KuzzleError).Message)
 }
 
 func TestCountDocument(t *testing.T) {

--- a/document/create.go
+++ b/document/create.go
@@ -56,7 +56,7 @@ func (d *Document) Create(index string, collection string, id string, body json.
 
 	res := <-ch
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return "", res.Error
 	}
 

--- a/document/createOrReplace.go
+++ b/document/createOrReplace.go
@@ -60,7 +60,7 @@ func (d *Document) CreateOrReplace(index string, collection string, _id string, 
 
 	res := <-ch
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return "", res.Error
 	}
 

--- a/document/createOrReplace_test.go
+++ b/document/createOrReplace_test.go
@@ -63,7 +63,7 @@ func TestCreateOrReplaceDocumentError(t *testing.T) {
 	d := document.NewDocument(k)
 	_, err := d.CreateOrReplace("index", "collection", "id1", json.RawMessage(`{"foo":"bar"}`), nil)
 	assert.NotNil(t, err)
-	assert.Equal(t, "Unit test error", err.(*types.KuzzleError).Message)
+	assert.Equal(t, "Unit test error", err.(types.KuzzleError).Message)
 }
 
 func TestCreateOrReplaceDocument(t *testing.T) {

--- a/document/create_test.go
+++ b/document/create_test.go
@@ -56,7 +56,7 @@ func TestCreateDocumentError(t *testing.T) {
 	d := document.NewDocument(k)
 	_, err := d.Create("index", "collection", "id1", json.RawMessage(`{"foo":"bar"}`), nil)
 	assert.NotNil(t, err)
-	assert.Equal(t, "Unit test error", err.(*types.KuzzleError).Message)
+	assert.Equal(t, "Unit test error", err.(types.KuzzleError).Message)
 }
 
 func TestCreateDocument(t *testing.T) {

--- a/document/delete.go
+++ b/document/delete.go
@@ -48,7 +48,7 @@ func (d *Document) Delete(index string, collection string, _id string, options t
 
 	res := <-ch
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return "", res.Error
 	}
 

--- a/document/deleteByQuery.go
+++ b/document/deleteByQuery.go
@@ -48,7 +48,7 @@ func (d *Document) DeleteByQuery(index string, collection string, body string, o
 
 	res := <-ch
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return nil, res.Error
 	}
 

--- a/document/deleteByQuery_test.go
+++ b/document/deleteByQuery_test.go
@@ -60,7 +60,7 @@ func TestDeleteByQueryDocumentError(t *testing.T) {
 
 	_, err := d.DeleteByQuery("index", "collection", "body", nil)
 	assert.NotNil(t, err)
-	assert.Equal(t, "Unit test error", err.(*types.KuzzleError).Message)
+	assert.Equal(t, "Unit test error", err.(types.KuzzleError).Message)
 }
 
 func TestDeleteByQueryDocument(t *testing.T) {

--- a/document/delete_test.go
+++ b/document/delete_test.go
@@ -56,7 +56,7 @@ func TestDeleteDocumentError(t *testing.T) {
 	d := document.NewDocument(k)
 	_, err := d.Delete("index", "collection", "id1", nil)
 	assert.NotNil(t, err)
-	assert.Equal(t, "Unit test error", err.(*types.KuzzleError).Message)
+	assert.Equal(t, "Unit test error", err.(types.KuzzleError).Message)
 }
 
 func TestDeleteDocument(t *testing.T) {

--- a/document/exists.go
+++ b/document/exists.go
@@ -48,7 +48,7 @@ func (d *Document) Exists(index string, collection string, _id string, options t
 
 	res := <-ch
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return false, res.Error
 	}
 

--- a/document/exists_test.go
+++ b/document/exists_test.go
@@ -56,7 +56,7 @@ func TestExistsDocumentError(t *testing.T) {
 	d := document.NewDocument(k)
 	_, err := d.Exists("index", "collection", "id1", nil)
 	assert.NotNil(t, err)
-	assert.Equal(t, "Unit test error", err.(*types.KuzzleError).Message)
+	assert.Equal(t, "Unit test error", err.(types.KuzzleError).Message)
 }
 
 func TestExistsDocument(t *testing.T) {

--- a/document/get.go
+++ b/document/get.go
@@ -48,7 +48,7 @@ func (d *Document) Get(index string, collection string, _id string, options type
 
 	res := <-ch
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return "", res.Error
 	}
 

--- a/document/get_test.go
+++ b/document/get_test.go
@@ -56,7 +56,7 @@ func TestGetDocumentError(t *testing.T) {
 	d := document.NewDocument(k)
 	_, err := d.Get("index", "collection", "id1", nil)
 	assert.NotNil(t, err)
-	assert.Equal(t, "Unit test error", err.(*types.KuzzleError).Message)
+	assert.Equal(t, "Unit test error", err.(types.KuzzleError).Message)
 }
 
 func TestGetDocument(t *testing.T) {

--- a/document/mCreate.go
+++ b/document/mCreate.go
@@ -48,7 +48,7 @@ func (d *Document) MCreate(index string, collection string, body json.RawMessage
 
 	res := <-ch
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return "", res.Error
 	}
 

--- a/document/mCreateOrReplace.go
+++ b/document/mCreateOrReplace.go
@@ -48,7 +48,7 @@ func (d *Document) MCreateOrReplace(index string, collection string, body json.R
 
 	res := <-ch
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return "", res.Error
 	}
 

--- a/document/mCreateOrReplace_test.go
+++ b/document/mCreateOrReplace_test.go
@@ -60,7 +60,7 @@ func TestMCreateOrReplaceDocumentError(t *testing.T) {
 
 	_, err := d.MCreateOrReplace("index", "collection", json.RawMessage(`{"foo":"bar"}`), nil)
 	assert.NotNil(t, err)
-	assert.Equal(t, "Unit test error", err.(*types.KuzzleError).Message)
+	assert.Equal(t, "Unit test error", err.(types.KuzzleError).Message)
 }
 
 func TestMCreateOrReplaceDocument(t *testing.T) {

--- a/document/mCreate_test.go
+++ b/document/mCreate_test.go
@@ -60,7 +60,7 @@ func TestMCreateDocumentError(t *testing.T) {
 
 	_, err := d.MCreate("index", "collection", json.RawMessage(`{"foo":"bar"}`), nil)
 	assert.NotNil(t, err)
-	assert.Equal(t, "Unit test error", err.(*types.KuzzleError).Message)
+	assert.Equal(t, "Unit test error", err.(types.KuzzleError).Message)
 }
 
 func TestMCreateDocument(t *testing.T) {

--- a/document/mDelete.go
+++ b/document/mDelete.go
@@ -48,7 +48,7 @@ func (d *Document) MDelete(index string, collection string, ids []string, option
 
 	res := <-ch
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return nil, res.Error
 	}
 

--- a/document/mDelete_test.go
+++ b/document/mDelete_test.go
@@ -67,7 +67,7 @@ func TestMDeleteDocumentError(t *testing.T) {
 	ids = append(ids, "id1")
 	_, err := d.MDelete("index", "collection", ids, nil)
 	assert.NotNil(t, err)
-	assert.Equal(t, "Unit test error", err.(*types.KuzzleError).Message)
+	assert.Equal(t, "Unit test error", err.(types.KuzzleError).Message)
 }
 
 func TestMDeleteDocument(t *testing.T) {

--- a/document/mGet.go
+++ b/document/mGet.go
@@ -53,7 +53,7 @@ func (d *Document) MGet(index string, collection string, ids []string, includeTr
 
 	res := <-ch
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return "", res.Error
 	}
 

--- a/document/mGet_test.go
+++ b/document/mGet_test.go
@@ -63,7 +63,7 @@ func TestMGetDocumentError(t *testing.T) {
 	ids = append(ids, "id1")
 	_, err := d.MGet("index", "collection", ids, true, nil)
 	assert.NotNil(t, err)
-	assert.Equal(t, "Unit test error", err.(*types.KuzzleError).Message)
+	assert.Equal(t, "Unit test error", err.(types.KuzzleError).Message)
 }
 
 func TestMGetDocument(t *testing.T) {

--- a/document/mReplace.go
+++ b/document/mReplace.go
@@ -48,7 +48,7 @@ func (d *Document) MReplace(index string, collection string, body json.RawMessag
 
 	res := <-ch
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return "", res.Error
 	}
 

--- a/document/mReplace_test.go
+++ b/document/mReplace_test.go
@@ -60,7 +60,7 @@ func TestMReplaceDocumentError(t *testing.T) {
 
 	_, err := d.MReplace("index", "collection", json.RawMessage(`{"foo":"bar"}`), nil)
 	assert.NotNil(t, err)
-	assert.Equal(t, "Unit test error", err.(*types.KuzzleError).Message)
+	assert.Equal(t, "Unit test error", err.(types.KuzzleError).Message)
 }
 
 func TestMReplaceDocument(t *testing.T) {

--- a/document/mUpdate.go
+++ b/document/mUpdate.go
@@ -48,7 +48,7 @@ func (d *Document) MUpdate(index string, collection string, body json.RawMessage
 
 	res := <-ch
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return "", res.Error
 	}
 

--- a/document/mUpdate_test.go
+++ b/document/mUpdate_test.go
@@ -60,7 +60,7 @@ func TestMUpdateDocumentError(t *testing.T) {
 
 	_, err := d.MUpdate("index", "collection", json.RawMessage(`{"foo":"bar"}`), nil)
 	assert.NotNil(t, err)
-	assert.Equal(t, "Unit test error", err.(*types.KuzzleError).Message)
+	assert.Equal(t, "Unit test error", err.(types.KuzzleError).Message)
 }
 
 func TestMUpdateDocument(t *testing.T) {

--- a/document/replace.go
+++ b/document/replace.go
@@ -53,7 +53,7 @@ func (d *Document) Replace(index string, collection string, _id string, body jso
 
 	res := <-ch
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return "", res.Error
 	}
 

--- a/document/replace_test.go
+++ b/document/replace_test.go
@@ -68,7 +68,7 @@ func TestReplaceDocumentError(t *testing.T) {
 
 	_, err := d.Replace("index", "collection", "id1", json.RawMessage(`{"foo":"bar"}`), nil)
 	assert.NotNil(t, err)
-	assert.Equal(t, "Unit test error", err.(*types.KuzzleError).Message)
+	assert.Equal(t, "Unit test error", err.(types.KuzzleError).Message)
 }
 
 func TestReplaceDocument(t *testing.T) {

--- a/document/search.go
+++ b/document/search.go
@@ -48,7 +48,7 @@ func (d *Document) Search(index string, collection string, body json.RawMessage,
 
 	res := <-ch
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return nil, res.Error
 	}
 

--- a/document/search_test.go
+++ b/document/search_test.go
@@ -60,7 +60,7 @@ func TestSearchDocumentError(t *testing.T) {
 
 	_, err := d.Search("index", "collection", json.RawMessage(`{"foo":"bar"}`), nil)
 	assert.NotNil(t, err)
-	assert.Equal(t, "Unit test error", err.(*types.KuzzleError).Message)
+	assert.Equal(t, "Unit test error", err.(types.KuzzleError).Message)
 }
 
 func TestSearchDocument(t *testing.T) {

--- a/document/update.go
+++ b/document/update.go
@@ -53,7 +53,7 @@ func (d *Document) Update(index string, collection string, id string, body json.
 
 	res := <-ch
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return "", res.Error
 	}
 

--- a/document/update_test.go
+++ b/document/update_test.go
@@ -68,7 +68,7 @@ func TestUpdateDocumentError(t *testing.T) {
 
 	_, err := d.Update("index", "collection", "id1", json.RawMessage(`{"foo":"bar"}`), nil)
 	assert.NotNil(t, err)
-	assert.Equal(t, "Unit test error", err.(*types.KuzzleError).Message)
+	assert.Equal(t, "Unit test error", err.(types.KuzzleError).Message)
 }
 
 func TestUpdateDocument(t *testing.T) {

--- a/document/validate.go
+++ b/document/validate.go
@@ -48,7 +48,7 @@ func (d *Document) Validate(index string, collection string, body json.RawMessag
 
 	res := <-ch
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return false, res.Error
 	}
 

--- a/document/validate_test.go
+++ b/document/validate_test.go
@@ -56,7 +56,7 @@ func TestValidateDocumentError(t *testing.T) {
 	d := document.NewDocument(k)
 	_, err := d.Validate("index", "collection", json.RawMessage(`{"foo":"bar"}`), nil)
 	assert.NotNil(t, err)
-	assert.Equal(t, "Unit test error", err.(*types.KuzzleError).Message)
+	assert.Equal(t, "Unit test error", err.(types.KuzzleError).Message)
 }
 
 func TestValidateDocument(t *testing.T) {

--- a/index/create.go
+++ b/index/create.go
@@ -35,7 +35,7 @@ func (i *Index) Create(index string, options types.QueryOptions) error {
 
 	res := <-result
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return res.Error
 	}
 

--- a/index/create_test.go
+++ b/index/create_test.go
@@ -37,7 +37,7 @@ func TestCreateNull(t *testing.T) {
 func TestCreateQueryError(t *testing.T) {
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/index/delete.go
+++ b/index/delete.go
@@ -33,7 +33,7 @@ func (i *Index) Delete(index string, options types.QueryOptions) error {
 
 	res := <-result
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return res.Error
 	}
 

--- a/index/delete_test.go
+++ b/index/delete_test.go
@@ -37,7 +37,7 @@ func TestDeleteNull(t *testing.T) {
 func TestDeleteQueryError(t *testing.T) {
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/index/exists.go
+++ b/index/exists.go
@@ -39,7 +39,7 @@ func (i *Index) Exists(index string, options types.QueryOptions) (bool, error) {
 
 	res := <-result
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return false, res.Error
 	}
 

--- a/index/exists_test.go
+++ b/index/exists_test.go
@@ -37,7 +37,7 @@ func TestExistsNull(t *testing.T) {
 func TestExistsQueryError(t *testing.T) {
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/index/getAutoRefresh.go
+++ b/index/getAutoRefresh.go
@@ -39,7 +39,7 @@ func (i *Index) GetAutoRefresh(index string, options types.QueryOptions) (bool, 
 
 	res := <-result
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return false, res.Error
 	}
 

--- a/index/getAutoRefresh_test.go
+++ b/index/getAutoRefresh_test.go
@@ -37,7 +37,7 @@ func TestGetAutoRefreshNull(t *testing.T) {
 func TestGetAutoRefreshQueryError(t *testing.T) {
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/index/list.go
+++ b/index/list.go
@@ -34,7 +34,7 @@ func (i *Index) List(options types.QueryOptions) ([]string, error) {
 
 	res := <-result
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return nil, res.Error
 	}
 

--- a/index/list_test.go
+++ b/index/list_test.go
@@ -37,7 +37,7 @@ func TestListError(t *testing.T) {
 	i := index.NewIndex(k)
 	_, err := i.List(nil)
 	assert.NotNil(t, err)
-	assert.Equal(t, "Unit test error", err.(*types.KuzzleError).Message)
+	assert.Equal(t, "Unit test error", err.(types.KuzzleError).Message)
 }
 
 func TestList(t *testing.T) {

--- a/index/mDelete.go
+++ b/index/mDelete.go
@@ -38,7 +38,7 @@ func (i *Index) MDelete(indexes []string, options types.QueryOptions) ([]string,
 
 	res := <-result
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return nil, res.Error
 	}
 

--- a/index/mDelete_test.go
+++ b/index/mDelete_test.go
@@ -38,7 +38,7 @@ func TestMDeleteNull(t *testing.T) {
 func TestMDeleteQueryError(t *testing.T) {
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/index/refresh.go
+++ b/index/refresh.go
@@ -35,5 +35,8 @@ func (i *Index) Refresh(index string, options types.QueryOptions) error {
 
 	res := <-result
 
-	return res.Error
+	if res.Error.Error() != "" {
+		return res.Error
+	}
+	return nil
 }

--- a/index/refreshInternal.go
+++ b/index/refreshInternal.go
@@ -33,6 +33,5 @@ func (i *Index) RefreshInternal(options types.QueryOptions) error {
 	if res.Error.Error() != "" {
 		return res.Error
 	}
-
 	return nil
 }

--- a/index/refreshInternal.go
+++ b/index/refreshInternal.go
@@ -30,7 +30,7 @@ func (i *Index) RefreshInternal(options types.QueryOptions) error {
 
 	res := <-result
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return res.Error
 	}
 

--- a/index/refreshInternal_test.go
+++ b/index/refreshInternal_test.go
@@ -30,7 +30,7 @@ import (
 func TestRefreshInternalQueryError(t *testing.T) {
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)
@@ -68,7 +68,7 @@ func ExampleIndex_RefreshInternal() {
 	k, _ := kuzzle.NewKuzzle(conn, nil)
 	i := index.NewIndex(k)
 	err := i.RefreshInternal(nil)
-	if err != nil {
+	if err.Error() != "" {
 		fmt.Println(err.Error())
 		return
 	}

--- a/index/refresh_test.go
+++ b/index/refresh_test.go
@@ -37,7 +37,7 @@ func TestRefreshNull(t *testing.T) {
 func TestRefreshQueryError(t *testing.T) {
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)
@@ -77,7 +77,7 @@ func ExampleIndex_Refresh() {
 	i := index.NewIndex(k)
 	i.Create("index", nil)
 	err := i.Refresh("index", nil)
-	if err != nil {
+	if err.Error() != "" {
 		fmt.Println(err.Error())
 		return
 	}

--- a/index/setAutoRefresh.go
+++ b/index/setAutoRefresh.go
@@ -37,7 +37,7 @@ func (i *Index) SetAutoRefresh(index string, autoRefresh bool, options types.Que
 
 	res := <-result
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return res.Error
 	}
 

--- a/index/setAutoRefresh_test.go
+++ b/index/setAutoRefresh_test.go
@@ -37,7 +37,7 @@ func TestSetAutoRefreshNull(t *testing.T) {
 func TestSetAutoRefreshQueryError(t *testing.T) {
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/internal/wrappers/cgo/kuzzle/errors.go
+++ b/internal/wrappers/cgo/kuzzle/errors.go
@@ -174,7 +174,7 @@ func Set_room_result_error(s *C.room_result, err error) {
 }
 
 func setErr(status *C.int, error **C.char, stack **C.char, err error) {
-	kuzzleError := err.(*types.KuzzleError)
+	kuzzleError := err.(types.KuzzleError)
 	*status = C.int(kuzzleError.Status)
 	*error = C.CString(kuzzleError.Message)
 

--- a/internal/wrappers/cgo/kuzzle/go_to_c.go
+++ b/internal/wrappers/cgo/kuzzle/go_to_c.go
@@ -85,7 +85,7 @@ func goToCNotificationContent(gNotifContent *types.NotificationResult) *C.notifi
 func goToCNotificationResult(gNotif *types.KuzzleNotification) *C.notification_result {
 	result := (*C.notification_result)(C.calloc(1, C.sizeof_notification_result))
 
-	if gNotif.Error != nil {
+	if gNotif.Error.Error() != "" {
 		Set_notification_result_error(result, gNotif.Error)
 		return result
 	}
@@ -127,7 +127,7 @@ func goToCKuzzleResponse(gRes *types.KuzzleResponse) *C.kuzzle_response {
 	result.channel = C.CString(gRes.Channel)
 	result.status = C.int(gRes.Status)
 
-	if gRes.Error != nil {
+	if gRes.Error.Error() != "" {
 		// The error might be a partial error
 		Set_kuzzle_response_error(result, gRes.Error)
 	}

--- a/internal/wrappers/cgo/kuzzle/memory_storage.go
+++ b/internal/wrappers/cgo/kuzzle/memory_storage.go
@@ -197,7 +197,7 @@ func kuzzle_ms_geopos(k *C.kuzzle, key *C.char, members **C.char, mlen C.size_t,
 		SetQueryOptions(options))
 
 	if err != nil {
-		kuzzleError := err.(*types.KuzzleError)
+		kuzzleError := err.(types.KuzzleError)
 		result.status = C.int(kuzzleError.Status)
 		result.error = C.CString(kuzzleError.Message)
 

--- a/kuzzle/kuzzle_test.go
+++ b/kuzzle/kuzzle_test.go
@@ -119,7 +119,7 @@ func TestSetDefaultIndex(t *testing.T) {
 			request := types.KuzzleRequest{}
 			json.Unmarshal(query, &request)
 			assert.Equal(t, "myindex", request.Index)
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/ms/append.go
+++ b/ms/append.go
@@ -37,7 +37,7 @@ func (ms *Ms) Append(key string, value string, options types.QueryOptions) (int,
 
 	res := <-result
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return 0, res.Error
 	}
 	var returnedResult int

--- a/ms/append_test.go
+++ b/ms/append_test.go
@@ -28,7 +28,7 @@ import (
 func TestAppendError(t *testing.T) {
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "Unit test error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "Unit test error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/ms/bitcount.go
+++ b/ms/bitcount.go
@@ -43,7 +43,7 @@ func (ms *Ms) Bitcount(key string, options types.QueryOptions) (int, error) {
 
 	res := <-result
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return 0, res.Error
 	}
 	var returnedResult int

--- a/ms/bitcount_test.go
+++ b/ms/bitcount_test.go
@@ -28,7 +28,7 @@ import (
 func TestBitcountError(t *testing.T) {
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "Unit test error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "Unit test error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/ms/bitop.go
+++ b/ms/bitop.go
@@ -38,7 +38,7 @@ func (ms *Ms) Bitop(key string, operation string, keys []string, options types.Q
 
 	res := <-result
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return 0, res.Error
 	}
 	var returnedResult int

--- a/ms/bitop_test.go
+++ b/ms/bitop_test.go
@@ -28,7 +28,7 @@ import (
 func TestBitopError(t *testing.T) {
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "Unit test error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "Unit test error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/ms/bitpos.go
+++ b/ms/bitpos.go
@@ -44,7 +44,7 @@ func (ms *Ms) Bitpos(key string, bit int, options types.QueryOptions) (int, erro
 
 	res := <-result
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return 0, res.Error
 	}
 	var returnedResult int

--- a/ms/bitpos_test.go
+++ b/ms/bitpos_test.go
@@ -28,7 +28,7 @@ import (
 func TestBitposError(t *testing.T) {
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "Unit test error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "Unit test error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/ms/dbsize.go
+++ b/ms/dbsize.go
@@ -31,7 +31,7 @@ func (ms *Ms) Dbsize(options types.QueryOptions) (int, error) {
 
 	res := <-result
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return 0, res.Error
 	}
 	var returnedResult int

--- a/ms/dbsize_test.go
+++ b/ms/dbsize_test.go
@@ -28,7 +28,7 @@ import (
 func TestDbsizeError(t *testing.T) {
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "Unit test error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "Unit test error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/ms/decr.go
+++ b/ms/decr.go
@@ -33,7 +33,7 @@ func (ms *Ms) Decr(key string, options types.QueryOptions) (int, error) {
 
 	res := <-result
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return 0, res.Error
 	}
 	var returnedResult int

--- a/ms/decr_test.go
+++ b/ms/decr_test.go
@@ -28,7 +28,7 @@ import (
 func TestDecrError(t *testing.T) {
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "Unit test error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "Unit test error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/ms/decrby.go
+++ b/ms/decrby.go
@@ -38,7 +38,7 @@ func (ms *Ms) Decrby(key string, value int, options types.QueryOptions) (int, er
 
 	res := <-result
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return 0, res.Error
 	}
 	var returnedResult int

--- a/ms/decrby_test.go
+++ b/ms/decrby_test.go
@@ -28,7 +28,7 @@ import (
 func TestDecrbyError(t *testing.T) {
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "Unit test error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "Unit test error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/ms/del.go
+++ b/ms/del.go
@@ -41,7 +41,7 @@ func (ms *Ms) Del(keys []string, options types.QueryOptions) (int, error) {
 
 	res := <-result
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return 0, res.Error
 	}
 	var returnedResult int

--- a/ms/del_test.go
+++ b/ms/del_test.go
@@ -36,7 +36,7 @@ func TestDelEmptyList(t *testing.T) {
 func TestDelError(t *testing.T) {
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "Unit test error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "Unit test error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/ms/exists.go
+++ b/ms/exists.go
@@ -37,7 +37,7 @@ func (ms *Ms) Exists(keys []string, options types.QueryOptions) (int, error) {
 
 	res := <-result
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return 0, res.Error
 	}
 	var returnedResult int

--- a/ms/exists_test.go
+++ b/ms/exists_test.go
@@ -28,7 +28,7 @@ import (
 func TestExistsError(t *testing.T) {
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "Unit test error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "Unit test error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/ms/expire.go
+++ b/ms/expire.go
@@ -38,7 +38,7 @@ func (ms *Ms) Expire(key string, seconds int, options types.QueryOptions) (bool,
 
 	res := <-result
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return false, res.Error
 	}
 

--- a/ms/expire_test.go
+++ b/ms/expire_test.go
@@ -28,7 +28,7 @@ import (
 func TestExpireError(t *testing.T) {
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "Unit test error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "Unit test error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/ms/expireat.go
+++ b/ms/expireat.go
@@ -38,7 +38,7 @@ func (ms *Ms) Expireat(key string, timestamp int, options types.QueryOptions) (b
 
 	res := <-result
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return false, res.Error
 	}
 	var returnedResult int

--- a/ms/expireat_test.go
+++ b/ms/expireat_test.go
@@ -28,7 +28,7 @@ import (
 func TestExpireatError(t *testing.T) {
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "Unit test error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "Unit test error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/ms/flushdb.go
+++ b/ms/flushdb.go
@@ -30,5 +30,9 @@ func (ms *Ms) Flushdb(options types.QueryOptions) error {
 
 	res := <-result
 
-	return res.Error
+	if res.Error.Error() != "" {
+		return res.Error
+	}
+
+	return nil
 }

--- a/ms/flushdb_test.go
+++ b/ms/flushdb_test.go
@@ -17,18 +17,19 @@ package ms_test
 import (
 	"encoding/json"
 	"fmt"
+	"testing"
+
 	"github.com/kuzzleio/sdk-go/connection/websocket"
 	"github.com/kuzzleio/sdk-go/internal"
 	"github.com/kuzzleio/sdk-go/kuzzle"
 	"github.com/kuzzleio/sdk-go/types"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 func TestFlushdbError(t *testing.T) {
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "Unit test error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "Unit test error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/ms/geoadd.go
+++ b/ms/geoadd.go
@@ -37,7 +37,7 @@ func (ms *Ms) Geoadd(key string, points []*types.GeoPoint, options types.QueryOp
 
 	res := <-result
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return 0, res.Error
 	}
 	var returnedResult int

--- a/ms/geoadd_test.go
+++ b/ms/geoadd_test.go
@@ -28,7 +28,7 @@ import (
 func TestGeoaddError(t *testing.T) {
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "Unit test error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "Unit test error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/ms/geodist.go
+++ b/ms/geodist.go
@@ -39,7 +39,7 @@ func (ms *Ms) Geodist(key string, member1 string, member2 string, options types.
 
 	res := <-result
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return 0, res.Error
 	}
 	var returnedResult float64

--- a/ms/geodist_test.go
+++ b/ms/geodist_test.go
@@ -28,7 +28,7 @@ import (
 func TestGeodistError(t *testing.T) {
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "Unit test error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "Unit test error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/ms/geohash.go
+++ b/ms/geohash.go
@@ -33,7 +33,7 @@ func (ms *Ms) Geohash(key string, members []string, options types.QueryOptions) 
 
 	res := <-result
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return nil, res.Error
 	}
 	var returnedResult []string

--- a/ms/geohash_test.go
+++ b/ms/geohash_test.go
@@ -28,7 +28,7 @@ import (
 func TestGeohashError(t *testing.T) {
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "Unit test error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "Unit test error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/ms/geopos.go
+++ b/ms/geopos.go
@@ -34,7 +34,7 @@ func (ms *Ms) Geopos(key string, members []string, options types.QueryOptions) (
 
 	res := <-result
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return nil, res.Error
 	}
 	var stringResults [][]string

--- a/ms/geopos_test.go
+++ b/ms/geopos_test.go
@@ -28,7 +28,7 @@ import (
 func TestGeoposError(t *testing.T) {
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "Unit test error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "Unit test error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/ms/georadius.go
+++ b/ms/georadius.go
@@ -115,7 +115,7 @@ func (ms *Ms) Georadius(key string, lon float64, lat float64, distance float64, 
 
 	res := <-result
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return nil, res.Error
 	}
 

--- a/ms/georadius_test.go
+++ b/ms/georadius_test.go
@@ -28,7 +28,7 @@ import (
 func TestGeoradiusError(t *testing.T) {
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "Unit test error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "Unit test error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/ms/georadiusbymember.go
+++ b/ms/georadiusbymember.go
@@ -37,7 +37,7 @@ func (ms *Ms) Georadiusbymember(key string, member string, distance float64, uni
 
 	res := <-result
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return nil, res.Error
 	}
 

--- a/ms/georadiusbymember_test.go
+++ b/ms/georadiusbymember_test.go
@@ -28,7 +28,7 @@ import (
 func TestGeoradiusbymemberError(t *testing.T) {
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "Unit test error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "Unit test error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/ms/get.go
+++ b/ms/get.go
@@ -33,7 +33,7 @@ func (ms *Ms) Get(key string, options types.QueryOptions) (*string, error) {
 
 	res := <-result
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return nil, res.Error
 	}
 

--- a/ms/get_test.go
+++ b/ms/get_test.go
@@ -28,7 +28,7 @@ import (
 func TestGetError(t *testing.T) {
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "Unit test error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "Unit test error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/ms/getbit.go
+++ b/ms/getbit.go
@@ -34,7 +34,7 @@ func (ms *Ms) Getbit(key string, offset int, options types.QueryOptions) (int, e
 
 	res := <-result
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return -1, res.Error
 	}
 

--- a/ms/getbit_test.go
+++ b/ms/getbit_test.go
@@ -28,7 +28,7 @@ import (
 func TestGetbitError(t *testing.T) {
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "Unit test error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "Unit test error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/ms/getrange.go
+++ b/ms/getrange.go
@@ -35,7 +35,7 @@ func (ms *Ms) Getrange(key string, start int, end int, options types.QueryOption
 
 	res := <-result
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return "", res.Error
 	}
 	var returnedResult string

--- a/ms/getrange_test.go
+++ b/ms/getrange_test.go
@@ -28,7 +28,7 @@ import (
 func TestGetrangeError(t *testing.T) {
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "Unit test error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "Unit test error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/ms/getset.go
+++ b/ms/getset.go
@@ -37,7 +37,7 @@ func (ms *Ms) Getset(key string, value string, options types.QueryOptions) (*str
 
 	res := <-result
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return nil, res.Error
 	}
 	var returnedResult *string

--- a/ms/getset_test.go
+++ b/ms/getset_test.go
@@ -28,7 +28,7 @@ import (
 func TestGetsetError(t *testing.T) {
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "Unit test error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "Unit test error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/ms/hdel.go
+++ b/ms/hdel.go
@@ -42,7 +42,7 @@ func (ms *Ms) Hdel(key string, fields []string, options types.QueryOptions) (int
 
 	res := <-result
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return -1, res.Error
 	}
 

--- a/ms/hdel_test.go
+++ b/ms/hdel_test.go
@@ -36,7 +36,7 @@ func TestHdelEmptyFields(t *testing.T) {
 func TestHdelError(t *testing.T) {
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "Unit test error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "Unit test error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/ms/hexists.go
+++ b/ms/hexists.go
@@ -34,7 +34,7 @@ func (ms *Ms) Hexists(key string, field string, options types.QueryOptions) (boo
 
 	res := <-result
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return false, res.Error
 	}
 

--- a/ms/hexists_test.go
+++ b/ms/hexists_test.go
@@ -28,7 +28,7 @@ import (
 func TestHexistsError(t *testing.T) {
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "Unit test error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "Unit test error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/ms/hget.go
+++ b/ms/hget.go
@@ -34,7 +34,7 @@ func (ms *Ms) Hget(key string, field string, options types.QueryOptions) (*strin
 
 	res := <-result
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return nil, res.Error
 	}
 

--- a/ms/hget_test.go
+++ b/ms/hget_test.go
@@ -28,7 +28,7 @@ import (
 func TestHgetError(t *testing.T) {
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "Unit test error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "Unit test error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/ms/hgetall.go
+++ b/ms/hgetall.go
@@ -33,7 +33,7 @@ func (ms *Ms) Hgetall(key string, options types.QueryOptions) (map[string]string
 
 	res := <-result
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return nil, res.Error
 	}
 	returnedResult := map[string]string{}

--- a/ms/hgetall_test.go
+++ b/ms/hgetall_test.go
@@ -28,7 +28,7 @@ import (
 func TestHgetallError(t *testing.T) {
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "Unit test error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "Unit test error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/ms/hincrby.go
+++ b/ms/hincrby.go
@@ -39,7 +39,7 @@ func (ms *Ms) Hincrby(key string, field string, value int, options types.QueryOp
 
 	res := <-result
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return 0, res.Error
 	}
 	var returnedResult int

--- a/ms/hincrby_test.go
+++ b/ms/hincrby_test.go
@@ -28,7 +28,7 @@ import (
 func TestHincrbyError(t *testing.T) {
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "Unit test error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "Unit test error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/ms/hincrbyfloat.go
+++ b/ms/hincrbyfloat.go
@@ -40,7 +40,7 @@ func (ms *Ms) Hincrbyfloat(key string, field string, value float64, options type
 
 	res := <-result
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return 0, res.Error
 	}
 

--- a/ms/hincrbyfloat_test.go
+++ b/ms/hincrbyfloat_test.go
@@ -28,7 +28,7 @@ import (
 func TestHincrbyfloatError(t *testing.T) {
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "Unit test error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "Unit test error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/ms/hkeys.go
+++ b/ms/hkeys.go
@@ -33,7 +33,7 @@ func (ms *Ms) Hkeys(key string, options types.QueryOptions) ([]string, error) {
 
 	res := <-result
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return nil, res.Error
 	}
 	var returnedResult []string

--- a/ms/hkeys_test.go
+++ b/ms/hkeys_test.go
@@ -28,7 +28,7 @@ import (
 func TestHkeysError(t *testing.T) {
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "Unit test error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "Unit test error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/ms/hlen.go
+++ b/ms/hlen.go
@@ -33,7 +33,7 @@ func (ms *Ms) Hlen(key string, options types.QueryOptions) (int, error) {
 
 	res := <-result
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return -1, res.Error
 	}
 	var returnedResult int

--- a/ms/hlen_test.go
+++ b/ms/hlen_test.go
@@ -28,7 +28,7 @@ import (
 func TestHlenError(t *testing.T) {
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "Unit test error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "Unit test error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/ms/hmget.go
+++ b/ms/hmget.go
@@ -34,7 +34,7 @@ func (ms *Ms) Hmget(key string, fields []string, options types.QueryOptions) ([]
 
 	res := <-result
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return nil, res.Error
 	}
 

--- a/ms/hmget_test.go
+++ b/ms/hmget_test.go
@@ -28,7 +28,7 @@ import (
 func TestHmgetError(t *testing.T) {
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "Unit test error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "Unit test error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/ms/hmset.go
+++ b/ms/hmset.go
@@ -41,5 +41,8 @@ func (ms *Ms) Hmset(key string, entries []*types.MsHashField, options types.Quer
 
 	res := <-result
 
-	return res.Error
+	if res.Error.Error() != "" {
+		return res.Error
+	}
+	return nil
 }

--- a/ms/hmset_test.go
+++ b/ms/hmset_test.go
@@ -17,12 +17,13 @@ package ms_test
 import (
 	"encoding/json"
 	"fmt"
+	"testing"
+
 	"github.com/kuzzleio/sdk-go/connection/websocket"
 	"github.com/kuzzleio/sdk-go/internal"
 	"github.com/kuzzleio/sdk-go/kuzzle"
 	"github.com/kuzzleio/sdk-go/types"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 func TestHmsetEmptyEntries(t *testing.T) {
@@ -37,7 +38,7 @@ func TestHmsetEmptyEntries(t *testing.T) {
 func TestHmsetError(t *testing.T) {
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "Unit test error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "Unit test error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/ms/hscan.go
+++ b/ms/hscan.go
@@ -50,7 +50,7 @@ func (ms *Ms) Hscan(key string, cursor int, options types.QueryOptions) (*HscanR
 
 	res := <-result
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return nil, res.Error
 	}
 

--- a/ms/hscan_test.go
+++ b/ms/hscan_test.go
@@ -29,7 +29,7 @@ import (
 func TestHscanError(t *testing.T) {
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "Unit test error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "Unit test error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/ms/hset.go
+++ b/ms/hset.go
@@ -40,7 +40,7 @@ func (ms *Ms) Hset(key string, field string, value string, options types.QueryOp
 
 	res := <-result
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return false, res.Error
 	}
 

--- a/ms/hset_test.go
+++ b/ms/hset_test.go
@@ -28,7 +28,7 @@ import (
 func TestHsetError(t *testing.T) {
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "Unit test error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "Unit test error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/ms/hsetnx.go
+++ b/ms/hsetnx.go
@@ -39,7 +39,7 @@ func (ms *Ms) Hsetnx(key string, field string, value string, options types.Query
 
 	res := <-result
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return false, res.Error
 	}
 

--- a/ms/hsetnx_test.go
+++ b/ms/hsetnx_test.go
@@ -28,7 +28,7 @@ import (
 func TestHsetnxError(t *testing.T) {
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "Unit test error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "Unit test error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/ms/hstrlen.go
+++ b/ms/hstrlen.go
@@ -34,7 +34,7 @@ func (ms *Ms) Hstrlen(key string, field string, options types.QueryOptions) (int
 
 	res := <-result
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return -1, res.Error
 	}
 

--- a/ms/hstrlen_test.go
+++ b/ms/hstrlen_test.go
@@ -28,7 +28,7 @@ import (
 func TestHstrlenError(t *testing.T) {
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "Unit test error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "Unit test error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/ms/hvals.go
+++ b/ms/hvals.go
@@ -33,7 +33,7 @@ func (ms *Ms) Hvals(key string, options types.QueryOptions) ([]string, error) {
 
 	res := <-result
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return nil, res.Error
 	}
 

--- a/ms/hvals_test.go
+++ b/ms/hvals_test.go
@@ -28,7 +28,7 @@ import (
 func TestHvalsError(t *testing.T) {
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "Unit test error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "Unit test error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/ms/incr.go
+++ b/ms/incr.go
@@ -34,7 +34,7 @@ func (ms *Ms) Incr(key string, options types.QueryOptions) (int, error) {
 
 	res := <-result
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return 0, res.Error
 	}
 	var returnedResult int

--- a/ms/incr_test.go
+++ b/ms/incr_test.go
@@ -28,7 +28,7 @@ import (
 func TestIncrError(t *testing.T) {
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "Unit test error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "Unit test error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/ms/incrby.go
+++ b/ms/incrby.go
@@ -39,7 +39,7 @@ func (ms *Ms) Incrby(key string, value int, options types.QueryOptions) (int, er
 
 	res := <-result
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return 0, res.Error
 	}
 	var returnedResult int

--- a/ms/incrby_test.go
+++ b/ms/incrby_test.go
@@ -28,7 +28,7 @@ import (
 func TestIncrbyError(t *testing.T) {
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "Unit test error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "Unit test error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/ms/incrbyfloat.go
+++ b/ms/incrbyfloat.go
@@ -40,7 +40,7 @@ func (ms *Ms) Incrbyfloat(key string, value float64, options types.QueryOptions)
 
 	res := <-result
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return 0, res.Error
 	}
 

--- a/ms/incrbyfloat_test.go
+++ b/ms/incrbyfloat_test.go
@@ -28,7 +28,7 @@ import (
 func TestIncrbyfloatError(t *testing.T) {
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "Unit test error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "Unit test error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/ms/keys.go
+++ b/ms/keys.go
@@ -33,7 +33,7 @@ func (ms *Ms) Keys(pattern string, options types.QueryOptions) ([]string, error)
 
 	res := <-result
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return nil, res.Error
 	}
 	var returnedResult []string

--- a/ms/keys_test.go
+++ b/ms/keys_test.go
@@ -28,7 +28,7 @@ import (
 func TestKeysError(t *testing.T) {
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "Unit test error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "Unit test error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/ms/lindex.go
+++ b/ms/lindex.go
@@ -34,7 +34,7 @@ func (ms *Ms) Lindex(key string, index int, options types.QueryOptions) (*string
 
 	res := <-result
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return nil, res.Error
 	}
 	var returnedResult *string

--- a/ms/lindex_test.go
+++ b/ms/lindex_test.go
@@ -28,7 +28,7 @@ import (
 func TestLindexError(t *testing.T) {
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "Unit test error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "Unit test error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/ms/linsert.go
+++ b/ms/linsert.go
@@ -44,7 +44,7 @@ func (ms *Ms) Linsert(key string, position string, pivot string, value string, o
 
 	res := <-result
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return -1, res.Error
 	}
 	var returnedResult int

--- a/ms/linsert_test.go
+++ b/ms/linsert_test.go
@@ -36,7 +36,7 @@ func TestLinsertInvalidPivot(t *testing.T) {
 func TestLinsertError(t *testing.T) {
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "Unit test error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "Unit test error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/ms/llen.go
+++ b/ms/llen.go
@@ -33,7 +33,7 @@ func (ms *Ms) Llen(key string, options types.QueryOptions) (int, error) {
 
 	res := <-result
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return 0, res.Error
 	}
 	var returnedResult int

--- a/ms/llen_test.go
+++ b/ms/llen_test.go
@@ -28,7 +28,7 @@ import (
 func TestLlenError(t *testing.T) {
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "Unit test error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "Unit test error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/ms/lpop.go
+++ b/ms/lpop.go
@@ -33,7 +33,7 @@ func (ms *Ms) Lpop(key string, options types.QueryOptions) (*string, error) {
 
 	res := <-result
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return nil, res.Error
 	}
 	var returnedResult *string

--- a/ms/lpop_test.go
+++ b/ms/lpop_test.go
@@ -28,7 +28,7 @@ import (
 func TestLpopError(t *testing.T) {
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "Unit test error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "Unit test error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/ms/lpush.go
+++ b/ms/lpush.go
@@ -44,7 +44,7 @@ func (ms *Ms) Lpush(key string, values []string, options types.QueryOptions) (in
 
 	res := <-result
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return 0, res.Error
 	}
 	var returnedResult int

--- a/ms/lpush_test.go
+++ b/ms/lpush_test.go
@@ -37,7 +37,7 @@ func TestLpushEmptyValues(t *testing.T) {
 func TestLpushError(t *testing.T) {
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "Unit test error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "Unit test error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/ms/lpushx.go
+++ b/ms/lpushx.go
@@ -39,7 +39,7 @@ func (ms *Ms) Lpushx(key string, value string, options types.QueryOptions) (int,
 
 	res := <-result
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return 0, res.Error
 	}
 	var returnedResult int

--- a/ms/lpushx_test.go
+++ b/ms/lpushx_test.go
@@ -28,7 +28,7 @@ import (
 func TestLpushxError(t *testing.T) {
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "Unit test error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "Unit test error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/ms/lrange.go
+++ b/ms/lrange.go
@@ -35,7 +35,7 @@ func (ms *Ms) Lrange(key string, start int, stop int, options types.QueryOptions
 
 	res := <-result
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return nil, res.Error
 	}
 	var returnedResult []string

--- a/ms/lrange_test.go
+++ b/ms/lrange_test.go
@@ -28,7 +28,7 @@ import (
 func TestLrangeError(t *testing.T) {
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "Unit test error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "Unit test error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/ms/lrem.go
+++ b/ms/lrem.go
@@ -39,7 +39,7 @@ func (ms *Ms) Lrem(key string, count int, value string, options types.QueryOptio
 
 	res := <-result
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return 0, res.Error
 	}
 	var returnedResult int

--- a/ms/lrem_test.go
+++ b/ms/lrem_test.go
@@ -28,7 +28,7 @@ import (
 func TestLremError(t *testing.T) {
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "Unit test error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "Unit test error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/ms/lset.go
+++ b/ms/lset.go
@@ -38,5 +38,8 @@ func (ms *Ms) Lset(key string, index int, value string, options types.QueryOptio
 
 	res := <-result
 
-	return res.Error
+	if res.Error.Error() != "" {
+		return res.Error
+	}
+	return nil
 }

--- a/ms/lset_test.go
+++ b/ms/lset_test.go
@@ -17,18 +17,19 @@ package ms_test
 import (
 	"encoding/json"
 	"fmt"
+	"testing"
+
 	"github.com/kuzzleio/sdk-go/connection/websocket"
 	"github.com/kuzzleio/sdk-go/internal"
 	"github.com/kuzzleio/sdk-go/kuzzle"
 	"github.com/kuzzleio/sdk-go/types"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 func TestLsetError(t *testing.T) {
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "Unit test error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "Unit test error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/ms/ltrim.go
+++ b/ms/ltrim.go
@@ -39,5 +39,9 @@ func (ms *Ms) Ltrim(key string, start int, stop int, options types.QueryOptions)
 
 	res := <-result
 
-	return res.Error
+	if res.Error.Error() != "" {
+		return res.Error
+	}
+
+	return nil
 }

--- a/ms/ltrim_test.go
+++ b/ms/ltrim_test.go
@@ -17,18 +17,19 @@ package ms_test
 import (
 	"encoding/json"
 	"fmt"
+	"testing"
+
 	"github.com/kuzzleio/sdk-go/connection/websocket"
 	"github.com/kuzzleio/sdk-go/internal"
 	"github.com/kuzzleio/sdk-go/kuzzle"
 	"github.com/kuzzleio/sdk-go/types"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 func TestLtrimError(t *testing.T) {
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "Unit test error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "Unit test error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/ms/mget.go
+++ b/ms/mget.go
@@ -36,7 +36,7 @@ func (ms *Ms) Mget(keys []string, options types.QueryOptions) ([]*string, error)
 
 	res := <-result
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return nil, res.Error
 	}
 	var returnedResult []*string

--- a/ms/mget_test.go
+++ b/ms/mget_test.go
@@ -37,7 +37,7 @@ func TestMgetEmptyKeys(t *testing.T) {
 func TestMgetError(t *testing.T) {
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "Unit test error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "Unit test error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/ms/mset.go
+++ b/ms/mset.go
@@ -40,5 +40,8 @@ func (ms *Ms) Mset(entries []*types.MSKeyValue, options types.QueryOptions) erro
 
 	res := <-result
 
-	return res.Error
+	if res.Error.Error() != "" {
+		return res.Error
+	}
+	return nil
 }

--- a/ms/mset_test.go
+++ b/ms/mset_test.go
@@ -17,12 +17,13 @@ package ms_test
 import (
 	"encoding/json"
 	"fmt"
+	"testing"
+
 	"github.com/kuzzleio/sdk-go/connection/websocket"
 	"github.com/kuzzleio/sdk-go/internal"
 	"github.com/kuzzleio/sdk-go/kuzzle"
 	"github.com/kuzzleio/sdk-go/types"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 func TestMsetEmptyEntries(t *testing.T) {
@@ -36,7 +37,7 @@ func TestMsetEmptyEntries(t *testing.T) {
 func TestMsetError(t *testing.T) {
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "Unit test error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "Unit test error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/ms/msetnx.go
+++ b/ms/msetnx.go
@@ -41,7 +41,7 @@ func (ms *Ms) Msetnx(entries []*types.MSKeyValue, options types.QueryOptions) (b
 
 	res := <-result
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return false, res.Error
 	}
 	var returnedResult int

--- a/ms/msetnx_test.go
+++ b/ms/msetnx_test.go
@@ -37,7 +37,7 @@ func TestMsetnxEmptyEntries(t *testing.T) {
 func TestMsetnxError(t *testing.T) {
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "Unit test error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "Unit test error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/ms/object.go
+++ b/ms/object.go
@@ -37,7 +37,7 @@ func (ms *Ms) Object(key string, subcommand string, options types.QueryOptions) 
 
 	res := <-result
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return nil, res.Error
 	}
 	var returnedResult *string

--- a/ms/object_test.go
+++ b/ms/object_test.go
@@ -37,7 +37,7 @@ func TestObjectInvalidSubcommand(t *testing.T) {
 func TestObjectError(t *testing.T) {
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "Unit test error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "Unit test error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/ms/persist.go
+++ b/ms/persist.go
@@ -32,7 +32,7 @@ func (ms *Ms) Persist(key string, options types.QueryOptions) (bool, error) {
 
 	res := <-result
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return false, res.Error
 	}
 	var returnedResult int

--- a/ms/persist_test.go
+++ b/ms/persist_test.go
@@ -28,7 +28,7 @@ import (
 func TestPersistError(t *testing.T) {
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "Unit test error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "Unit test error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/ms/pexpire.go
+++ b/ms/pexpire.go
@@ -38,7 +38,7 @@ func (ms *Ms) Pexpire(key string, ttl int, options types.QueryOptions) (bool, er
 
 	res := <-result
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return false, res.Error
 	}
 	var returnedResult int

--- a/ms/pexpire_test.go
+++ b/ms/pexpire_test.go
@@ -28,7 +28,7 @@ import (
 func TestPexpireError(t *testing.T) {
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "Unit test error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "Unit test error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/ms/pexpireat.go
+++ b/ms/pexpireat.go
@@ -39,7 +39,7 @@ func (ms *Ms) Pexpireat(key string, timestamp int, options types.QueryOptions) (
 
 	res := <-result
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return false, res.Error
 	}
 	var returnedResult int

--- a/ms/pexpireat_test.go
+++ b/ms/pexpireat_test.go
@@ -28,7 +28,7 @@ import (
 func TestPexpireatError(t *testing.T) {
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "Unit test error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "Unit test error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/ms/pfadd.go
+++ b/ms/pfadd.go
@@ -41,7 +41,7 @@ func (ms *Ms) Pfadd(key string, elements []string, options types.QueryOptions) (
 
 	res := <-result
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return false, res.Error
 	}
 	var returnedResult int

--- a/ms/pfadd_test.go
+++ b/ms/pfadd_test.go
@@ -37,7 +37,7 @@ func TestPfaddEmptyElements(t *testing.T) {
 func TestPfaddError(t *testing.T) {
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "Unit test error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "Unit test error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/ms/pfcount.go
+++ b/ms/pfcount.go
@@ -41,7 +41,7 @@ func (ms *Ms) Pfcount(keys []string, options types.QueryOptions) (int, error) {
 
 	res := <-result
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return 0, res.Error
 	}
 	var returnedResult int

--- a/ms/pfcount_test.go
+++ b/ms/pfcount_test.go
@@ -37,7 +37,7 @@ func TestPfcountEmptyKeys(t *testing.T) {
 func TestPfcountError(t *testing.T) {
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "Unit test error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "Unit test error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/ms/pfmerge.go
+++ b/ms/pfmerge.go
@@ -41,5 +41,8 @@ func (ms *Ms) Pfmerge(key string, sources []string, options types.QueryOptions) 
 
 	res := <-result
 
-	return res.Error
+	if res.Error.Error() != "" {
+		return res.Error
+	}
+	return nil
 }

--- a/ms/pfmerge_test.go
+++ b/ms/pfmerge_test.go
@@ -17,12 +17,13 @@ package ms_test
 import (
 	"encoding/json"
 	"fmt"
+	"testing"
+
 	"github.com/kuzzleio/sdk-go/connection/websocket"
 	"github.com/kuzzleio/sdk-go/internal"
 	"github.com/kuzzleio/sdk-go/kuzzle"
 	"github.com/kuzzleio/sdk-go/types"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 func TestPfmergeEmptySources(t *testing.T) {
@@ -37,7 +38,7 @@ func TestPfmergeEmptySources(t *testing.T) {
 func TestPfmergeError(t *testing.T) {
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "Unit test error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "Unit test error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/ms/ping.go
+++ b/ms/ping.go
@@ -31,7 +31,7 @@ func (ms *Ms) Ping(options types.QueryOptions) (string, error) {
 
 	res := <-result
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return "", res.Error
 	}
 	var returnedResult string

--- a/ms/ping_test.go
+++ b/ms/ping_test.go
@@ -28,7 +28,7 @@ import (
 func TestPingError(t *testing.T) {
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "Unit test error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "Unit test error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/ms/psetex.go
+++ b/ms/psetex.go
@@ -38,5 +38,8 @@ func (ms *Ms) Psetex(key string, value string, ttl int, options types.QueryOptio
 
 	res := <-result
 
-	return res.Error
+	if res.Error.Error() != "" {
+		return res.Error
+	}
+	return nil
 }

--- a/ms/psetex_test.go
+++ b/ms/psetex_test.go
@@ -17,18 +17,19 @@ package ms_test
 import (
 	"encoding/json"
 	"fmt"
+	"testing"
+
 	"github.com/kuzzleio/sdk-go/connection/websocket"
 	"github.com/kuzzleio/sdk-go/internal"
 	"github.com/kuzzleio/sdk-go/kuzzle"
 	"github.com/kuzzleio/sdk-go/types"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 func TestPsetexError(t *testing.T) {
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "Unit test error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "Unit test error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/ms/pttl.go
+++ b/ms/pttl.go
@@ -32,7 +32,7 @@ func (ms *Ms) Pttl(key string, options types.QueryOptions) (int, error) {
 
 	res := <-result
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return 0, res.Error
 	}
 	var returnedResult int

--- a/ms/pttl_test.go
+++ b/ms/pttl_test.go
@@ -28,7 +28,7 @@ import (
 func TestPttlError(t *testing.T) {
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "Unit test error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "Unit test error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/ms/randomkey.go
+++ b/ms/randomkey.go
@@ -31,7 +31,7 @@ func (ms *Ms) Randomkey(options types.QueryOptions) (*string, error) {
 
 	res := <-result
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return nil, res.Error
 	}
 	var returnedResult *string

--- a/ms/randomkey_test.go
+++ b/ms/randomkey_test.go
@@ -28,7 +28,7 @@ import (
 func TestRandomkeyError(t *testing.T) {
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "Unit test error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "Unit test error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/ms/rename.go
+++ b/ms/rename.go
@@ -36,5 +36,8 @@ func (ms *Ms) Rename(key string, newkey string, options types.QueryOptions) erro
 
 	res := <-result
 
-	return res.Error
+	if res.Error.Error() != "" {
+		return res.Error
+	}
+	return nil
 }

--- a/ms/rename_test.go
+++ b/ms/rename_test.go
@@ -17,18 +17,19 @@ package ms_test
 import (
 	"encoding/json"
 	"fmt"
+	"testing"
+
 	"github.com/kuzzleio/sdk-go/connection/websocket"
 	"github.com/kuzzleio/sdk-go/internal"
 	"github.com/kuzzleio/sdk-go/kuzzle"
 	"github.com/kuzzleio/sdk-go/types"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 func TestRenameError(t *testing.T) {
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "Unit test error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "Unit test error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/ms/renamenx.go
+++ b/ms/renamenx.go
@@ -37,7 +37,7 @@ func (ms *Ms) Renamenx(key string, newkey string, options types.QueryOptions) (b
 
 	res := <-result
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return false, res.Error
 	}
 	var returnedResult int

--- a/ms/renamenx_test.go
+++ b/ms/renamenx_test.go
@@ -28,7 +28,7 @@ import (
 func TestRenamenxError(t *testing.T) {
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "Unit test error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "Unit test error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/ms/rpop.go
+++ b/ms/rpop.go
@@ -36,7 +36,7 @@ func (ms *Ms) Rpop(key string, options types.QueryOptions) (*string, error) {
 
 	res := <-result
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return nil, res.Error
 	}
 	var returnedResult *string

--- a/ms/rpop_test.go
+++ b/ms/rpop_test.go
@@ -28,7 +28,7 @@ import (
 func TestRpopError(t *testing.T) {
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "Unit test error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "Unit test error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/ms/rpoplpush.go
+++ b/ms/rpoplpush.go
@@ -38,7 +38,7 @@ func (ms *Ms) Rpoplpush(source string, destination string, options types.QueryOp
 
 	res := <-result
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return nil, res.Error
 	}
 	var returnedResult string

--- a/ms/rpoplpush_test.go
+++ b/ms/rpoplpush_test.go
@@ -28,7 +28,7 @@ import (
 func TestRpoplpushError(t *testing.T) {
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "Unit test error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "Unit test error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/ms/rpush.go
+++ b/ms/rpush.go
@@ -42,7 +42,7 @@ func (ms *Ms) Rpush(source string, values []string, options types.QueryOptions) 
 
 	res := <-result
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return 0, res.Error
 	}
 	var returnedResult int

--- a/ms/rpush_test.go
+++ b/ms/rpush_test.go
@@ -37,7 +37,7 @@ func TestRpushEmptyValues(t *testing.T) {
 func TestRpushError(t *testing.T) {
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "Unit test error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "Unit test error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/ms/rpushx.go
+++ b/ms/rpushx.go
@@ -38,7 +38,7 @@ func (ms *Ms) Rpushx(key string, value string, options types.QueryOptions) (int,
 
 	res := <-result
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return 0, res.Error
 	}
 	var returnedResult int

--- a/ms/rpushx_test.go
+++ b/ms/rpushx_test.go
@@ -28,7 +28,7 @@ import (
 func TestRpushxError(t *testing.T) {
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "Unit test error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "Unit test error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/ms/sadd.go
+++ b/ms/sadd.go
@@ -42,7 +42,7 @@ func (ms *Ms) Sadd(key string, values []string, options types.QueryOptions) (int
 
 	res := <-result
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return 0, res.Error
 	}
 

--- a/ms/sadd_test.go
+++ b/ms/sadd_test.go
@@ -37,7 +37,7 @@ func TestSaddEmptyValues(t *testing.T) {
 func TestSaddError(t *testing.T) {
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "Unit test error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "Unit test error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/ms/scan.go
+++ b/ms/scan.go
@@ -47,7 +47,7 @@ func (ms *Ms) Scan(cursor int, options types.QueryOptions) (*types.MSScanRespons
 
 	res := <-result
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return nil, res.Error
 	}
 

--- a/ms/scan_test.go
+++ b/ms/scan_test.go
@@ -28,7 +28,7 @@ import (
 func TestScanError(t *testing.T) {
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "Unit test error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "Unit test error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/ms/scard.go
+++ b/ms/scard.go
@@ -33,7 +33,7 @@ func (ms *Ms) Scard(key string, options types.QueryOptions) (int, error) {
 
 	res := <-result
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return 0, res.Error
 	}
 

--- a/ms/scard_test.go
+++ b/ms/scard_test.go
@@ -28,7 +28,7 @@ import (
 func TestScardError(t *testing.T) {
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "Unit test error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "Unit test error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/ms/sdiff.go
+++ b/ms/sdiff.go
@@ -38,7 +38,7 @@ func (ms *Ms) Sdiff(key string, sets []string, options types.QueryOptions) ([]st
 
 	res := <-result
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return nil, res.Error
 	}
 	var returnedResult []string

--- a/ms/sdiff_test.go
+++ b/ms/sdiff_test.go
@@ -37,7 +37,7 @@ func TestSdiffEmptySets(t *testing.T) {
 func TestSdiffError(t *testing.T) {
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "Unit test error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "Unit test error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/ms/sdiffstore.go
+++ b/ms/sdiffstore.go
@@ -45,7 +45,7 @@ func (ms *Ms) Sdiffstore(key string, sets []string, destination string, options 
 
 	res := <-result
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return 0, res.Error
 	}
 

--- a/ms/sdiffstore_test.go
+++ b/ms/sdiffstore_test.go
@@ -37,7 +37,7 @@ func TestSdiffstoreEmptySets(t *testing.T) {
 func TestSdiffstoreError(t *testing.T) {
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "Unit test error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "Unit test error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/ms/set.go
+++ b/ms/set.go
@@ -56,5 +56,8 @@ func (ms *Ms) Set(key string, value interface{}, options types.QueryOptions) err
 
 	res := <-result
 
-	return res.Error
+	if res.Error.Error() != "" {
+		return res.Error
+	}
+	return nil
 }

--- a/ms/set_test.go
+++ b/ms/set_test.go
@@ -17,18 +17,19 @@ package ms_test
 import (
 	"encoding/json"
 	"fmt"
+	"testing"
+
 	"github.com/kuzzleio/sdk-go/connection/websocket"
 	"github.com/kuzzleio/sdk-go/internal"
 	"github.com/kuzzleio/sdk-go/kuzzle"
 	"github.com/kuzzleio/sdk-go/types"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 func TestSetError(t *testing.T) {
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "Unit test error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "Unit test error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/ms/setex.go
+++ b/ms/setex.go
@@ -39,5 +39,8 @@ func (ms *Ms) Setex(key string, value interface{}, ttl int, options types.QueryO
 
 	res := <-result
 
-	return res.Error
+	if res.Error.Error() != "" {
+		return res.Error
+	}
+	return nil
 }

--- a/ms/setex_test.go
+++ b/ms/setex_test.go
@@ -17,18 +17,19 @@ package ms_test
 import (
 	"encoding/json"
 	"fmt"
+	"testing"
+
 	"github.com/kuzzleio/sdk-go/connection/websocket"
 	"github.com/kuzzleio/sdk-go/internal"
 	"github.com/kuzzleio/sdk-go/kuzzle"
 	"github.com/kuzzleio/sdk-go/types"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 func TestSetexError(t *testing.T) {
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "Unit test error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "Unit test error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/ms/setnx.go
+++ b/ms/setnx.go
@@ -38,7 +38,7 @@ func (ms *Ms) Setnx(key string, value interface{}, options types.QueryOptions) (
 
 	res := <-result
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return false, res.Error
 	}
 	var returnedResult int

--- a/ms/setnx_test.go
+++ b/ms/setnx_test.go
@@ -28,7 +28,7 @@ import (
 func TestSetnxError(t *testing.T) {
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "Unit test error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "Unit test error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/ms/sinter.go
+++ b/ms/sinter.go
@@ -37,7 +37,7 @@ func (ms *Ms) Sinter(keys []string, options types.QueryOptions) ([]string, error
 
 	res := <-result
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return nil, res.Error
 	}
 	var returnedResult []string

--- a/ms/sinter_test.go
+++ b/ms/sinter_test.go
@@ -37,7 +37,7 @@ func TestSinterEmptyKeys(t *testing.T) {
 func TestSinterError(t *testing.T) {
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "Unit test error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "Unit test error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/ms/sinterstore.go
+++ b/ms/sinterstore.go
@@ -44,7 +44,7 @@ func (ms *Ms) Sinterstore(destination string, keys []string, options types.Query
 
 	res := <-result
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return 0, res.Error
 	}
 	var returnedResult int

--- a/ms/sinterstore_test.go
+++ b/ms/sinterstore_test.go
@@ -37,7 +37,7 @@ func TestSinterstoreEmptyKeys(t *testing.T) {
 func TestSinterstoreError(t *testing.T) {
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "Unit test error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "Unit test error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/ms/sismember.go
+++ b/ms/sismember.go
@@ -34,7 +34,7 @@ func (ms *Ms) Sismember(key string, member string, options types.QueryOptions) (
 
 	res := <-result
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return false, res.Error
 	}
 	var returnedResult int

--- a/ms/sismember_test.go
+++ b/ms/sismember_test.go
@@ -28,7 +28,7 @@ import (
 func TestSismemberError(t *testing.T) {
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "Unit test error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "Unit test error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/ms/smembers.go
+++ b/ms/smembers.go
@@ -33,7 +33,7 @@ func (ms *Ms) Smembers(key string, options types.QueryOptions) ([]string, error)
 
 	res := <-result
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return nil, res.Error
 	}
 

--- a/ms/smembers_test.go
+++ b/ms/smembers_test.go
@@ -28,7 +28,7 @@ import (
 func TestSmembersError(t *testing.T) {
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "Unit test error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "Unit test error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/ms/smove.go
+++ b/ms/smove.go
@@ -39,7 +39,7 @@ func (ms *Ms) Smove(key string, destination string, member string, options types
 
 	res := <-result
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return false, res.Error
 	}
 

--- a/ms/smove_test.go
+++ b/ms/smove_test.go
@@ -28,7 +28,7 @@ import (
 func TestSmoveError(t *testing.T) {
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "Unit test error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "Unit test error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/ms/sort.go
+++ b/ms/sort.go
@@ -67,7 +67,7 @@ func (ms *Ms) Sort(key string, options types.QueryOptions) ([]string, error) {
 
 	res := <-result
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return nil, res.Error
 	}
 

--- a/ms/sort_test.go
+++ b/ms/sort_test.go
@@ -28,7 +28,7 @@ import (
 func TestSortError(t *testing.T) {
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "Unit test error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "Unit test error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/ms/spop.go
+++ b/ms/spop.go
@@ -39,7 +39,7 @@ func (ms *Ms) Spop(key string, options types.QueryOptions) ([]string, error) {
 
 	res := <-result
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return nil, res.Error
 	}
 

--- a/ms/spop_test.go
+++ b/ms/spop_test.go
@@ -28,7 +28,7 @@ import (
 func TestSpopError(t *testing.T) {
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "Unit test error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "Unit test error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/ms/srandmember.go
+++ b/ms/srandmember.go
@@ -46,7 +46,7 @@ func (ms *Ms) Srandmember(key string, options types.QueryOptions) ([]string, err
 
 	res := <-result
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return nil, res.Error
 	}
 

--- a/ms/srandmember_test.go
+++ b/ms/srandmember_test.go
@@ -28,7 +28,7 @@ import (
 func TestSrandmemberError(t *testing.T) {
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "Unit test error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "Unit test error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/ms/srem.go
+++ b/ms/srem.go
@@ -42,7 +42,7 @@ func (ms *Ms) Srem(key string, valuesToRemove []string, options types.QueryOptio
 
 	res := <-result
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return 0, res.Error
 	}
 

--- a/ms/srem_test.go
+++ b/ms/srem_test.go
@@ -37,7 +37,7 @@ func TestSremEmptyValues(t *testing.T) {
 func TestSremError(t *testing.T) {
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "Unit test error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "Unit test error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/ms/sscan.go
+++ b/ms/sscan.go
@@ -44,7 +44,7 @@ func (ms *Ms) Sscan(key string, cursor int, options types.QueryOptions) (*types.
 
 	res := <-result
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return nil, res.Error
 	}
 

--- a/ms/sscan_test.go
+++ b/ms/sscan_test.go
@@ -28,7 +28,7 @@ import (
 func TestSscanError(t *testing.T) {
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "Unit test error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "Unit test error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/ms/strlen.go
+++ b/ms/strlen.go
@@ -33,7 +33,7 @@ func (ms *Ms) Strlen(key string, options types.QueryOptions) (int, error) {
 
 	res := <-result
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return 0, res.Error
 	}
 

--- a/ms/strlen_test.go
+++ b/ms/strlen_test.go
@@ -28,7 +28,7 @@ import (
 func TestStrlenError(t *testing.T) {
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "Unit test error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "Unit test error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/ms/sunion.go
+++ b/ms/sunion.go
@@ -37,7 +37,7 @@ func (ms *Ms) Sunion(sets []string, options types.QueryOptions) ([]string, error
 
 	res := <-result
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return nil, res.Error
 	}
 

--- a/ms/sunion_test.go
+++ b/ms/sunion_test.go
@@ -37,7 +37,7 @@ func TestSunionEmptySet(t *testing.T) {
 func TestSunionError(t *testing.T) {
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "Unit test error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "Unit test error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/ms/sunionstore.go
+++ b/ms/sunionstore.go
@@ -43,7 +43,7 @@ func (ms *Ms) Sunionstore(destination string, sets []string, options types.Query
 
 	res := <-result
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return 0, res.Error
 	}
 

--- a/ms/sunionstore_test.go
+++ b/ms/sunionstore_test.go
@@ -37,7 +37,7 @@ func TestSunionstoreEmptySet(t *testing.T) {
 func TestSunionStoreError(t *testing.T) {
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "Unit test error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "Unit test error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/ms/time.go
+++ b/ms/time.go
@@ -31,7 +31,7 @@ func (ms *Ms) Time(options types.QueryOptions) ([]int, error) {
 
 	res := <-result
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return nil, res.Error
 	}
 	var returnedResult []int

--- a/ms/time_test.go
+++ b/ms/time_test.go
@@ -28,7 +28,7 @@ import (
 func TestTimeError(t *testing.T) {
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "Unit test error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "Unit test error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/ms/touch.go
+++ b/ms/touch.go
@@ -40,7 +40,7 @@ func (ms *Ms) Touch(keys []string, options types.QueryOptions) (int, error) {
 
 	res := <-result
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return 0, res.Error
 	}
 	var returnedResult int

--- a/ms/touch_test.go
+++ b/ms/touch_test.go
@@ -37,7 +37,7 @@ func TestTouchEmptyKeys(t *testing.T) {
 func TestTouchError(t *testing.T) {
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "Unit test error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "Unit test error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/ms/ttl.go
+++ b/ms/ttl.go
@@ -37,7 +37,7 @@ func (ms *Ms) Ttl(key string, options types.QueryOptions) (int, error) {
 
 	res := <-result
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return 0, res.Error
 	}
 	var returnedResult int

--- a/ms/ttl_test.go
+++ b/ms/ttl_test.go
@@ -28,7 +28,7 @@ import (
 func TestTtlError(t *testing.T) {
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "Unit test error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "Unit test error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/ms/type.go
+++ b/ms/type.go
@@ -33,7 +33,7 @@ func (ms *Ms) Type(key string, options types.QueryOptions) (string, error) {
 
 	res := <-result
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return "", res.Error
 	}
 	var returnedResult string

--- a/ms/type_test.go
+++ b/ms/type_test.go
@@ -28,7 +28,7 @@ import (
 func TestTypeError(t *testing.T) {
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "Unit test error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "Unit test error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/ms/zadd.go
+++ b/ms/zadd.go
@@ -59,7 +59,7 @@ func (ms *Ms) Zadd(key string, elements []*types.MSSortedSet, options types.Quer
 
 	res := <-result
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return 0, res.Error
 	}
 

--- a/ms/zadd_test.go
+++ b/ms/zadd_test.go
@@ -37,7 +37,7 @@ func TestZaddEmptyElements(t *testing.T) {
 func TestZaddError(t *testing.T) {
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "Unit test error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "Unit test error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/ms/zcard.go
+++ b/ms/zcard.go
@@ -33,7 +33,7 @@ func (ms *Ms) Zcard(key string, options types.QueryOptions) (int, error) {
 
 	res := <-result
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return 0, res.Error
 	}
 

--- a/ms/zcard_test.go
+++ b/ms/zcard_test.go
@@ -28,7 +28,7 @@ import (
 func TestZcardError(t *testing.T) {
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "Unit test error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "Unit test error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/ms/zcount.go
+++ b/ms/zcount.go
@@ -38,7 +38,7 @@ func (ms *Ms) Zcount(key string, min int, max int, options types.QueryOptions) (
 
 	res := <-result
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return 0, res.Error
 	}
 

--- a/ms/zcount_test.go
+++ b/ms/zcount_test.go
@@ -28,7 +28,7 @@ import (
 func TestZcountError(t *testing.T) {
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "Unit test error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "Unit test error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/ms/zincrby.go
+++ b/ms/zincrby.go
@@ -40,7 +40,7 @@ func (ms *Ms) Zincrby(key string, member string, increment float64, options type
 
 	res := <-result
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return 0, res.Error
 	}
 

--- a/ms/zincrby_test.go
+++ b/ms/zincrby_test.go
@@ -28,7 +28,7 @@ import (
 func TestZincrbyError(t *testing.T) {
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "Unit test error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "Unit test error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/ms/zinterstore.go
+++ b/ms/zinterstore.go
@@ -57,7 +57,7 @@ func (ms *Ms) Zinterstore(destination string, keys []string, options types.Query
 
 	res := <-result
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return 0, res.Error
 	}
 

--- a/ms/zinterstore_test.go
+++ b/ms/zinterstore_test.go
@@ -37,7 +37,7 @@ func TestZinterstoreEmptyKeys(t *testing.T) {
 func TestZinterstoreError(t *testing.T) {
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "Unit test error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "Unit test error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/ms/zlexcount.go
+++ b/ms/zlexcount.go
@@ -39,7 +39,7 @@ func (ms *Ms) Zlexcount(key string, min string, max string, options types.QueryO
 
 	res := <-result
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return 0, res.Error
 	}
 

--- a/ms/zlexcount_test.go
+++ b/ms/zlexcount_test.go
@@ -46,7 +46,7 @@ func TestZlexcountEmptyMax(t *testing.T) {
 func TestZlexcountError(t *testing.T) {
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "Unit test error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "Unit test error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/ms/zrange.go
+++ b/ms/zrange.go
@@ -41,7 +41,7 @@ func (ms *Ms) Zrange(key string, start int, stop int, options types.QueryOptions
 
 	res := <-result
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return nil, res.Error
 	}
 

--- a/ms/zrange_test.go
+++ b/ms/zrange_test.go
@@ -28,7 +28,7 @@ import (
 func TestZrangeError(t *testing.T) {
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "Unit test error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "Unit test error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/ms/zrangebylex.go
+++ b/ms/zrangebylex.go
@@ -41,7 +41,7 @@ func (ms *Ms) Zrangebylex(key string, min string, max string, options types.Quer
 
 	res := <-result
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return nil, res.Error
 	}
 

--- a/ms/zrangebylex_test.go
+++ b/ms/zrangebylex_test.go
@@ -46,7 +46,7 @@ func TestZrangebylexEmptyMax(t *testing.T) {
 func TestZrangebylexError(t *testing.T) {
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "Unit test error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "Unit test error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/ms/zrangebyscore.go
+++ b/ms/zrangebyscore.go
@@ -38,7 +38,7 @@ func (ms *Ms) Zrangebyscore(key string, min float64, max float64, options types.
 
 	res := <-result
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return nil, res.Error
 	}
 

--- a/ms/zrangebyscore_test.go
+++ b/ms/zrangebyscore_test.go
@@ -28,7 +28,7 @@ import (
 func TestZrangebyscoreError(t *testing.T) {
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "Unit test error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "Unit test error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/ms/zrank.go
+++ b/ms/zrank.go
@@ -34,7 +34,7 @@ func (ms *Ms) Zrank(key string, member string, options types.QueryOptions) (int,
 
 	res := <-result
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return 0, res.Error
 	}
 

--- a/ms/zrank_test.go
+++ b/ms/zrank_test.go
@@ -28,7 +28,7 @@ import (
 func TestZrankError(t *testing.T) {
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "Unit test error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "Unit test error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/ms/zrem.go
+++ b/ms/zrem.go
@@ -42,7 +42,7 @@ func (ms *Ms) Zrem(key string, members []string, options types.QueryOptions) (in
 
 	res := <-result
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return 0, res.Error
 	}
 

--- a/ms/zrem_test.go
+++ b/ms/zrem_test.go
@@ -37,7 +37,7 @@ func TestZremEmptyMembers(t *testing.T) {
 func TestZremError(t *testing.T) {
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "Unit test error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "Unit test error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/ms/zremrangebylex.go
+++ b/ms/zremrangebylex.go
@@ -43,7 +43,7 @@ func (ms *Ms) Zremrangebylex(key string, min string, max string, options types.Q
 
 	res := <-result
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return 0, res.Error
 	}
 

--- a/ms/zremrangebylex_test.go
+++ b/ms/zremrangebylex_test.go
@@ -46,7 +46,7 @@ func TestZremrangebylexEmptyMax(t *testing.T) {
 func TestZremrangebylexError(t *testing.T) {
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "Unit test error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "Unit test error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/ms/zremrangebyrank.go
+++ b/ms/zremrangebyrank.go
@@ -42,7 +42,7 @@ func (ms *Ms) Zremrangebyrank(key string, min int, max int, options types.QueryO
 
 	res := <-result
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return 0, res.Error
 	}
 

--- a/ms/zremrangebyrank_test.go
+++ b/ms/zremrangebyrank_test.go
@@ -28,7 +28,7 @@ import (
 func TestZremrangebyrankError(t *testing.T) {
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "Unit test error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "Unit test error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/ms/zremrangebyscore.go
+++ b/ms/zremrangebyscore.go
@@ -40,7 +40,7 @@ func (ms *Ms) Zremrangebyscore(key string, min float64, max float64, options typ
 
 	res := <-result
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return 0, res.Error
 	}
 

--- a/ms/zremrangebyscore_test.go
+++ b/ms/zremrangebyscore_test.go
@@ -28,7 +28,7 @@ import (
 func TestZremrangebyscoreError(t *testing.T) {
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "Unit test error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "Unit test error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/ms/zrevrange.go
+++ b/ms/zrevrange.go
@@ -37,7 +37,7 @@ func (ms *Ms) Zrevrange(key string, start int, stop int, options types.QueryOpti
 
 	res := <-result
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return nil, res.Error
 	}
 

--- a/ms/zrevrange_test.go
+++ b/ms/zrevrange_test.go
@@ -28,7 +28,7 @@ import (
 func TestZrevrangeError(t *testing.T) {
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "Unit test error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "Unit test error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/ms/zrevrangebylex.go
+++ b/ms/zrevrangebylex.go
@@ -41,7 +41,7 @@ func (ms *Ms) Zrevrangebylex(key string, min string, max string, options types.Q
 
 	res := <-result
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return nil, res.Error
 	}
 

--- a/ms/zrevrangebylex_test.go
+++ b/ms/zrevrangebylex_test.go
@@ -46,7 +46,7 @@ func TestZrevrangebylexEmptyMax(t *testing.T) {
 func TestZrevrangebylexError(t *testing.T) {
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "Unit test error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "Unit test error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/ms/zrevrangebyscore.go
+++ b/ms/zrevrangebyscore.go
@@ -38,7 +38,7 @@ func (ms *Ms) Zrevrangebyscore(key string, min float64, max float64, options typ
 
 	res := <-result
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return nil, res.Error
 	}
 

--- a/ms/zrevrangebyscore_test.go
+++ b/ms/zrevrangebyscore_test.go
@@ -28,7 +28,7 @@ import (
 func TestZrevrangebyscoreError(t *testing.T) {
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "Unit test error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "Unit test error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/ms/zrevrank.go
+++ b/ms/zrevrank.go
@@ -34,7 +34,7 @@ func (ms *Ms) Zrevrank(key string, member string, options types.QueryOptions) (i
 
 	res := <-result
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return 0, res.Error
 	}
 

--- a/ms/zrevrank_test.go
+++ b/ms/zrevrank_test.go
@@ -28,7 +28,7 @@ import (
 func TestZrevrankError(t *testing.T) {
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "Unit test error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "Unit test error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/ms/zscan.go
+++ b/ms/zscan.go
@@ -50,7 +50,7 @@ func (ms *Ms) Zscan(key string, cursor int, options types.QueryOptions) (*types.
 
 	res := <-result
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return nil, res.Error
 	}
 

--- a/ms/zscan_test.go
+++ b/ms/zscan_test.go
@@ -28,7 +28,7 @@ import (
 func TestZscanError(t *testing.T) {
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "Unit test error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "Unit test error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/ms/zscore.go
+++ b/ms/zscore.go
@@ -35,7 +35,7 @@ func (ms *Ms) Zscore(key string, member string, options types.QueryOptions) (flo
 
 	res := <-result
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return 0, res.Error
 	}
 

--- a/ms/zscore_test.go
+++ b/ms/zscore_test.go
@@ -28,7 +28,7 @@ import (
 func TestZscoreError(t *testing.T) {
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "Unit test error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "Unit test error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/ms/zunionstore.go
+++ b/ms/zunionstore.go
@@ -57,7 +57,7 @@ func (ms *Ms) Zunionstore(destination string, keys []string, options types.Query
 
 	res := <-result
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return 0, res.Error
 	}
 

--- a/ms/zunionstore_test.go
+++ b/ms/zunionstore_test.go
@@ -37,7 +37,7 @@ func TestZunionstoreEmptyKeys(t *testing.T) {
 func TestZunionstoreError(t *testing.T) {
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "Unit test error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "Unit test error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/realtime/count.go
+++ b/realtime/count.go
@@ -42,7 +42,7 @@ func (r *Realtime) Count(index, collection, roomID string) (int, error) {
 
 	res := <-result
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return -1, res.Error
 	}
 

--- a/realtime/count_test.go
+++ b/realtime/count_test.go
@@ -56,7 +56,7 @@ func TestCountRoomIDNull(t *testing.T) {
 func TestCountError(t *testing.T) {
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "Unit test error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "Unit test error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/realtime/join.go
+++ b/realtime/join.go
@@ -56,7 +56,7 @@ func (r *Realtime) Join(index, collection, roomID string, options types.RoomOpti
 	go r.k.Query(query, opts, result)
 
 	res := <-result
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return res.Error
 	}
 

--- a/realtime/list.go
+++ b/realtime/list.go
@@ -39,7 +39,7 @@ func (r *Realtime) List(index string, collection string) (json.RawMessage, error
 
 	res := <-result
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return nil, res.Error
 	}
 

--- a/realtime/list_test.go
+++ b/realtime/list_test.go
@@ -54,7 +54,7 @@ func TestListError(t *testing.T) {
 
 	_, err := nr.List("index", "collection")
 	assert.NotNil(t, err)
-	assert.Equal(t, "Unit test error", err.(*types.KuzzleError).Message)
+	assert.Equal(t, "Unit test error", err.(types.KuzzleError).Message)
 }
 
 func TestList(t *testing.T) {

--- a/realtime/publish.go
+++ b/realtime/publish.go
@@ -36,7 +36,7 @@ func (r *Realtime) Publish(index string, collection string, body string) error {
 
 	res := <-result
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return res.Error
 	}
 

--- a/realtime/subscribe.go
+++ b/realtime/subscribe.go
@@ -56,7 +56,7 @@ func (r *Realtime) Subscribe(index, collection string, filters json.RawMessage, 
 
 	res := <-result
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return nil, res.Error
 	}
 

--- a/realtime/subscribe_test.go
+++ b/realtime/subscribe_test.go
@@ -76,7 +76,7 @@ func TestSubscribeQueryError(t *testing.T) {
 
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "ah!"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "ah!"}}
 		},
 	}
 	k, _ = kuzzle.NewKuzzle(c, nil)
@@ -134,7 +134,7 @@ func TestRoomSubscribeNotConnected(t *testing.T) {
 
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "Not Connected"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "Not Connected"}}
 		},
 	}
 

--- a/realtime/unsubscribe.go
+++ b/realtime/unsubscribe.go
@@ -38,7 +38,7 @@ func (r *Realtime) Unsubscribe(roomID string) error {
 
 	res := <-result
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return res.Error
 	}
 

--- a/realtime/validate.go
+++ b/realtime/validate.go
@@ -40,7 +40,7 @@ func (r *Realtime) Validate(index string, collection string, body string) (bool,
 
 	res := <-result
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return false, res.Error
 	}
 

--- a/security/createCredentials.go
+++ b/security/createCredentials.go
@@ -39,7 +39,7 @@ func (s *Security) CreateCredentials(strategy, id string, body json.RawMessage, 
 
 	res := <-result
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return nil, res.Error
 	}
 

--- a/security/createCredentials_test.go
+++ b/security/createCredentials_test.go
@@ -45,7 +45,7 @@ func TestCreateCredentialsBodyNull(t *testing.T) {
 func TestCreateCredentialsError(t *testing.T) {
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "Unit test error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "Unit test error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/security/createFirstAdmin.go
+++ b/security/createFirstAdmin.go
@@ -42,7 +42,7 @@ func (s *Security) CreateFirstAdmin(body json.RawMessage, options types.QueryOpt
 
 	res := <-result
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return nil, res.Error
 	}
 

--- a/security/createFirstAdmin_test.go
+++ b/security/createFirstAdmin_test.go
@@ -33,7 +33,7 @@ func TestCreateFirstAdminBodyNull(t *testing.T) {
 func TestCreateFirstAdminError(t *testing.T) {
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "Unit test error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "Unit test error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/security/createOrReplaceProfile.go
+++ b/security/createOrReplaceProfile.go
@@ -38,7 +38,7 @@ func (s *Security) CreateOrReplaceProfile(id string, body json.RawMessage, optio
 
 	res := <-result
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return nil, res.Error
 	}
 

--- a/security/createOrReplaceProfile_test.go
+++ b/security/createOrReplaceProfile_test.go
@@ -33,7 +33,7 @@ func TestCreateOrReplaceProfileBodyNull(t *testing.T) {
 func TestCreateOrReplaceProfileError(t *testing.T) {
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "Unit test error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "Unit test error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/security/createOrReplaceRole.go
+++ b/security/createOrReplaceRole.go
@@ -38,7 +38,7 @@ func (s *Security) CreateOrReplaceRole(id string, body json.RawMessage, options 
 
 	res := <-result
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return nil, res.Error
 	}
 

--- a/security/createOrReplaceRole_test.go
+++ b/security/createOrReplaceRole_test.go
@@ -33,7 +33,7 @@ func TestCreateOrReplaceRoleBodyNull(t *testing.T) {
 func TestCreateOrReplaceRoleError(t *testing.T) {
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "Unit test error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "Unit test error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/security/createProfile.go
+++ b/security/createProfile.go
@@ -38,7 +38,7 @@ func (s *Security) CreateProfile(id string, body json.RawMessage, options types.
 
 	res := <-result
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return nil, res.Error
 	}
 

--- a/security/createProfile_test.go
+++ b/security/createProfile_test.go
@@ -39,7 +39,7 @@ func TestCreateProfileBodyNull(t *testing.T) {
 func TestCreateProfileError(t *testing.T) {
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "Unit test error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "Unit test error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/security/createRestrictedUser.go
+++ b/security/createRestrictedUser.go
@@ -41,7 +41,7 @@ func (s *Security) CreateRestrictedUser(body json.RawMessage, options types.Quer
 
 	res := <-result
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return nil, res.Error
 	}
 

--- a/security/createRestrictedUser_test.go
+++ b/security/createRestrictedUser_test.go
@@ -33,7 +33,7 @@ func TestCreateRestrictedUserBodyNull(t *testing.T) {
 func TestCreateRestrictedUserError(t *testing.T) {
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "Unit test error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "Unit test error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/security/createRole.go
+++ b/security/createRole.go
@@ -38,7 +38,7 @@ func (s *Security) CreateRole(id string, body json.RawMessage, options types.Que
 
 	res := <-result
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return nil, res.Error
 	}
 

--- a/security/createRole_test.go
+++ b/security/createRole_test.go
@@ -39,7 +39,7 @@ func TestCreateRoleBodyNull(t *testing.T) {
 func TestCreateRoleError(t *testing.T) {
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "Unit test error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "Unit test error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/security/createUser.go
+++ b/security/createUser.go
@@ -37,7 +37,7 @@ func (s *Security) CreateUser(body json.RawMessage, options types.QueryOptions) 
 
 	res := <-result
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return nil, res.Error
 	}
 

--- a/security/createUser_test.go
+++ b/security/createUser_test.go
@@ -33,7 +33,7 @@ func TestCreateUserBodyNull(t *testing.T) {
 func TestCreateUserError(t *testing.T) {
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "Unit test error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "Unit test error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/security/deleteCredentials.go
+++ b/security/deleteCredentials.go
@@ -36,7 +36,7 @@ func (s *Security) DeleteCredentials(strategy, id string, options types.QueryOpt
 
 	res := <-result
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return res.Error
 	}
 

--- a/security/deleteCredentials_test.go
+++ b/security/deleteCredentials_test.go
@@ -39,7 +39,7 @@ func TestDeleteCredentialsIDNull(t *testing.T) {
 func TestDeleteCredentialsError(t *testing.T) {
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "Unit test error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "Unit test error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/security/deleteProfile.go
+++ b/security/deleteProfile.go
@@ -37,7 +37,7 @@ func (s *Security) DeleteProfile(id string, options types.QueryOptions) (string,
 
 	res := <-result
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return "", res.Error
 	}
 

--- a/security/deleteProfile_test.go
+++ b/security/deleteProfile_test.go
@@ -33,7 +33,7 @@ func TestDeleteProfileIDNull(t *testing.T) {
 func TestDeleteProfileError(t *testing.T) {
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "Unit test error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "Unit test error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/security/deleteRole.go
+++ b/security/deleteRole.go
@@ -37,7 +37,7 @@ func (s *Security) DeleteRole(id string, options types.QueryOptions) (string, er
 
 	res := <-result
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return "", res.Error
 	}
 

--- a/security/deleteRole_test.go
+++ b/security/deleteRole_test.go
@@ -33,7 +33,7 @@ func TestDeleteRoleIDNull(t *testing.T) {
 func TestDeleteRoleError(t *testing.T) {
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "Unit test error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "Unit test error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/security/deleteUser.go
+++ b/security/deleteUser.go
@@ -37,7 +37,7 @@ func (s *Security) DeleteUser(id string, options types.QueryOptions) (string, er
 
 	res := <-result
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return "", res.Error
 	}
 

--- a/security/deleteUser_test.go
+++ b/security/deleteUser_test.go
@@ -33,7 +33,7 @@ func TestDeleteUserIDNull(t *testing.T) {
 func TestDeleteUserError(t *testing.T) {
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "Unit test error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "Unit test error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/security/getAllCredentialFields.go
+++ b/security/getAllCredentialFields.go
@@ -32,7 +32,7 @@ func (s *Security) GetAllCredentialFields(options types.QueryOptions) (json.RawM
 
 	res := <-ch
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return nil, res.Error
 	}
 

--- a/security/getAllCredentialFields_test.go
+++ b/security/getAllCredentialFields_test.go
@@ -33,7 +33,7 @@ func TestGetAllCredentialFieldsError(t *testing.T) {
 			json.Unmarshal(query, &request)
 			assert.Equal(t, "security", request.Controller)
 			assert.Equal(t, "getAllCredentialFields", request.Action)
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/security/getCredentialFields.go
+++ b/security/getCredentialFields.go
@@ -37,7 +37,7 @@ func (s *Security) GetCredentialFields(strategy string, options types.QueryOptio
 
 	res := <-ch
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return nil, res.Error
 	}
 

--- a/security/getCredentialFields_test.go
+++ b/security/getCredentialFields_test.go
@@ -29,7 +29,7 @@ import (
 func TestGetCredentialFieldsEmptyStrategy(t *testing.T) {
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "unit test error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "Unit test error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)
@@ -45,7 +45,7 @@ func TestGetCredentialFieldsError(t *testing.T) {
 			assert.Equal(t, "security", request.Controller)
 			assert.Equal(t, "getCredentialFields", request.Action)
 			assert.Equal(t, "local", request.Strategy)
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/security/getCredentials.go
+++ b/security/getCredentials.go
@@ -37,7 +37,7 @@ func (s *Security) GetCredentials(strategy, id string, options types.QueryOption
 
 	res := <-ch
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return nil, res.Error
 	}
 

--- a/security/getCredentialsById.go
+++ b/security/getCredentialsById.go
@@ -38,7 +38,7 @@ func (s *Security) GetCredentialsByID(strategy, id string, options types.QueryOp
 
 	res := <-ch
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return nil, res.Error
 	}
 

--- a/security/getCredentialsById_test.go
+++ b/security/getCredentialsById_test.go
@@ -39,7 +39,7 @@ func TestGetCredentialsByIDIDNull(t *testing.T) {
 func TestGetCredentialsByIDError(t *testing.T) {
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "Unit test error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "Unit test error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/security/getCredentials_test.go
+++ b/security/getCredentials_test.go
@@ -39,7 +39,7 @@ func TestGetCredentialsIDNull(t *testing.T) {
 func TestGetCredentialsError(t *testing.T) {
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "Unit test error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "Unit test error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/security/getProfile.go
+++ b/security/getProfile.go
@@ -37,7 +37,7 @@ func (s *Security) GetProfile(id string, options types.QueryOptions) (*Profile, 
 
 	res := <-ch
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return nil, res.Error
 	}
 

--- a/security/getProfileMapping.go
+++ b/security/getProfileMapping.go
@@ -32,7 +32,7 @@ func (s *Security) GetProfileMapping(options types.QueryOptions) (json.RawMessag
 
 	res := <-ch
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return nil, res.Error
 	}
 

--- a/security/getProfileMapping_test.go
+++ b/security/getProfileMapping_test.go
@@ -27,7 +27,7 @@ import (
 func TestGetProfileMappingError(t *testing.T) {
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "Unit test error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "Unit test error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/security/getProfileRights.go
+++ b/security/getProfileRights.go
@@ -37,7 +37,7 @@ func (s *Security) GetProfileRights(id string, options types.QueryOptions) (json
 
 	res := <-ch
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return nil, res.Error
 	}
 

--- a/security/getProfileRights_test.go
+++ b/security/getProfileRights_test.go
@@ -34,7 +34,7 @@ func TestGetProfileRightsIDNull(t *testing.T) {
 func TestGetProfileRightsError(t *testing.T) {
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "Unit test error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "Unit test error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/security/getRole.go
+++ b/security/getRole.go
@@ -36,7 +36,7 @@ func (s *Security) GetRole(id string, options types.QueryOptions) (*Role, error)
 
 	res := <-ch
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return nil, res.Error
 	}
 

--- a/security/getRoleMapping.go
+++ b/security/getRoleMapping.go
@@ -32,7 +32,7 @@ func (s *Security) GetRoleMapping(options types.QueryOptions) (json.RawMessage, 
 
 	res := <-ch
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return nil, res.Error
 	}
 

--- a/security/getRoleMapping_test.go
+++ b/security/getRoleMapping_test.go
@@ -27,7 +27,7 @@ import (
 func TestGetRoleMappingError(t *testing.T) {
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "Unit test error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "Unit test error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/security/getRole_test.go
+++ b/security/getRole_test.go
@@ -42,7 +42,7 @@ func TestGetRoleEmptyId(t *testing.T) {
 func TestGetRoleError(t *testing.T) {
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "Unit test error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "Unit test error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/security/getUser.go
+++ b/security/getUser.go
@@ -36,7 +36,7 @@ func (s *Security) GetUser(id string, options types.QueryOptions) (*User, error)
 
 	res := <-ch
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return nil, res.Error
 	}
 

--- a/security/getUserMapping.go
+++ b/security/getUserMapping.go
@@ -32,7 +32,7 @@ func (s *Security) GetUserMapping(options types.QueryOptions) (json.RawMessage, 
 
 	res := <-ch
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return nil, res.Error
 	}
 

--- a/security/getUserMapping_test.go
+++ b/security/getUserMapping_test.go
@@ -27,7 +27,7 @@ import (
 func TestGetUserMappingError(t *testing.T) {
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "Unit test error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "Unit test error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/security/getUserRights.go
+++ b/security/getUserRights.go
@@ -37,7 +37,7 @@ func (s *Security) GetUserRights(id string, options types.QueryOptions) (json.Ra
 
 	res := <-ch
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return nil, res.Error
 	}
 

--- a/security/getUserRights_test.go
+++ b/security/getUserRights_test.go
@@ -34,7 +34,7 @@ func TestGetUserRightsIDNull(t *testing.T) {
 func TestGetUserRightsError(t *testing.T) {
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "Unit test error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "Unit test error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/security/hasCredentials.go
+++ b/security/hasCredentials.go
@@ -38,7 +38,7 @@ func (s *Security) HasCredentials(strategy, id string, options types.QueryOption
 
 	res := <-ch
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return false, res.Error
 	}
 

--- a/security/hasCredentials_test.go
+++ b/security/hasCredentials_test.go
@@ -45,7 +45,7 @@ func TestHasCredentialsIdNull(t *testing.T) {
 func TestHasCredentialsError(t *testing.T) {
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "Unit test error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "Unit test error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/security/mDeleteCredentials.go
+++ b/security/mDeleteCredentials.go
@@ -39,7 +39,7 @@ func (s *Security) MDeleteCredentials(ids []string, options types.QueryOptions) 
 
 	res := <-ch
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return nil, res.Error
 	}
 

--- a/security/mDeleteCredentials_test.go
+++ b/security/mDeleteCredentials_test.go
@@ -33,7 +33,7 @@ func TestMDeleteCredentialsEmptyIDs(t *testing.T) {
 func TestMDeleteCredentialsError(t *testing.T) {
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "Unit test error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "Unit test error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/security/mDeleteRoles.go
+++ b/security/mDeleteRoles.go
@@ -39,7 +39,7 @@ func (s *Security) MDeleteRoles(ids []string, options types.QueryOptions) ([]str
 
 	res := <-ch
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return nil, res.Error
 	}
 

--- a/security/mDeleteRoles_test.go
+++ b/security/mDeleteRoles_test.go
@@ -33,7 +33,7 @@ func TestMDeleteRolesEmptyIDs(t *testing.T) {
 func TestMDeleteRolesError(t *testing.T) {
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "Unit test error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "Unit test error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/security/mDeleteUsers.go
+++ b/security/mDeleteUsers.go
@@ -39,7 +39,7 @@ func (s *Security) MDeleteUsers(ids []string, options types.QueryOptions) ([]str
 
 	res := <-ch
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return nil, res.Error
 	}
 

--- a/security/mDeleteUsers_test.go
+++ b/security/mDeleteUsers_test.go
@@ -33,7 +33,7 @@ func TestMDeleteUsersEmptyIDs(t *testing.T) {
 func TestMDeleteUsersError(t *testing.T) {
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "Unit test error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "Unit test error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/security/mGetProfiles.go
+++ b/security/mGetProfiles.go
@@ -39,7 +39,7 @@ func (s *Security) MGetProfiles(ids []string, options types.QueryOptions) ([]*Pr
 
 	res := <-ch
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return nil, res.Error
 	}
 

--- a/security/mGetRoles.go
+++ b/security/mGetRoles.go
@@ -39,7 +39,7 @@ func (s *Security) MGetRoles(ids []string, options types.QueryOptions) ([]*Role,
 
 	res := <-ch
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return nil, res.Error
 	}
 

--- a/security/replaceUser.go
+++ b/security/replaceUser.go
@@ -38,7 +38,7 @@ func (s *Security) ReplaceUser(id string, content json.RawMessage, options types
 
 	res := <-ch
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return nil, res.Error
 	}
 

--- a/security/replaceUser_test.go
+++ b/security/replaceUser_test.go
@@ -41,7 +41,7 @@ func TestReplaceUserContentNull(t *testing.T) {
 func TestReplaceUserError(t *testing.T) {
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "unit test error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "Unit test error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/security/searchProfiles.go
+++ b/security/searchProfiles.go
@@ -43,7 +43,7 @@ func (s *Security) SearchProfiles(body json.RawMessage, options types.QueryOptio
 
 	res := <-ch
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return nil, res.Error
 	}
 

--- a/security/searchRoles.go
+++ b/security/searchRoles.go
@@ -43,7 +43,7 @@ func (s *Security) SearchRoles(body json.RawMessage, options types.QueryOptions)
 
 	res := <-ch
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return nil, res.Error
 	}
 	jsonSearchResult := &jsonRoleSearchResult{}

--- a/security/searchRoles_test.go
+++ b/security/searchRoles_test.go
@@ -29,7 +29,7 @@ import (
 func TestSearchRolesError(t *testing.T) {
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "Unit test error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "Unit test error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/security/searchUsers.go
+++ b/security/searchUsers.go
@@ -43,7 +43,7 @@ func (s *Security) SearchUsers(body json.RawMessage, options types.QueryOptions)
 
 	res := <-ch
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return nil, res.Error
 	}
 

--- a/security/updateCredentials.go
+++ b/security/updateCredentials.go
@@ -39,7 +39,7 @@ func (s *Security) UpdateCredentials(strategy string, kuid string, body json.Raw
 
 	res := <-result
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return res.Error
 	}
 

--- a/security/updateCredentials_test.go
+++ b/security/updateCredentials_test.go
@@ -33,7 +33,7 @@ func TestUpdateCredentialsQueryError(t *testing.T) {
 			json.Unmarshal(query, &request)
 			assert.Equal(t, "security", request.Controller)
 			assert.Equal(t, "updateCredentials", request.Action)
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)
@@ -44,7 +44,7 @@ func TestUpdateCredentialsQueryError(t *testing.T) {
 func TestUpdateCredentialsEmptyStrategy(t *testing.T) {
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "unit test error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "Unit test error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)
@@ -55,7 +55,7 @@ func TestUpdateCredentialsEmptyStrategy(t *testing.T) {
 func TestUpdateCredentialsEmptyKuid(t *testing.T) {
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "unit test error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "Unit test error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/security/updateProfile.go
+++ b/security/updateProfile.go
@@ -37,7 +37,7 @@ func (s *Security) UpdateProfile(id string, body json.RawMessage, options types.
 
 	res := <-ch
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return nil, res.Error
 	}
 

--- a/security/updateProfileMapping.go
+++ b/security/updateProfileMapping.go
@@ -36,7 +36,7 @@ func (s *Security) UpdateProfileMapping(body json.RawMessage, options types.Quer
 
 	res := <-ch
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return res.Error
 	}
 

--- a/security/updateRole.go
+++ b/security/updateRole.go
@@ -37,7 +37,7 @@ func (s *Security) UpdateRole(id string, body json.RawMessage, options types.Que
 
 	res := <-ch
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return nil, res.Error
 	}
 

--- a/security/updateRoleMapping.go
+++ b/security/updateRoleMapping.go
@@ -36,7 +36,7 @@ func (s *Security) UpdateRoleMapping(body json.RawMessage, options types.QueryOp
 
 	res := <-ch
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return res.Error
 	}
 

--- a/security/updateUser.go
+++ b/security/updateUser.go
@@ -37,7 +37,7 @@ func (s *Security) UpdateUser(id string, body json.RawMessage, options types.Que
 
 	res := <-ch
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return nil, res.Error
 	}
 

--- a/security/updateUserMapping.go
+++ b/security/updateUserMapping.go
@@ -36,7 +36,7 @@ func (s *Security) UpdateUserMapping(body json.RawMessage, options types.QueryOp
 
 	res := <-ch
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return res.Error
 	}
 

--- a/security/validateCredentials.go
+++ b/security/validateCredentials.go
@@ -39,7 +39,7 @@ func (s *Security) ValidateCredentials(strategy string, kuid string, body json.R
 
 	res := <-result
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return false, res.Error
 	}
 

--- a/security/validateCredentials_test.go
+++ b/security/validateCredentials_test.go
@@ -33,7 +33,7 @@ func TestValidateCredentialsQueryError(t *testing.T) {
 			json.Unmarshal(query, &request)
 			assert.Equal(t, "security", request.Controller)
 			assert.Equal(t, "validateCredentials", request.Action)
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)
@@ -44,7 +44,7 @@ func TestValidateCredentialsQueryError(t *testing.T) {
 func TestValidateCredentialsEmptyStrategy(t *testing.T) {
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "unit test error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "Unit test error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)
@@ -55,7 +55,7 @@ func TestValidateCredentialsEmptyStrategy(t *testing.T) {
 func TestValidateCredentialsEmptyKuid(t *testing.T) {
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "unit test error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "Unit test error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/server/adminExists.go
+++ b/server/adminExists.go
@@ -33,7 +33,7 @@ func (s *Server) AdminExists(options types.QueryOptions) (bool, error) {
 
 	res := <-result
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return false, res.Error
 	}
 

--- a/server/adminExists_test.go
+++ b/server/adminExists_test.go
@@ -33,7 +33,7 @@ func TestAdminExistsQueryError(t *testing.T) {
 			assert.Equal(t, "server", request.Controller)
 			assert.Equal(t, "adminExists", request.Action)
 
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/server/getAllStats.go
+++ b/server/getAllStats.go
@@ -33,7 +33,7 @@ func (s *Server) GetAllStats(options types.QueryOptions) (json.RawMessage, error
 
 	res := <-result
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return nil, res.Error
 	}
 	return res.Result, nil

--- a/server/getAllStats_test.go
+++ b/server/getAllStats_test.go
@@ -33,7 +33,7 @@ func TestGetAllStatsQueryError(t *testing.T) {
 			json.Unmarshal(query, &request)
 			assert.Equal(t, "server", request.Controller)
 			assert.Equal(t, "getAllStats", request.Action)
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/server/getConfig.go
+++ b/server/getConfig.go
@@ -32,7 +32,7 @@ func (s *Server) GetConfig(options types.QueryOptions) (json.RawMessage, error) 
 
 	res := <-result
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return nil, res.Error
 	}
 

--- a/server/getConfig_test.go
+++ b/server/getConfig_test.go
@@ -33,7 +33,7 @@ func TestGetConfigQueryError(t *testing.T) {
 			assert.Equal(t, "server", request.Controller)
 			assert.Equal(t, "getConfig", request.Action)
 
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/server/getLastStats.go
+++ b/server/getLastStats.go
@@ -33,7 +33,7 @@ func (s *Server) GetLastStats(options types.QueryOptions) (json.RawMessage, erro
 
 	res := <-result
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return nil, res.Error
 	}
 

--- a/server/getLastStats_test.go
+++ b/server/getLastStats_test.go
@@ -33,7 +33,7 @@ func TestGetLastStatsQueryError(t *testing.T) {
 			json.Unmarshal(query, &request)
 			assert.Equal(t, "server", request.Controller)
 			assert.Equal(t, "getLastStats", request.Action)
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/server/getStats.go
+++ b/server/getStats.go
@@ -48,7 +48,7 @@ func (s *Server) GetStats(startTime *time.Time, stopTime *time.Time, options typ
 
 	res := <-result
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return nil, res.Error
 	}
 

--- a/server/getStats_test.go
+++ b/server/getStats_test.go
@@ -34,7 +34,7 @@ func TestGetStatsQueryError(t *testing.T) {
 			json.Unmarshal(query, &request)
 			assert.Equal(t, "server", request.Controller)
 			assert.Equal(t, "getLastStats", request.Action)
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/server/info.go
+++ b/server/info.go
@@ -32,7 +32,7 @@ func (s *Server) Info(options types.QueryOptions) (json.RawMessage, error) {
 
 	res := <-result
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return nil, res.Error
 	}
 

--- a/server/info_test.go
+++ b/server/info_test.go
@@ -33,7 +33,7 @@ func TestInfoQueryError(t *testing.T) {
 			assert.Equal(t, "server", request.Controller)
 			assert.Equal(t, "info", request.Action)
 
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/server/now.go
+++ b/server/now.go
@@ -32,7 +32,7 @@ func (s *Server) Now(options types.QueryOptions) (int, error) {
 
 	res := <-result
 
-	if res.Error != nil {
+	if res.Error.Error() != "" {
 		return -1, res.Error
 	}
 

--- a/server/now_test.go
+++ b/server/now_test.go
@@ -29,7 +29,7 @@ import (
 func TestNowQueryError(t *testing.T) {
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			return &types.KuzzleResponse{Error: &types.KuzzleError{Message: "error"}}
+			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "error"}}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)

--- a/types/kuzzle_response.go
+++ b/types/kuzzle_response.go
@@ -68,7 +68,7 @@ type (
 		Channel    string              `json:"channel"`
 		Timestamp  int                 `json:"timestamp"`
 		Status     int                 `json:"status"`
-		Error      *KuzzleError        `json:"error"`
+		Error      KuzzleError         `json:"error"`
 	}
 
 	// KuzzleResponse is a response to a KuzzleRequest
@@ -83,7 +83,7 @@ type (
 		RoomId     string          `json:"room"`
 		Channel    string          `json:"channel"`
 		Status     int             `json:"status"`
-		Error      *KuzzleError    `json:"error"`
+		Error      KuzzleError     `json:"error"`
 	}
 
 	SpecificationField struct {
@@ -263,7 +263,7 @@ type (
 	}
 )
 
-func (e *KuzzleError) Error() string {
+func (e KuzzleError) Error() string {
 	msg := e.Message
 
 	if len(e.Stack) > 0 {
@@ -278,8 +278,8 @@ func (e *KuzzleError) Error() string {
 }
 
 // NewError instanciates a new KuzzleError
-func NewError(msg string, status ...int) *KuzzleError {
-	err := &KuzzleError{Message: msg}
+func NewError(msg string, status ...int) KuzzleError {
+	err := KuzzleError{Message: msg}
 
 	if len(status) == 1 {
 		err.Status = status[0]


### PR DESCRIPTION
## What does this PR do ?

- Make KuzzleResponse.Error a no npointer type
- Remove pointer receveiver on KuzzleError Error() function