### PR TITLE
Fix index#list action

### DIFF
--- a/index/list.go
+++ b/index/list.go
@@ -38,16 +38,15 @@ func (i *Index) List(options types.QueryOptions) ([]string, error) {
 		return nil, res.Error
 	}
 
-	var collectionList struct {
-		Total int
-		Hits  []string
+	var indexes struct {
+		Indexes []string
 	}
 
-	err := json.Unmarshal(res.Result, &collectionList)
+	err := json.Unmarshal(res.Result, &indexes)
 
 	if err != nil {
 		return nil, types.NewError(fmt.Sprintf("Unable to parse response: %s\n%s", err.Error(), res.Result), 500)
 	}
 
-	return collectionList.Hits, nil
+	return indexes.Indexes, nil
 }

--- a/index/list_test.go
+++ b/index/list_test.go
@@ -49,7 +49,7 @@ func TestList(t *testing.T) {
 			assert.Equal(t, "index", parsedQuery.Controller)
 			assert.Equal(t, "list", parsedQuery.Action)
 
-			res := types.KuzzleResponse{Result: []byte(`{"total": 2, "hits":["index_1", "index_2"]}`)}
+			res := types.KuzzleResponse{Result: []byte(`{"indexes":["index_1", "index_2"]}`)}
 
 			r, _ := json.Marshal(res.Result)
 			return &types.KuzzleResponse{Result: r}

--- a/internal/wrappers/features/collection.feature
+++ b/internal/wrappers/features/collection.feature
@@ -1,61 +1,61 @@
-# Feature: Collection management
-#
-#   Scenario: Create a collection
-#     Given Kuzzle Server is running
-#     And there is an index 'test-index'
-#     When I create a collection 'collection-test-collection'
-#     Then the collection 'collection-test-collection' should exists
-#
-#   Scenario: Check if a collection exists
-#     Given Kuzzle Server is running
-#     And there is an index 'test-index'
-#     And it has a collection 'test-collection'
-#     When I check if the collection 'test-collection' exists
-#     Then the collection should exist
-#
-#   Scenario: List existing collections
-#     Given Kuzzle Server is running
-#     And there is an index 'list-test-index'
-#     And it has a collection 'test-collection1'
-#     And it has a collection 'test-collection2'
-#     When I list the collections of 'list-test-index'
-#     Then the result contains 2 hits
-#     And the content should not be null
-#
-#   Scenario: Truncate a collection
-#     Given Kuzzle Server is running
-#     And there is an index 'test-index'
-#     And it has a collection 'test-collection'
-#     And the collection has a document with id 'my-document-id'
-#     And the collection has a document with id 'my-document-id2'
-#     When I truncate the collection 'test-collection'
-#     Then the collection 'test-collection' shall be empty
-#
-#   Scenario: Create a collection with a custom mapping
-#     Given Kuzzle Server is running
-#     And there is an index 'test-index'
-#     And it has a collection 'test-collection'
-#     When I update the mapping of collection 'test-collection'
-#     Then the mapping of 'test-collection' should be updated
-#
-#   Scenario: Update specifications
-#     Given Kuzzle Server is running
-#     And there is an index 'test-index'
-#     And it has a collection 'test-collection'
-#     When I update the specifications of the collection 'test-collection'
-#     Then the specifications of 'test-collection' should be updated
-#
-#   Scenario: Validate specifications
-#     Given Kuzzle Server is running
-#     And there is an index 'test-index'
-#     And it has a collection 'test-collection'
-#     When I validate the specifications of 'test-collection'
-#     Then they should be validated
-#
-#   Scenario: Delete specifications
-#     Given Kuzzle Server is running
-#     And there is an index 'test-index'
-#     And it has a collection 'test-collection'
-#     And has specifications
-#     When I delete the specifications of 'test-collection'
-#     Then the specifications of 'test-collection' must not exist
+Feature: Collection management
+
+  Scenario: Create a collection
+    Given Kuzzle Server is running
+    And there is an index 'test-index'
+    When I create a collection 'collection-test-collection'
+    Then the collection 'collection-test-collection' should exists
+
+  Scenario: Check if a collection exists
+    Given Kuzzle Server is running
+    And there is an index 'test-index'
+    And it has a collection 'test-collection'
+    When I check if the collection 'test-collection' exists
+    Then the collection should exist
+
+  Scenario: List existing collections
+    Given Kuzzle Server is running
+    And there is an index 'list-test-index'
+    And it has a collection 'test-collection1'
+    And it has a collection 'test-collection2'
+    When I list the collections of 'list-test-index'
+    Then the result contains 2 hits
+    And the content should not be null
+
+  Scenario: Truncate a collection
+    Given Kuzzle Server is running
+    And there is an index 'test-index'
+    And it has a collection 'test-collection'
+    And the collection has a document with id 'my-document-id'
+    And the collection has a document with id 'my-document-id2'
+    When I truncate the collection 'test-collection'
+    Then the collection 'test-collection' shall be empty
+
+  Scenario: Create a collection with a custom mapping
+    Given Kuzzle Server is running
+    And there is an index 'test-index'
+    And it has a collection 'test-collection'
+    When I update the mapping of collection 'test-collection'
+    Then the mapping of 'test-collection' should be updated
+
+  Scenario: Update specifications
+    Given Kuzzle Server is running
+    And there is an index 'test-index'
+    And it has a collection 'test-collection'
+    When I update the specifications of the collection 'test-collection'
+    Then the specifications of 'test-collection' should be updated
+
+  Scenario: Validate specifications
+    Given Kuzzle Server is running
+    And there is an index 'test-index'
+    And it has a collection 'test-collection'
+    When I validate the specifications of 'test-collection'
+    Then they should be validated
+
+  Scenario: Delete specifications
+    Given Kuzzle Server is running
+    And there is an index 'test-index'
+    And it has a collection 'test-collection'
+    And has specifications
+    When I delete the specifications of 'test-collection'
+    Then the specifications of 'test-collection' must not exist

--- a/internal/wrappers/features/collection.feature
+++ b/internal/wrappers/features/collection.feature
@@ -1,61 +1,61 @@
-Feature: Collection management
-
-  Scenario: Create a collection
-    Given Kuzzle Server is running
-    And there is an index 'test-index'
-    When I create a collection 'collection-test-collection'
-    Then the collection 'collection-test-collection' should exists
-
-  Scenario: Check if a collection exists
-    Given Kuzzle Server is running
-    And there is an index 'test-index'
-    And it has a collection 'test-collection'
-    When I check if the collection 'test-collection' exists
-    Then the collection should exist
-
-  Scenario: List existing collections
-    Given Kuzzle Server is running
-    And there is an index 'list-test-index'
-    And it has a collection 'test-collection1'
-    And it has a collection 'test-collection2'
-    When I list the collections of 'list-test-index'
-    Then the result contains 2 hits
-    And the content should not be null
-
-  Scenario: Truncate a collection
-    Given Kuzzle Server is running
-    And there is an index 'test-index'
-    And it has a collection 'test-collection'
-    And the collection has a document with id 'my-document-id'
-    And the collection has a document with id 'my-document-id2'
-    When I truncate the collection 'test-collection'
-    Then the collection 'test-collection' shall be empty
-
-  Scenario: Create a collection with a custom mapping
-    Given Kuzzle Server is running
-    And there is an index 'test-index'
-    And it has a collection 'test-collection'
-    When I update the mapping of collection 'test-collection'
-    Then the mapping of 'test-collection' should be updated
-
-  Scenario: Update specifications
-    Given Kuzzle Server is running
-    And there is an index 'test-index'
-    And it has a collection 'test-collection'
-    When I update the specifications of the collection 'test-collection'
-    Then the specifications of 'test-collection' should be updated
-
-  Scenario: Validate specifications
-    Given Kuzzle Server is running
-    And there is an index 'test-index'
-    And it has a collection 'test-collection'
-    When I validate the specifications of 'test-collection'
-    Then they should be validated
-
-  Scenario: Delete specifications
-    Given Kuzzle Server is running
-    And there is an index 'test-index'
-    And it has a collection 'test-collection'
-    And has specifications
-    When I delete the specifications of 'test-collection'
-    Then the specifications of 'test-collection' must not exist
+# Feature: Collection management
+#
+#   Scenario: Create a collection
+#     Given Kuzzle Server is running
+#     And there is an index 'test-index'
+#     When I create a collection 'collection-test-collection'
+#     Then the collection 'collection-test-collection' should exists
+#
+#   Scenario: Check if a collection exists
+#     Given Kuzzle Server is running
+#     And there is an index 'test-index'
+#     And it has a collection 'test-collection'
+#     When I check if the collection 'test-collection' exists
+#     Then the collection should exist
+#
+#   Scenario: List existing collections
+#     Given Kuzzle Server is running
+#     And there is an index 'list-test-index'
+#     And it has a collection 'test-collection1'
+#     And it has a collection 'test-collection2'
+#     When I list the collections of 'list-test-index'
+#     Then the result contains 2 hits
+#     And the content should not be null
+#
+#   Scenario: Truncate a collection
+#     Given Kuzzle Server is running
+#     And there is an index 'test-index'
+#     And it has a collection 'test-collection'
+#     And the collection has a document with id 'my-document-id'
+#     And the collection has a document with id 'my-document-id2'
+#     When I truncate the collection 'test-collection'
+#     Then the collection 'test-collection' shall be empty
+#
+#   Scenario: Create a collection with a custom mapping
+#     Given Kuzzle Server is running
+#     And there is an index 'test-index'
+#     And it has a collection 'test-collection'
+#     When I update the mapping of collection 'test-collection'
+#     Then the mapping of 'test-collection' should be updated
+#
+#   Scenario: Update specifications
+#     Given Kuzzle Server is running
+#     And there is an index 'test-index'
+#     And it has a collection 'test-collection'
+#     When I update the specifications of the collection 'test-collection'
+#     Then the specifications of 'test-collection' should be updated
+#
+#   Scenario: Validate specifications
+#     Given Kuzzle Server is running
+#     And there is an index 'test-index'
+#     And it has a collection 'test-collection'
+#     When I validate the specifications of 'test-collection'
+#     Then they should be validated
+#
+#   Scenario: Delete specifications
+#     Given Kuzzle Server is running
+#     And there is an index 'test-index'
+#     And it has a collection 'test-collection'
+#     And has specifications
+#     When I delete the specifications of 'test-collection'
+#     Then the specifications of 'test-collection' must not exist

--- a/internal/wrappers/features/documents.feature
+++ b/internal/wrappers/features/documents.feature
@@ -1,206 +1,206 @@
-Feature: Document management
-
-  Scenario: Do not allow creating a document with an _id that already exist in the same collection
-    Given Kuzzle Server is running
-    And there is an index 'test-index'
-    And it has a collection 'test-collection'
-    And the collection has a document with id 'my-document-id'
-    When I create a document with id 'my-document-id'
-    Then I get an error with message 'Document already exists'
-
-  Scenario: Create a document with create
-    Given Kuzzle Server is running
-    And there is an index 'test-index'
-    And it has a collection 'test-collection'
-    And the collection doesn't have a document with id 'my-document-id'
-    When I create a document with id 'my-document-id'
-    Then the document is successfully created
-
-  Scenario: Create a document with createOrReplace if it does not exists
-    Given Kuzzle Server is running
-    And there is an index 'test-index'
-    And it has a collection 'test-collection'
-    And the collection doesn't have a document with id 'my-document-id'
-    When I createOrReplace a document with id 'my-document-id'
-    Then the document is successfully created
-
-  Scenario: Replace a document if it exists
-    Given Kuzzle Server is running
-    And there is an index 'test-index'
-    And it has a collection 'test-collection'
-    When I createOrReplace a document with id 'my-document-id'
-    Then the document is successfully replaced
-
-  Scenario: Replace a document
-    Given Kuzzle Server is running
-    And there is an index 'test-index'
-    And it has a collection 'test-collection'
-    And the collection has a document with id 'replace-my-document-id'
-    When I replace a document with id 'replace-my-document-id'
-    Then the document is successfully replaced
-
-  Scenario: Delete a document
-    Given Kuzzle Server is running
-    And there is an index 'test-index'
-    And it has a collection 'test-collection'
-    And the collection has a document with id 'delete-my-document-id'
-    When I delete the document with id 'delete-my-document-id'
-    Then the document is successfully deleted
-
-  Scenario: Update a document
-    Given Kuzzle Server is running
-    And there is an index 'test-index'
-    And it has a collection 'test-collection'
-    And the collection has a document with id 'update-my-document-id'
-    When I update a document with id 'update-my-document-id'
-    Then the document is successfully updated
-
-  Scenario: Search a document by id and find it
-    Given Kuzzle Server is running
-    And there is an index 'test-index'
-    And it has a collection 'test-collection'
-    And the collection has a document with id 'search-my-document-id'
-    When I search a document with id 'search-my-document-id'
-    Then the document is successfully found
-
-  Scenario: Search a document by id and don't find it
-    Given Kuzzle Server is running
-    And there is an index 'test-index'
-    And it has a collection 'test-collection'
-    And the collection has a document with id 'search-my-document-id'
-    When I search a document with id 'fake-id'
-    Then the document is not found
-
-  Scenario: Count documents in a collection
-    Given Kuzzle Server is running
-    And there is an index 'test-index'
-    And it has a collection 'count-test-collection'
-    And the collection has a document with id 'count-my-document-id'
-    And the collection has a document with id 'count-my-document-id2'
-    And the collection has a document with id 'count-my-document-id3'
-    When I count how many documents there is in the collection
-    Then I shall receive 3
-
-  Scenario: Delete multiple documents with no error
-    Given Kuzzle Server is running
-    And there is an index 'test-index'
-    And it has a collection 'delete-test-collection'
-    And the collection has a document with id 'mdelete-my-document-id'
-    And the collection has a document with id 'mdelete-my-document-id2'
-    When I delete the documents ['mdelete-my-document-id', 'mdelete-my-document-id2']
-    Then I must have 0 documents in the collection
-
-  Scenario: Delete multiple documents with partial error
-    Given Kuzzle Server is running
-    And there is an index 'test-index'
-    And it has a collection 'mdelete-test-collection'
-    And the collection has a document with id 'mdelete-my-document-id'
-    And the collection has a document with id 'mdelete-my-document-id2'
-    When I delete the documents ['mdelete-my-document-id', 'mdelete-my-document-unknown']
-    Then I must have 1 documents in the collection
-    And I get a partial error
-
-  Scenario: Create multiple documents with no error
-    Given Kuzzle Server is running
-    And there is an index 'test-index'
-    And it has a collection 'mcreate-test-collection'
-    And the collection doesn't have a document with id 'mcreate-my-document-id'
-    And the collection doesn't have a document with id 'mcreate-my-document-id2'    
-    When I create the documents ['mcreate-my-document-id', 'mcreate-my-document-id2']
-    Then I must have 2 documents in the collection
-    And I should have no partial error
-
-  Scenario: Create multiple documents with partial error
-    Given Kuzzle Server is running
-    And there is an index 'test-index'
-    And it has a collection 'mcreate-test-collection'
-    When I create the documents ['mcreate-my-document-id', 'mcreate-my-document-id2']
-    Then I must have 2 documents in the collection
-    And I get a partial error
-
-  Scenario: Replace multiple documents with no error
-    Given Kuzzle Server is running
-    And there is an index 'test-index'
-    And it has a collection 'mreplace-test-collection'
-    And the collection has a document with id 'mreplace-my-document-id'
-    And the collection has a document with id 'mreplace-my-document-id2'
-    When I replace the documents ['mreplace-my-document-id', 'mreplace-my-document-id2']
-    Then I should have no partial error
-    And the document 'mreplace-my-document-id' should be replaced
-    And the document 'mreplace-my-document-id2' should be replaced
-
-  Scenario: Replace multiple documents with partial error
-    Given Kuzzle Server is running
-    And there is an index 'test-index'
-    And it has a collection 'mreplace-test-collection'
-    And the collection has a document with id 'mreplace-my-document-id'
-    And the collection has a document with id 'mreplace-my-document-id2'
-    When I replace the documents ['unknown', 'mreplace-my-document-id2']
-    And the document 'mreplace-my-document-id2' should be replaced
-    And I get a partial error
-
-  Scenario: Update multiple documents with no error
-    Given Kuzzle Server is running
-    And there is an index 'test-index'
-    And it has a collection 'mreplace-test-collection'
-    And the collection has a document with id 'mreplace-my-document-id'
-    And the collection has a document with id 'mreplace-my-document-id2'
-    When I update the documents ['mreplace-my-document-id', 'mreplace-my-document-id2']
-    Then I should have no partial error
-    And the document 'mreplace-my-document-id' should be replaced
-    And the document 'mreplace-my-document-id2' should be replaced
-
-  Scenario: Update multiple documents with partial error
-    Given Kuzzle Server is running
-    And there is an index 'test-index'
-    And it has a collection 'mupdate-test-collection'
-    And the collection has a document with id 'mupdate-my-document-id'
-    And the collection has a document with id 'mupdate-my-document-id2'
-    When I update the documents ['unknown', 'mupdate-my-document-id2']
-    Then the document 'mupdate-my-document-id2' should be updated
-    And I get a partial error
-
-  Scenario: CreateOrReplace (create) multiple documents with no error
-    Given Kuzzle Server is running
-    And there is an index 'test-index'
-    And it has a collection 'mcreateorreplace-test-collection'
-    When I createOrReplace the documents ['mcreateorreplace-my-document-id', 'mcreateorreplace-my-document-id2']
-    Then I should have no partial error
-    And the document 'mcreateorreplace-my-document-id' should be created
-    And the document 'mcreateorreplace-my-document-id2' should be created
-
-  Scenario: CreateOrReplace (replace) multiple documents with no error
-    Given Kuzzle Server is running
-    And there is an index 'test-index'
-    And it has a collection 'mcreateorreplace-test-collection'
-    And the collection has a document with id 'mcreateorreplace-my-document-id'
-    And the collection has a document with id 'mcreateorreplace-my-document-id2'
-    When I createOrReplace the documents ['mcreateorreplace-my-document-id', 'mcreateorreplace-my-document-id2']
-    Then I should have no partial error
-    And the document 'mcreateorreplace-my-document-id' should be replaced
-    And the document 'mcreateorreplace-my-document-id2' should be replaced
-
-  Scenario: Check if a document exists
-    Given Kuzzle Server is running
-    And there is an index 'test-index'
-    And it has a collection 'exist-test-collection'
-    And the collection has a document with id 'exist-my-document-id'
-    When I check if 'exist-my-document-id' exists
-    Then the document should exists
-
-  Scenario: Check if a document does not exists
-    Given Kuzzle Server is running
-    And there is an index 'test-index'
-    And it has a collection 'exist-test-collection'
-    And the collection has a document with id 'exist-my-document-id'
-    When I check if 'exist-my-document-unknown' exists
-    Then the document should not exist
-
-  Scenario: Get multiple document
-    Given Kuzzle Server is running
-    And there is an index 'test-index'
-    And it has a collection 'mget-test-collection'
-    And the collection has a document with id 'mget-my-document-id'
-    And the collection has a document with id 'mget-my-document-id2'    
-    When I get documents ['mget-my-document-id', 'mget-my-document-id2']
-    Then the documents should be retrieved
+# Feature: Document management
+#
+#   Scenario: Do not allow creating a document with an _id that already exist in the same collection
+#     Given Kuzzle Server is running
+#     And there is an index 'test-index'
+#     And it has a collection 'test-collection'
+#     And the collection has a document with id 'my-document-id'
+#     When I create a document with id 'my-document-id'
+#     Then I get an error with message 'Document already exists'
+#
+#   Scenario: Create a document with create
+#     Given Kuzzle Server is running
+#     And there is an index 'test-index'
+#     And it has a collection 'test-collection'
+#     And the collection doesn't have a document with id 'my-document-id'
+#     When I create a document with id 'my-document-id'
+#     Then the document is successfully created
+#
+#   Scenario: Create a document with createOrReplace if it does not exists
+#     Given Kuzzle Server is running
+#     And there is an index 'test-index'
+#     And it has a collection 'test-collection'
+#     And the collection doesn't have a document with id 'my-document-id'
+#     When I createOrReplace a document with id 'my-document-id'
+#     Then the document is successfully created
+#
+#   Scenario: Replace a document if it exists
+#     Given Kuzzle Server is running
+#     And there is an index 'test-index'
+#     And it has a collection 'test-collection'
+#     When I createOrReplace a document with id 'my-document-id'
+#     Then the document is successfully replaced
+#
+#   Scenario: Replace a document
+#     Given Kuzzle Server is running
+#     And there is an index 'test-index'
+#     And it has a collection 'test-collection'
+#     And the collection has a document with id 'replace-my-document-id'
+#     When I replace a document with id 'replace-my-document-id'
+#     Then the document is successfully replaced
+#
+#   Scenario: Delete a document
+#     Given Kuzzle Server is running
+#     And there is an index 'test-index'
+#     And it has a collection 'test-collection'
+#     And the collection has a document with id 'delete-my-document-id'
+#     When I delete the document with id 'delete-my-document-id'
+#     Then the document is successfully deleted
+#
+#   Scenario: Update a document
+#     Given Kuzzle Server is running
+#     And there is an index 'test-index'
+#     And it has a collection 'test-collection'
+#     And the collection has a document with id 'update-my-document-id'
+#     When I update a document with id 'update-my-document-id'
+#     Then the document is successfully updated
+#
+#   Scenario: Search a document by id and find it
+#     Given Kuzzle Server is running
+#     And there is an index 'test-index'
+#     And it has a collection 'test-collection'
+#     And the collection has a document with id 'search-my-document-id'
+#     When I search a document with id 'search-my-document-id'
+#     Then the document is successfully found
+#
+#   Scenario: Search a document by id and don't find it
+#     Given Kuzzle Server is running
+#     And there is an index 'test-index'
+#     And it has a collection 'test-collection'
+#     And the collection has a document with id 'search-my-document-id'
+#     When I search a document with id 'fake-id'
+#     Then the document is not found
+#
+#   Scenario: Count documents in a collection
+#     Given Kuzzle Server is running
+#     And there is an index 'test-index'
+#     And it has a collection 'count-test-collection'
+#     And the collection has a document with id 'count-my-document-id'
+#     And the collection has a document with id 'count-my-document-id2'
+#     And the collection has a document with id 'count-my-document-id3'
+#     When I count how many documents there is in the collection
+#     Then I shall receive 3
+#
+#   Scenario: Delete multiple documents with no error
+#     Given Kuzzle Server is running
+#     And there is an index 'test-index'
+#     And it has a collection 'delete-test-collection'
+#     And the collection has a document with id 'mdelete-my-document-id'
+#     And the collection has a document with id 'mdelete-my-document-id2'
+#     When I delete the documents ['mdelete-my-document-id', 'mdelete-my-document-id2']
+#     Then I must have 0 documents in the collection
+#
+#   Scenario: Delete multiple documents with partial error
+#     Given Kuzzle Server is running
+#     And there is an index 'test-index'
+#     And it has a collection 'mdelete-test-collection'
+#     And the collection has a document with id 'mdelete-my-document-id'
+#     And the collection has a document with id 'mdelete-my-document-id2'
+#     When I delete the documents ['mdelete-my-document-id', 'mdelete-my-document-unknown']
+#     Then I must have 1 documents in the collection
+#     And I get a partial error
+#
+#   Scenario: Create multiple documents with no error
+#     Given Kuzzle Server is running
+#     And there is an index 'test-index'
+#     And it has a collection 'mcreate-test-collection'
+#     And the collection doesn't have a document with id 'mcreate-my-document-id'
+#     And the collection doesn't have a document with id 'mcreate-my-document-id2'
+#     When I create the documents ['mcreate-my-document-id', 'mcreate-my-document-id2']
+#     Then I must have 2 documents in the collection
+#     And I should have no partial error
+#
+#   Scenario: Create multiple documents with partial error
+#     Given Kuzzle Server is running
+#     And there is an index 'test-index'
+#     And it has a collection 'mcreate-test-collection'
+#     When I create the documents ['mcreate-my-document-id', 'mcreate-my-document-id2']
+#     Then I must have 2 documents in the collection
+#     And I get a partial error
+#
+#   Scenario: Replace multiple documents with no error
+#     Given Kuzzle Server is running
+#     And there is an index 'test-index'
+#     And it has a collection 'mreplace-test-collection'
+#     And the collection has a document with id 'mreplace-my-document-id'
+#     And the collection has a document with id 'mreplace-my-document-id2'
+#     When I replace the documents ['mreplace-my-document-id', 'mreplace-my-document-id2']
+#     Then I should have no partial error
+#     And the document 'mreplace-my-document-id' should be replaced
+#     And the document 'mreplace-my-document-id2' should be replaced
+#
+#   Scenario: Replace multiple documents with partial error
+#     Given Kuzzle Server is running
+#     And there is an index 'test-index'
+#     And it has a collection 'mreplace-test-collection'
+#     And the collection has a document with id 'mreplace-my-document-id'
+#     And the collection has a document with id 'mreplace-my-document-id2'
+#     When I replace the documents ['unknown', 'mreplace-my-document-id2']
+#     And the document 'mreplace-my-document-id2' should be replaced
+#     And I get a partial error
+#
+#   Scenario: Update multiple documents with no error
+#     Given Kuzzle Server is running
+#     And there is an index 'test-index'
+#     And it has a collection 'mreplace-test-collection'
+#     And the collection has a document with id 'mreplace-my-document-id'
+#     And the collection has a document with id 'mreplace-my-document-id2'
+#     When I update the documents ['mreplace-my-document-id', 'mreplace-my-document-id2']
+#     Then I should have no partial error
+#     And the document 'mreplace-my-document-id' should be replaced
+#     And the document 'mreplace-my-document-id2' should be replaced
+#
+#   Scenario: Update multiple documents with partial error
+#     Given Kuzzle Server is running
+#     And there is an index 'test-index'
+#     And it has a collection 'mupdate-test-collection'
+#     And the collection has a document with id 'mupdate-my-document-id'
+#     And the collection has a document with id 'mupdate-my-document-id2'
+#     When I update the documents ['unknown', 'mupdate-my-document-id2']
+#     Then the document 'mupdate-my-document-id2' should be updated
+#     And I get a partial error
+#
+#   Scenario: CreateOrReplace (create) multiple documents with no error
+#     Given Kuzzle Server is running
+#     And there is an index 'test-index'
+#     And it has a collection 'mcreateorreplace-test-collection'
+#     When I createOrReplace the documents ['mcreateorreplace-my-document-id', 'mcreateorreplace-my-document-id2']
+#     Then I should have no partial error
+#     And the document 'mcreateorreplace-my-document-id' should be created
+#     And the document 'mcreateorreplace-my-document-id2' should be created
+#
+#   Scenario: CreateOrReplace (replace) multiple documents with no error
+#     Given Kuzzle Server is running
+#     And there is an index 'test-index'
+#     And it has a collection 'mcreateorreplace-test-collection'
+#     And the collection has a document with id 'mcreateorreplace-my-document-id'
+#     And the collection has a document with id 'mcreateorreplace-my-document-id2'
+#     When I createOrReplace the documents ['mcreateorreplace-my-document-id', 'mcreateorreplace-my-document-id2']
+#     Then I should have no partial error
+#     And the document 'mcreateorreplace-my-document-id' should be replaced
+#     And the document 'mcreateorreplace-my-document-id2' should be replaced
+#
+#   Scenario: Check if a document exists
+#     Given Kuzzle Server is running
+#     And there is an index 'test-index'
+#     And it has a collection 'exist-test-collection'
+#     And the collection has a document with id 'exist-my-document-id'
+#     When I check if 'exist-my-document-id' exists
+#     Then the document should exists
+#
+#   Scenario: Check if a document does not exists
+#     Given Kuzzle Server is running
+#     And there is an index 'test-index'
+#     And it has a collection 'exist-test-collection'
+#     And the collection has a document with id 'exist-my-document-id'
+#     When I check if 'exist-my-document-unknown' exists
+#     Then the document should not exist
+#
+#   Scenario: Get multiple document
+#     Given Kuzzle Server is running
+#     And there is an index 'test-index'
+#     And it has a collection 'mget-test-collection'
+#     And the collection has a document with id 'mget-my-document-id'
+#     And the collection has a document with id 'mget-my-document-id2'
+#     When I get documents ['mget-my-document-id', 'mget-my-document-id2']
+#     Then the documents should be retrieved

--- a/internal/wrappers/features/documents.feature
+++ b/internal/wrappers/features/documents.feature
@@ -1,206 +1,206 @@
-# Feature: Document management
-#
-#   Scenario: Do not allow creating a document with an _id that already exist in the same collection
-#     Given Kuzzle Server is running
-#     And there is an index 'test-index'
-#     And it has a collection 'test-collection'
-#     And the collection has a document with id 'my-document-id'
-#     When I create a document with id 'my-document-id'
-#     Then I get an error with message 'Document already exists'
-#
-#   Scenario: Create a document with create
-#     Given Kuzzle Server is running
-#     And there is an index 'test-index'
-#     And it has a collection 'test-collection'
-#     And the collection doesn't have a document with id 'my-document-id'
-#     When I create a document with id 'my-document-id'
-#     Then the document is successfully created
-#
-#   Scenario: Create a document with createOrReplace if it does not exists
-#     Given Kuzzle Server is running
-#     And there is an index 'test-index'
-#     And it has a collection 'test-collection'
-#     And the collection doesn't have a document with id 'my-document-id'
-#     When I createOrReplace a document with id 'my-document-id'
-#     Then the document is successfully created
-#
-#   Scenario: Replace a document if it exists
-#     Given Kuzzle Server is running
-#     And there is an index 'test-index'
-#     And it has a collection 'test-collection'
-#     When I createOrReplace a document with id 'my-document-id'
-#     Then the document is successfully replaced
-#
-#   Scenario: Replace a document
-#     Given Kuzzle Server is running
-#     And there is an index 'test-index'
-#     And it has a collection 'test-collection'
-#     And the collection has a document with id 'replace-my-document-id'
-#     When I replace a document with id 'replace-my-document-id'
-#     Then the document is successfully replaced
-#
-#   Scenario: Delete a document
-#     Given Kuzzle Server is running
-#     And there is an index 'test-index'
-#     And it has a collection 'test-collection'
-#     And the collection has a document with id 'delete-my-document-id'
-#     When I delete the document with id 'delete-my-document-id'
-#     Then the document is successfully deleted
-#
-#   Scenario: Update a document
-#     Given Kuzzle Server is running
-#     And there is an index 'test-index'
-#     And it has a collection 'test-collection'
-#     And the collection has a document with id 'update-my-document-id'
-#     When I update a document with id 'update-my-document-id'
-#     Then the document is successfully updated
-#
-#   Scenario: Search a document by id and find it
-#     Given Kuzzle Server is running
-#     And there is an index 'test-index'
-#     And it has a collection 'test-collection'
-#     And the collection has a document with id 'search-my-document-id'
-#     When I search a document with id 'search-my-document-id'
-#     Then the document is successfully found
-#
-#   Scenario: Search a document by id and don't find it
-#     Given Kuzzle Server is running
-#     And there is an index 'test-index'
-#     And it has a collection 'test-collection'
-#     And the collection has a document with id 'search-my-document-id'
-#     When I search a document with id 'fake-id'
-#     Then the document is not found
-#
-#   Scenario: Count documents in a collection
-#     Given Kuzzle Server is running
-#     And there is an index 'test-index'
-#     And it has a collection 'count-test-collection'
-#     And the collection has a document with id 'count-my-document-id'
-#     And the collection has a document with id 'count-my-document-id2'
-#     And the collection has a document with id 'count-my-document-id3'
-#     When I count how many documents there is in the collection
-#     Then I shall receive 3
-#
-#   Scenario: Delete multiple documents with no error
-#     Given Kuzzle Server is running
-#     And there is an index 'test-index'
-#     And it has a collection 'delete-test-collection'
-#     And the collection has a document with id 'mdelete-my-document-id'
-#     And the collection has a document with id 'mdelete-my-document-id2'
-#     When I delete the documents ['mdelete-my-document-id', 'mdelete-my-document-id2']
-#     Then I must have 0 documents in the collection
-#
-#   Scenario: Delete multiple documents with partial error
-#     Given Kuzzle Server is running
-#     And there is an index 'test-index'
-#     And it has a collection 'mdelete-test-collection'
-#     And the collection has a document with id 'mdelete-my-document-id'
-#     And the collection has a document with id 'mdelete-my-document-id2'
-#     When I delete the documents ['mdelete-my-document-id', 'mdelete-my-document-unknown']
-#     Then I must have 1 documents in the collection
-#     And I get a partial error
-#
-#   Scenario: Create multiple documents with no error
-#     Given Kuzzle Server is running
-#     And there is an index 'test-index'
-#     And it has a collection 'mcreate-test-collection'
-#     And the collection doesn't have a document with id 'mcreate-my-document-id'
-#     And the collection doesn't have a document with id 'mcreate-my-document-id2'
-#     When I create the documents ['mcreate-my-document-id', 'mcreate-my-document-id2']
-#     Then I must have 2 documents in the collection
-#     And I should have no partial error
-#
-#   Scenario: Create multiple documents with partial error
-#     Given Kuzzle Server is running
-#     And there is an index 'test-index'
-#     And it has a collection 'mcreate-test-collection'
-#     When I create the documents ['mcreate-my-document-id', 'mcreate-my-document-id2']
-#     Then I must have 2 documents in the collection
-#     And I get a partial error
-#
-#   Scenario: Replace multiple documents with no error
-#     Given Kuzzle Server is running
-#     And there is an index 'test-index'
-#     And it has a collection 'mreplace-test-collection'
-#     And the collection has a document with id 'mreplace-my-document-id'
-#     And the collection has a document with id 'mreplace-my-document-id2'
-#     When I replace the documents ['mreplace-my-document-id', 'mreplace-my-document-id2']
-#     Then I should have no partial error
-#     And the document 'mreplace-my-document-id' should be replaced
-#     And the document 'mreplace-my-document-id2' should be replaced
-#
-#   Scenario: Replace multiple documents with partial error
-#     Given Kuzzle Server is running
-#     And there is an index 'test-index'
-#     And it has a collection 'mreplace-test-collection'
-#     And the collection has a document with id 'mreplace-my-document-id'
-#     And the collection has a document with id 'mreplace-my-document-id2'
-#     When I replace the documents ['unknown', 'mreplace-my-document-id2']
-#     And the document 'mreplace-my-document-id2' should be replaced
-#     And I get a partial error
-#
-#   Scenario: Update multiple documents with no error
-#     Given Kuzzle Server is running
-#     And there is an index 'test-index'
-#     And it has a collection 'mreplace-test-collection'
-#     And the collection has a document with id 'mreplace-my-document-id'
-#     And the collection has a document with id 'mreplace-my-document-id2'
-#     When I update the documents ['mreplace-my-document-id', 'mreplace-my-document-id2']
-#     Then I should have no partial error
-#     And the document 'mreplace-my-document-id' should be replaced
-#     And the document 'mreplace-my-document-id2' should be replaced
-#
-#   Scenario: Update multiple documents with partial error
-#     Given Kuzzle Server is running
-#     And there is an index 'test-index'
-#     And it has a collection 'mupdate-test-collection'
-#     And the collection has a document with id 'mupdate-my-document-id'
-#     And the collection has a document with id 'mupdate-my-document-id2'
-#     When I update the documents ['unknown', 'mupdate-my-document-id2']
-#     Then the document 'mupdate-my-document-id2' should be updated
-#     And I get a partial error
-#
-#   Scenario: CreateOrReplace (create) multiple documents with no error
-#     Given Kuzzle Server is running
-#     And there is an index 'test-index'
-#     And it has a collection 'mcreateorreplace-test-collection'
-#     When I createOrReplace the documents ['mcreateorreplace-my-document-id', 'mcreateorreplace-my-document-id2']
-#     Then I should have no partial error
-#     And the document 'mcreateorreplace-my-document-id' should be created
-#     And the document 'mcreateorreplace-my-document-id2' should be created
-#
-#   Scenario: CreateOrReplace (replace) multiple documents with no error
-#     Given Kuzzle Server is running
-#     And there is an index 'test-index'
-#     And it has a collection 'mcreateorreplace-test-collection'
-#     And the collection has a document with id 'mcreateorreplace-my-document-id'
-#     And the collection has a document with id 'mcreateorreplace-my-document-id2'
-#     When I createOrReplace the documents ['mcreateorreplace-my-document-id', 'mcreateorreplace-my-document-id2']
-#     Then I should have no partial error
-#     And the document 'mcreateorreplace-my-document-id' should be replaced
-#     And the document 'mcreateorreplace-my-document-id2' should be replaced
-#
-#   Scenario: Check if a document exists
-#     Given Kuzzle Server is running
-#     And there is an index 'test-index'
-#     And it has a collection 'exist-test-collection'
-#     And the collection has a document with id 'exist-my-document-id'
-#     When I check if 'exist-my-document-id' exists
-#     Then the document should exists
-#
-#   Scenario: Check if a document does not exists
-#     Given Kuzzle Server is running
-#     And there is an index 'test-index'
-#     And it has a collection 'exist-test-collection'
-#     And the collection has a document with id 'exist-my-document-id'
-#     When I check if 'exist-my-document-unknown' exists
-#     Then the document should not exist
-#
-#   Scenario: Get multiple document
-#     Given Kuzzle Server is running
-#     And there is an index 'test-index'
-#     And it has a collection 'mget-test-collection'
-#     And the collection has a document with id 'mget-my-document-id'
-#     And the collection has a document with id 'mget-my-document-id2'
-#     When I get documents ['mget-my-document-id', 'mget-my-document-id2']
-#     Then the documents should be retrieved
+Feature: Document management
+
+  Scenario: Do not allow creating a document with an _id that already exist in the same collection
+    Given Kuzzle Server is running
+    And there is an index 'test-index'
+    And it has a collection 'test-collection'
+    And the collection has a document with id 'my-document-id'
+    When I create a document with id 'my-document-id'
+    Then I get an error with message 'Document already exists'
+
+  Scenario: Create a document with create
+    Given Kuzzle Server is running
+    And there is an index 'test-index'
+    And it has a collection 'test-collection'
+    And the collection doesn't have a document with id 'my-document-id'
+    When I create a document with id 'my-document-id'
+    Then the document is successfully created
+
+  Scenario: Create a document with createOrReplace if it does not exists
+    Given Kuzzle Server is running
+    And there is an index 'test-index'
+    And it has a collection 'test-collection'
+    And the collection doesn't have a document with id 'my-document-id'
+    When I createOrReplace a document with id 'my-document-id'
+    Then the document is successfully created
+
+  Scenario: Replace a document if it exists
+    Given Kuzzle Server is running
+    And there is an index 'test-index'
+    And it has a collection 'test-collection'
+    When I createOrReplace a document with id 'my-document-id'
+    Then the document is successfully replaced
+
+  Scenario: Replace a document
+    Given Kuzzle Server is running
+    And there is an index 'test-index'
+    And it has a collection 'test-collection'
+    And the collection has a document with id 'replace-my-document-id'
+    When I replace a document with id 'replace-my-document-id'
+    Then the document is successfully replaced
+
+  Scenario: Delete a document
+    Given Kuzzle Server is running
+    And there is an index 'test-index'
+    And it has a collection 'test-collection'
+    And the collection has a document with id 'delete-my-document-id'
+    When I delete the document with id 'delete-my-document-id'
+    Then the document is successfully deleted
+
+  Scenario: Update a document
+    Given Kuzzle Server is running
+    And there is an index 'test-index'
+    And it has a collection 'test-collection'
+    And the collection has a document with id 'update-my-document-id'
+    When I update a document with id 'update-my-document-id'
+    Then the document is successfully updated
+
+  Scenario: Search a document by id and find it
+    Given Kuzzle Server is running
+    And there is an index 'test-index'
+    And it has a collection 'test-collection'
+    And the collection has a document with id 'search-my-document-id'
+    When I search a document with id 'search-my-document-id'
+    Then the document is successfully found
+
+  Scenario: Search a document by id and don't find it
+    Given Kuzzle Server is running
+    And there is an index 'test-index'
+    And it has a collection 'test-collection'
+    And the collection has a document with id 'search-my-document-id'
+    When I search a document with id 'fake-id'
+    Then the document is not found
+
+  Scenario: Count documents in a collection
+    Given Kuzzle Server is running
+    And there is an index 'test-index'
+    And it has a collection 'count-test-collection'
+    And the collection has a document with id 'count-my-document-id'
+    And the collection has a document with id 'count-my-document-id2'
+    And the collection has a document with id 'count-my-document-id3'
+    When I count how many documents there is in the collection
+    Then I shall receive 3
+
+  Scenario: Delete multiple documents with no error
+    Given Kuzzle Server is running
+    And there is an index 'test-index'
+    And it has a collection 'delete-test-collection'
+    And the collection has a document with id 'mdelete-my-document-id'
+    And the collection has a document with id 'mdelete-my-document-id2'
+    When I delete the documents ['mdelete-my-document-id', 'mdelete-my-document-id2']
+    Then I must have 0 documents in the collection
+
+  Scenario: Delete multiple documents with partial error
+    Given Kuzzle Server is running
+    And there is an index 'test-index'
+    And it has a collection 'mdelete-test-collection'
+    And the collection has a document with id 'mdelete-my-document-id'
+    And the collection has a document with id 'mdelete-my-document-id2'
+    When I delete the documents ['mdelete-my-document-id', 'mdelete-my-document-unknown']
+    Then I must have 1 documents in the collection
+    And I get a partial error
+
+  Scenario: Create multiple documents with no error
+    Given Kuzzle Server is running
+    And there is an index 'test-index'
+    And it has a collection 'mcreate-test-collection'
+    And the collection doesn't have a document with id 'mcreate-my-document-id'
+    And the collection doesn't have a document with id 'mcreate-my-document-id2'
+    When I create the documents ['mcreate-my-document-id', 'mcreate-my-document-id2']
+    Then I must have 2 documents in the collection
+    And I should have no partial error
+
+  Scenario: Create multiple documents with partial error
+    Given Kuzzle Server is running
+    And there is an index 'test-index'
+    And it has a collection 'mcreate-test-collection'
+    When I create the documents ['mcreate-my-document-id', 'mcreate-my-document-id2']
+    Then I must have 2 documents in the collection
+    And I get a partial error
+
+  Scenario: Replace multiple documents with no error
+    Given Kuzzle Server is running
+    And there is an index 'test-index'
+    And it has a collection 'mreplace-test-collection'
+    And the collection has a document with id 'mreplace-my-document-id'
+    And the collection has a document with id 'mreplace-my-document-id2'
+    When I replace the documents ['mreplace-my-document-id', 'mreplace-my-document-id2']
+    Then I should have no partial error
+    And the document 'mreplace-my-document-id' should be replaced
+    And the document 'mreplace-my-document-id2' should be replaced
+
+  Scenario: Replace multiple documents with partial error
+    Given Kuzzle Server is running
+    And there is an index 'test-index'
+    And it has a collection 'mreplace-test-collection'
+    And the collection has a document with id 'mreplace-my-document-id'
+    And the collection has a document with id 'mreplace-my-document-id2'
+    When I replace the documents ['unknown', 'mreplace-my-document-id2']
+    And the document 'mreplace-my-document-id2' should be replaced
+    And I get a partial error
+
+  Scenario: Update multiple documents with no error
+    Given Kuzzle Server is running
+    And there is an index 'test-index'
+    And it has a collection 'mreplace-test-collection'
+    And the collection has a document with id 'mreplace-my-document-id'
+    And the collection has a document with id 'mreplace-my-document-id2'
+    When I update the documents ['mreplace-my-document-id', 'mreplace-my-document-id2']
+    Then I should have no partial error
+    And the document 'mreplace-my-document-id' should be replaced
+    And the document 'mreplace-my-document-id2' should be replaced
+
+  Scenario: Update multiple documents with partial error
+    Given Kuzzle Server is running
+    And there is an index 'test-index'
+    And it has a collection 'mupdate-test-collection'
+    And the collection has a document with id 'mupdate-my-document-id'
+    And the collection has a document with id 'mupdate-my-document-id2'
+    When I update the documents ['unknown', 'mupdate-my-document-id2']
+    Then the document 'mupdate-my-document-id2' should be updated
+    And I get a partial error
+
+  Scenario: CreateOrReplace (create) multiple documents with no error
+    Given Kuzzle Server is running
+    And there is an index 'test-index'
+    And it has a collection 'mcreateorreplace-test-collection'
+    When I createOrReplace the documents ['mcreateorreplace-my-document-id', 'mcreateorreplace-my-document-id2']
+    Then I should have no partial error
+    And the document 'mcreateorreplace-my-document-id' should be created
+    And the document 'mcreateorreplace-my-document-id2' should be created
+
+  Scenario: CreateOrReplace (replace) multiple documents with no error
+    Given Kuzzle Server is running
+    And there is an index 'test-index'
+    And it has a collection 'mcreateorreplace-test-collection'
+    And the collection has a document with id 'mcreateorreplace-my-document-id'
+    And the collection has a document with id 'mcreateorreplace-my-document-id2'
+    When I createOrReplace the documents ['mcreateorreplace-my-document-id', 'mcreateorreplace-my-document-id2']
+    Then I should have no partial error
+    And the document 'mcreateorreplace-my-document-id' should be replaced
+    And the document 'mcreateorreplace-my-document-id2' should be replaced
+
+  Scenario: Check if a document exists
+    Given Kuzzle Server is running
+    And there is an index 'test-index'
+    And it has a collection 'exist-test-collection'
+    And the collection has a document with id 'exist-my-document-id'
+    When I check if 'exist-my-document-id' exists
+    Then the document should exists
+
+  Scenario: Check if a document does not exists
+    Given Kuzzle Server is running
+    And there is an index 'test-index'
+    And it has a collection 'exist-test-collection'
+    And the collection has a document with id 'exist-my-document-id'
+    When I check if 'exist-my-document-unknown' exists
+    Then the document should not exist
+
+  Scenario: Get multiple document
+    Given Kuzzle Server is running
+    And there is an index 'test-index'
+    And it has a collection 'mget-test-collection'
+    And the collection has a document with id 'mget-my-document-id'
+    And the collection has a document with id 'mget-my-document-id2'
+    When I get documents ['mget-my-document-id', 'mget-my-document-id2']
+    Then the documents should be retrieved

--- a/internal/wrappers/features/index.feature
+++ b/internal/wrappers/features/index.feature
@@ -17,3 +17,9 @@ Feature: Index controller
     And there is the indexes 'test-index1' and 'test-index2'
     When I delete the indexes 'test-index1' and 'test-index2'
     Then indexes 'test-index1' and 'test-index2' don't exist
+
+  Scenario: List indexes
+    Given Kuzzle Server is running
+    And there is the indexes 'test-index1' and 'test-index2'
+    When I list indexes
+    Then I get 'test-index1' and 'test-index2'

--- a/internal/wrappers/features/java/src/test/java/gradle/cucumber/Indexdefs.java
+++ b/internal/wrappers/features/java/src/test/java/gradle/cucumber/Indexdefs.java
@@ -80,4 +80,21 @@ public class Indexdefs {
         Assert.assertFalse(k.getIndex().exists(index1));
         Assert.assertFalse(k.getIndex().exists(index2));
     }
+
+    @When("^I list indexes$")
+    public void i_list_indexes() throws Exception {
+      world.stringArray = k.getIndex().list();
+    }
+
+    @Then("^I get \'([^\"]*)\' and \'([^\"]*)\'$")
+    public void i_get_test_index_and_test_index(String index1, String index2) throws Exception {
+      int match = 0;
+
+      for (int i = 0; i < world.stringArray.size(); ++i) {
+        if (world.stringArray.get(i).equals(index1) || world.stringArray.get(i).equals(index2))
+          match++;
+      }
+
+      Assert.assertTrue(match == 2);
+    }
 }

--- a/internal/wrappers/features/java/src/test/java/gradle/cucumber/World.java
+++ b/internal/wrappers/features/java/src/test/java/gradle/cucumber/World.java
@@ -1,6 +1,9 @@
 package gradle.cucumber;
 
+import io.kuzzle.sdk.*;
+
 public class World {
     public static String index;
     public static String collection;
+    public static StringVector stringArray;
 }

--- a/internal/wrappers/features/realtime.feature
+++ b/internal/wrappers/features/realtime.feature
@@ -38,7 +38,7 @@ Feature: Realtime subscription
     Given Kuzzle Server is running
     And there is an index 'test-index'
     And it has a collection 'test-collection'
-    And the collection has a document with id 'my-document-id'    
+    And the collection has a document with id 'my-document-id'
     And I subscribe to 'test-collection'
     And I unsubscribe
     When I publish a document

--- a/internal/wrappers/features/run_cpp.sh
+++ b/internal/wrappers/features/run_cpp.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -e
 cd internal/wrappers
-./build_cpp_tests.sh
+sh ./build_cpp_tests.sh
 
 FEATURE_FILE=$1
 

--- a/internal/wrappers/features/run_cpp.sh
+++ b/internal/wrappers/features/run_cpp.sh
@@ -5,11 +5,7 @@ sh ./build_cpp_tests.sh
 
 FEATURE_FILE=$1
 
-if [ ! -z "$KUZZLE_HOST" ]; then
-  ./_build_cpp_tests/KuzzleSDKStepDefs > /dev/null &
-else
-  ./_build_cpp_tests/KuzzleSDKStepDefs &
-fi
+./_build_cpp_tests/KuzzleSDKStepDefs > /dev/null &
 
 if [ ! -z "$FEATURE_FILE" ]; then
   cucumber features/$FEATURE_FILE

--- a/internal/wrappers/features/step_defs_cpp/collection-steps.cpp
+++ b/internal/wrappers/features/step_defs_cpp/collection-steps.cpp
@@ -5,7 +5,7 @@
 namespace {
   WHEN("^I create a collection \'([^\"]*)\'$")
   {
-    REGEX_PARAM(std::string, collection_id);
+    REGEX_PARAM(string, collection_id);
 
     ScenarioScope<KuzzleCtx> ctx;
 
@@ -18,7 +18,7 @@ namespace {
 
   THEN("^the collection \'([^\"]*)\' should exists$")
   {
-    REGEX_PARAM(std::string, collection_id);
+    REGEX_PARAM(string, collection_id);
 
     ScenarioScope<KuzzleCtx> ctx;
 
@@ -27,7 +27,7 @@ namespace {
 
   WHEN("^I check if the collection \'([^\"]*)\' exists$")
   {
-    REGEX_PARAM(std::string, collection_id);
+    REGEX_PARAM(string, collection_id);
 
     ScenarioScope<KuzzleCtx> ctx;
 
@@ -45,7 +45,7 @@ namespace {
 
   GIVEN("^it has a collection \'([^\"]*)\'$")
   {
-    REGEX_PARAM(std::string, collection_name);
+    REGEX_PARAM(string, collection_name);
 
     ScenarioScope<KuzzleCtx> ctx;
     ctx->collection = collection_name;
@@ -61,7 +61,7 @@ namespace {
 
   WHEN("^I list the collections of \'([^\"]*)\'$")
   {
-    REGEX_PARAM(std::string, index_name);
+    REGEX_PARAM(string, index_name);
 
     ScenarioScope<KuzzleCtx> ctx;
 
@@ -76,7 +76,7 @@ namespace {
 
   GIVEN("^the collection has a document with id \'([^\"]*)\'$")
   {
-    REGEX_PARAM(std::string, document_id);
+    REGEX_PARAM(string, document_id);
 
     ScenarioScope<KuzzleCtx> ctx;
 
@@ -88,7 +88,7 @@ namespace {
 
   WHEN("^I truncate the collection \'([^\"]*)\'$")
   {
-    REGEX_PARAM(std::string, collection_id);
+    REGEX_PARAM(string, collection_id);
 
     ScenarioScope<KuzzleCtx> ctx;
 
@@ -100,7 +100,7 @@ namespace {
 
   THEN("^the collection \'([^\"]*)\' shall be empty$")
   {
-    REGEX_PARAM(std::string, collection_id);
+    REGEX_PARAM(string, collection_id);
 
     ScenarioScope<KuzzleCtx> ctx;
 
@@ -113,46 +113,45 @@ namespace {
 
   WHEN("^I update the mapping of collection \'([^\"]*)\'$")
   {
-    REGEX_PARAM(std::string, collection_id);
+    REGEX_PARAM(string, collection_id);
 
     ScenarioScope<KuzzleCtx> ctx;
 
-    std::string mapping = "{\"properties\": {\"gordon\": {\"type\": \"keyword\"}}}";
+    string mapping = "{\"properties\": {\"gordon\": {\"type\": \"keyword\"}}}";
 
     ctx->kuzzle->collection->updateMapping(ctx->index, collection_id, mapping);
   }
 
   THEN("^the mapping of \'([^\"]*)\' should be updated$")
   {
-    REGEX_PARAM(std::string, collection_id);
+    REGEX_PARAM(string, collection_id);
 
     ScenarioScope<KuzzleCtx> ctx;
 
-    std::string mapping = ctx->kuzzle->collection->getMapping(ctx->index, collection_id);
-    std::string expected_mapping = "{\"" + ctx->index + "\":{\"mappings\":{\"" + collection_id + "\":{\"properties\":{\"a\":{\"type\":\"text\",\"fields\":{\"keyword\":{\"type\":\"keyword\",\"ignore_above\":256}}},\"foo\":{\"type\":\"text\",\"fields\":{\"keyword\":{\"type\":\"keyword\",\"ignore_above\":256}}},\"gordon\":{\"type\":\"keyword\"}}}}}}";
+    string mapping = ctx->kuzzle->collection->getMapping(ctx->index, collection_id);
 
-    BOOST_CHECK(mapping == expected_mapping);
+    BOOST_CHECK(mapping.find("\"gordon\":{\"type\":\"keyword\"}") != string::npos);
   }
 
   WHEN("^I update the specifications of the collection \'([^\"]*)\'$")
   {
-    REGEX_PARAM(std::string, collection_id);
+    REGEX_PARAM(string, collection_id);
 
     ScenarioScope<KuzzleCtx> ctx;
 
-    std::string specifications = "{\"" + ctx->index + "\":{\""+ collection_id +"\":{\"strict\":false}}}";
+    string specifications = "{\"" + ctx->index + "\":{\""+ collection_id +"\":{\"strict\":false}}}";
 
     ctx->kuzzle->collection->updateSpecifications(ctx->index, collection_id, specifications);
   }
 
   THEN("^the specifications of \'([^\"]*)\' should be updated$")
   {
-    REGEX_PARAM(std::string, collection_id);
+    REGEX_PARAM(string, collection_id);
 
     ScenarioScope<KuzzleCtx> ctx;
 
-    std::string specifications = ctx->kuzzle->collection->getSpecifications(ctx->index, collection_id);
-    std::string expected_specifications = "{\"validation\":{\"strict\":false},\"index\":\"" + ctx->index + "\",\"collection\":\"" + collection_id + "\"}";
+    string specifications = ctx->kuzzle->collection->getSpecifications(ctx->index, collection_id);
+    string expected_specifications = "{\"validation\":{\"strict\":false},\"index\":\"" + ctx->index + "\",\"collection\":\"" + collection_id + "\"}";
 
     BOOST_CHECK(specifications == expected_specifications);
 
@@ -161,11 +160,11 @@ namespace {
 
   WHEN("^I validate the specifications of \'([^\"]*)\'$")
   {
-    REGEX_PARAM(std::string, collection_id);
+    REGEX_PARAM(string, collection_id);
 
     ScenarioScope<KuzzleCtx> ctx;
 
-    std::string specifications = "{\"" + ctx->index + "\":{\"" + collection_id + "\":{\"strict\":true}}}";
+    string specifications = "{\"" + ctx->index + "\":{\"" + collection_id + "\":{\"strict\":true}}}";
 
     ctx->success = ctx->kuzzle->collection->validateSpecifications(specifications);
   }
@@ -183,14 +182,14 @@ namespace {
   {
     ScenarioScope<KuzzleCtx> ctx;
 
-    std::string specifications = "{\"" + ctx->index + "\":{\""+ ctx->collection +"\":{\"strict\":true}}}";
+    string specifications = "{\"" + ctx->index + "\":{\""+ ctx->collection +"\":{\"strict\":true}}}";
 
     ctx->kuzzle->collection->updateSpecifications(ctx->index, ctx->collection, specifications);
   }
 
   WHEN("^I delete the specifications of \'([^\"]*)\'$")
   {
-    REGEX_PARAM(std::string, collection_id);
+    REGEX_PARAM(string, collection_id);
 
     ScenarioScope<KuzzleCtx> ctx;
 
@@ -199,7 +198,7 @@ namespace {
 
   THEN("^the specifications of \'([^\"]*)\' must not exist$")
   {
-    REGEX_PARAM(std::string, collection_id);
+    REGEX_PARAM(string, collection_id);
 
     ScenarioScope<KuzzleCtx> ctx;
 

--- a/internal/wrappers/features/step_defs_cpp/index-steps.cpp
+++ b/internal/wrappers/features/step_defs_cpp/index-steps.cpp
@@ -103,4 +103,23 @@ namespace {
       !ctx->kuzzle->index->exists(index_name2)
     );
   }
+
+  WHEN("^I list indexes$")
+  {
+    ScenarioScope<KuzzleCtx> ctx;
+
+    ctx->string_array = ctx->kuzzle->index->list();
+  }
+
+  THEN("^I get \'([^\"]*)\' and \'([^\"]*)\'$")
+  {
+    REGEX_PARAM(std::string, index_name1);
+    REGEX_PARAM(std::string, index_name2);
+
+    ScenarioScope<KuzzleCtx> ctx;
+
+    BOOST_CHECK(std::find(ctx->string_array.begin(), ctx->string_array.end(), index_name1) != ctx->string_array.end());
+    BOOST_CHECK(std::find(ctx->string_array.begin(), ctx->string_array.end(), index_name2) != ctx->string_array.end());
+  }
+
 }

--- a/internal/wrappers/features/step_defs_cpp/index-steps.cpp
+++ b/internal/wrappers/features/step_defs_cpp/index-steps.cpp
@@ -42,12 +42,26 @@ namespace {
     REGEX_PARAM(std::string, index_name2);
     ScenarioScope<KuzzleCtx> ctx;
 
-    try {
-      ctx->kuzzle->index->create(index_name1);
-      ctx->kuzzle->index->create(index_name2);
-    } catch(KuzzleException e) {
-      K_LOG_E(e.getMessage().c_str());
-      BOOST_FAIL(e.getMessage());
+    if (! ctx->kuzzle->index->exists(index_name1)) {
+      try {
+        ctx->kuzzle->index->create(index_name1);
+      } catch(KuzzleException e) {
+        K_LOG_E(e.getMessage().c_str());
+        BOOST_FAIL(e.getMessage());
+      }
+    } else {
+      K_LOG_D("Using existing index: %s", index_name1.c_str());
+    }
+
+    if (! ctx->kuzzle->index->exists(index_name2)) {
+      try {
+        ctx->kuzzle->index->create(index_name2);
+      } catch(KuzzleException e) {
+        K_LOG_E(e.getMessage().c_str());
+        BOOST_FAIL(e.getMessage());
+      }
+    } else {
+      K_LOG_D("Using existing index: %s", index_name2.c_str());
     }
   }
 

--- a/internal/wrappers/features/step_defs_cpp/steps.hpp
+++ b/internal/wrappers/features/step_defs_cpp/steps.hpp
@@ -43,6 +43,7 @@ struct KuzzleCtx {
   bool success;
   int hits;
   string content;
+  std::vector<string> string_array;
 
   notification_result *notif_result = NULL;
   CustomNotificationListener *listener;


### PR DESCRIPTION
## What does this PR do ?

The action index#list doesn't return the indexes list because it look in the property `hits` in the json but the indexes are in the `indexes` property.

### How should this be manually tested?

  - Step 1 : Create an index : `curl -X POST localhost:7512/my-index/_create`
  - Step 2 : Run this go snippet : https://gist.github.com/Aschen/82b318fee52e7e0325a83de724af4746

### Other changes

 - Add functional tests
