### PR TITLE
Rename struct members for java getter/setter

### DIFF
--- a/internal/wrappers/templates/java/core.i
+++ b/internal/wrappers/templates/java/core.i
@@ -26,6 +26,48 @@
 %rename(NotificationContent) notification_content;
 %rename(SubscribeToSelf) subscribe_to_self;
 
+// struct options
+%rename(queueMaxSize) queue_max_size;
+%rename(offlineMode) offline_mode;
+%rename(autoQueue) auto_queue;
+%rename(autoReconnect) auto_reconnect;
+%rename(autoReplay) auto_replay;
+%rename(autoReplay) auto_replay;
+%rename(autoResubscribe) auto_resubscribe;
+%rename(reconnectionDelay) reconnection_delay;
+%rename(replayInterval) replay_interval;
+%rename(defaultIndex) default_index;
+
+// struct query_options
+%rename(scrollId) scroll_id;
+%rename(ifExist) if_exist;
+%rename(retryOnConflict) retry_on_conflict;
+
+// struct kuzzle_request
+%rename(membersLength) members_length;
+%rename(keysLength) keys_length;
+%rename(fieldsLength) fields_length;
+
+// struct role
+%rename(profileIds) profile_ids;
+%rename(profileIdsLength) profile_ids_length;
+
+// struct notification_result
+%rename(nType) n_type;
+%rename(roomId) room_id;
+
+// struct statistics
+%rename(completedRequests) completed_requests;
+%rename(failedRequests) failed_requests;
+%rename(ongoingRequests) ongoing_requests;
+
+// struct token_validity
+%rename(expiresAt) expires_at;
+
+// struct kuzzle_response
+%rename(requestId) request_id;
+%rename(roomId) room_id;
+
 %rename(delete) delete_;
 
 %ignore *::error;


### PR DESCRIPTION
## What does this PR do ?

When converting C struct to Java, the getter/setter were not in `camelCase` (eg: `setQueue_max_size()`)  
This PR rename the struct member in the java swig template `queue_max_size` => `queueMaxSize`

### How should this be manually tested?

  - Step 1 : Delete previous sdk version: `sudo rm -rf internal/wrappers/build/java/build/*`
  - Step 2 : Build the sdk: `docker run --rm -it --mount type=bind,source="$(pwd)",target=/go/src/github.com/kuzzleio/sdk-go kuzzleio/sdk-cross:amd64 /build.sh`
  - Step 3 : Check the getter/setter: `javap -classpath internal/wrappers/build/java/build/libs/kuzzlesdk-1.0.0.jar io.kuzzle.sdk.Options`
