### PR TITLE
Change options.offline_mode type

### DIFF
--- a/internal/wrappers/cgo/kuzzle/options.go
+++ b/internal/wrappers/cgo/kuzzle/options.go
@@ -33,7 +33,6 @@ func kuzzle_new_options() *C.options {
 
 	copts.queue_ttl = C.uint(opts.QueueTTL())
 	copts.queue_max_size = C.ulong(opts.QueueMaxSize())
-	copts.offline_mode = C.uchar(opts.OfflineMode())
 	copts.auto_queue = C.bool(opts.AutoQueue())
 	copts.auto_reconnect = C.bool(opts.AutoReconnect())
 	copts.auto_replay = C.bool(opts.AutoReplay())
@@ -45,6 +44,12 @@ func kuzzle_new_options() *C.options {
 		copts.connect = C.MANUAL
 	} else {
 		copts.connect = C.AUTO
+	}
+
+	if opts.OfflineMode() == 1 {
+		copts.offline_mode = C.MANUAL
+	} else {
+		copts.offline_mode = C.AUTO
 	}
 
 	refresh := opts.Refresh()

--- a/internal/wrappers/headers/kuzzlesdk.h
+++ b/internal/wrappers/headers/kuzzlesdk.h
@@ -186,7 +186,7 @@ enum Mode {AUTO, MANUAL};
 #define KUZZLE_OPTIONS_DEFAULT { \
     .queue_ttl = 120000, \
     .queue_max_size = 500, \
-    .offline_mode = 0,  \
+    .offline_mode = MANUAL,  \
     .auto_queue = false,  \
     .auto_reconnect = true,  \
     .auto_replay = false, \
@@ -200,7 +200,7 @@ enum Mode {AUTO, MANUAL};
 typedef struct {
     unsigned queue_ttl;
     unsigned long queue_max_size;
-    unsigned char offline_mode;
+    enum Mode offline_mode;
     bool auto_queue;
     bool auto_reconnect;
     bool auto_replay;


### PR DESCRIPTION
## What does this PR do ?

The `Options` struct passed to the Kuzzle constructor has a `connect` and a `offline_mode` fields that can both have 2 values in the JS SDK: `manual` or `auto`.  
In the Go/Cpp SDK, the `connect` field type is an enum but not the `offline_mode` field.  

### How should this be manually tested?

  - Step 1 : In the following file `internal/wrappers/features/step_defs_cpp/kuzzle-sdk-steps.cpp` add this line after the line `#101`: `ctx->kuzzle_options.offline_mode = MANUAL;`
  - Step 2 : Compile

