### PR TITLE
Rename deprecated method ReplayQueue to PlayQueue

### DIFF
--- a/.codepipeline/builds/amd64.yml
+++ b/.codepipeline/builds/amd64.yml
@@ -6,7 +6,7 @@ phases:
       - docker pull kuzzleio/sdk-cross:amd64
   build:
     commands:
-      - docker run -a stdout -a stderr --net host --rm --privileged --name build-machine --mount type=bind,source="$(pwd)",target=/go/src/github.com/kuzzleio/sdk-go kuzzleio/sdk-cross:amd64 /build.sh
+      - docker run -a stdout -a stderr --net host --rm --privileged --name build-machine -v "$(pwd)":/go/src/github.com/kuzzleio/sdk-go kuzzleio/sdk-cross:amd64 /build.sh
 artifacts:
   files:
     - '**/*'

--- a/.codepipeline/builds/armv7.yml
+++ b/.codepipeline/builds/armv7.yml
@@ -6,4 +6,4 @@ phases:
       - docker pull kuzzleio/sdk-cross:builder-armv7
   build:
     commands:
-      - docker run --rm --name build-machine --mount type=bind,source="$(pwd)",target=/go/src/github.com/kuzzleio/sdk-go kuzzleio/sdk-cross:armv7-builder /build.sh
+      - docker run --rm --name build-machine -v "$(pwd)":/go/src/github.com/kuzzleio/sdk-go kuzzleio/sdk-cross:armv7-builder /build.sh

--- a/.codepipeline/builds/i386.yml
+++ b/.codepipeline/builds/i386.yml
@@ -6,7 +6,7 @@ phases:
       - docker pull kuzzleio/sdk-cross:i386
   build:
     commands:
-      - docker run -a stdout -a stderr --net host --rm --privileged --name build-machine --mount type=bind,source="$(pwd)",target=/go/src/github.com/kuzzleio/sdk-go kuzzleio/sdk-cross:i386 /build.sh
+      - docker run -a stdout -a stderr --net host --rm --privileged --name build-machine -v "$(pwd)":/go/src/github.com/kuzzleio/sdk-go kuzzleio/sdk-cross:i386 /build.sh
 artifacts:
   files:
     - '**/*'

--- a/.codepipeline/deploys/amd64.yml
+++ b/.codepipeline/deploys/amd64.yml
@@ -6,4 +6,4 @@ phases:
       - docker pull kuzzleio/sdk-cross:amd64
   build:
     commands:
-      - docker run -a stdout -a stderr --privileged --rm --net host --name deploy-machine --mount type=bind,source="$(pwd)",target=/go/src/github.com/kuzzleio/sdk-go kuzzleio/sdk-cross:amd64 /deploy.sh
+      - docker run -a stdout -a stderr --privileged --rm --net host --name deploy-machine -v "$(pwd)":/go/src/github.com/kuzzleio/sdk-go kuzzleio/sdk-cross:amd64 /deploy.sh

--- a/.codepipeline/deploys/i386.yml
+++ b/.codepipeline/deploys/i386.yml
@@ -6,4 +6,4 @@ phases:
       - docker pull kuzzleio/sdk-cross:i386
   build:
     commands:
-      - docker run -a stdout -a stderr --privileged --rm --net host --name deploy-machine --mount type=bind,source="$(pwd)",target=/go/src/github.com/kuzzleio/sdk-go kuzzleio/sdk-cross:i386 /deploy.sh
+      - docker run -a stdout -a stderr --privileged --rm --net host --name deploy-machine -v "$(pwd)":/go/src/github.com/kuzzleio/sdk-go kuzzleio/sdk-cross:i386 /deploy.sh

--- a/.codepipeline/tests/amd64.yml
+++ b/.codepipeline/tests/amd64.yml
@@ -8,7 +8,7 @@ phases:
       - bash .codepipeline/start_kuzzle.sh
   build:
     commands:
-      - docker run -a stdout -a stderr --privileged --rm --network codepipeline_default --link kuzzle --name test-machine --mount type=bind,source="$(pwd)",target=/go/src/github.com/kuzzleio/sdk-go kuzzleio/sdk-cross:amd64 /test.sh
+      - docker run -a stdout -a stderr --privileged --rm --network codepipeline_default --link kuzzle --name test-machine -v "$(pwd)":/go/src/github.com/kuzzleio/sdk-go kuzzleio/sdk-cross:amd64 /test.sh
   post_build:
     commands:
       - docker kill codepipeline_elasticsearch_1 codepipeline_redis_1 kuzzle

--- a/.codepipeline/tests/i386.yml
+++ b/.codepipeline/tests/i386.yml
@@ -8,7 +8,7 @@ phases:
       - bash .codepipeline/start_kuzzle.sh
   build:
     commands:
-      - docker run -a stdout -a stderr --privileged --rm --network codepipeline_default --link kuzzle --name test-machine --mount type=bind,source="$(pwd)",target=/go/src/github.com/kuzzleio/sdk-go kuzzleio/sdk-cross:i386 /test.sh
+      - docker run -a stdout -a stderr --privileged --rm --network codepipeline_default --link kuzzle --name test-machine -v "$(pwd)":/go/src/github.com/kuzzleio/sdk-go kuzzleio/sdk-cross:i386 /test.sh
   post_build:
     commands:
       - docker kill codepipeline_elasticsearch_1 codepipeline_redis_1 kuzzle

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,9 +26,9 @@ install:
   - sudo pip install awscli --upgrade
 script:
   - ./test.sh
-  - docker run -a stdout -a stderr --net host --rm --privileged --name build-machine --mount type=bind,source="$(pwd)",target=/go/src/github.com/kuzzleio/sdk-go kuzzleio/sdk-cross:amd64 /build.sh
+  - docker run -a stdout -a stderr --net host --rm --privileged --name build-machine -v "$(pwd)":/go/src/github.com/kuzzleio/sdk-go kuzzleio/sdk-cross:amd64 /build.sh
   - sh .codepipeline/start_kuzzle.sh
-  - docker run -a stdout -a stderr --privileged --rm --network codepipeline_default --link kuzzle --name test-machine --mount type=bind,source="$(pwd)",target=/go/src/github.com/kuzzleio/sdk-go kuzzleio/sdk-cross:amd64 /test.sh
+  - docker run -a stdout -a stderr --privileged --rm --network codepipeline_default --link kuzzle --name test-machine -v "$(pwd)":/go/src/github.com/kuzzleio/sdk-go kuzzleio/sdk-cross:amd64 /test.sh
 after_success:
   - bash <(curl -s https://codecov.io/bash)
   - if [[ $TRAVIS_PULL_REQUEST != false ]]; then sudo bash .codepipeline/snapshots/snapshots.sh; fi;

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ You can use Docker to simplify wrappers generation and testing
 In project root, use:
 
 ```bash
-$ docker run --rm -it --mount type=bind,source="$(pwd)",target=/go/src/github.com/kuzzleio/sdk-go kuzzleio/sdk-cross:amd64 /build.sh
+$ docker run --rm -it -v "$(pwd)":/go/src/github.com/kuzzleio/sdk-go kuzzleio/sdk-cross:amd64 /build.sh
 ```
 
 This command will build all wrappers using our Docker Image
@@ -168,7 +168,7 @@ $ sh .codepipeline/start_kuzzle.sh
 Now run tests using Docker:
 
 ```bash
-$ docker run --rm -it --network codepipeline_default --link kuzzle --mount type=bind,source="$(pwd)",target=/go/src/github.com/kuzzleio/sdk-go kuzzleio/sdk-cross:amd64 /test.sh
+$ docker run --rm -it --network codepipeline_default --link kuzzle -v "$(pwd)":/go/src/github.com/kuzzleio/sdk-go kuzzleio/sdk-cross:amd64 /test.sh
 ```
 
 ## License

--- a/connection/connection.go
+++ b/connection/connection.go
@@ -39,7 +39,7 @@ type Connection interface {
 	RequestHistory() map[string]time.Time
 	StartQueuing()
 	StopQueuing()
-	ReplayQueue()
+	PlayQueue()
 	ClearQueue()
 
 	// property getters

--- a/connection/websocket/web_socket.go
+++ b/connection/websocket/web_socket.go
@@ -212,7 +212,7 @@ func (ws *webSocket) Connect() (bool, error) {
 		}
 	}()
 
-	ws.ReplayQueue()
+	ws.PlayQueue()
 
 	return ws.wasConnected, err
 }
@@ -438,8 +438,8 @@ func (ws *webSocket) ClearQueue() {
 	ws.offlineQueue = nil
 }
 
-// ReplayQueue replays the requests queued during offline mode. Works only if the SDK is not in a disconnected state, and if the autoReplay option is set to false.
-func (ws *webSocket) ReplayQueue() {
+// PlayQueue replays the requests queued during offline mode. Works only if the SDK is not in a disconnected state, and if the autoReplay option is set to false.
+func (ws *webSocket) PlayQueue() {
 	if ws.state != state.Offline && !ws.autoReplay {
 		ws.cleanQueue()
 		ws.dequeue()

--- a/internal/mock_connection.go
+++ b/internal/mock_connection.go
@@ -109,7 +109,7 @@ func (c *MockedConnection) RemoveListener(event int, channel chan<- interface{})
 	}
 }
 
-func (c *MockedConnection) ReplayQueue() {}
+func (c *MockedConnection) PlayQueue() {}
 
 func (c *MockedConnection) RemoveAllListeners(event int) {
 	if c.MockRemoveAllListeners != nil {

--- a/internal/wrappers/README.md
+++ b/internal/wrappers/README.md
@@ -12,13 +12,13 @@ This project contains a CGO wrapper to Kuzzle's [Go SDK](https://github.com/kuzz
 ## C++ SDK
 
 You can use Docker to run the C++ functional tests:
- - Build the SDK : `docker run --rm -it --mount type=bind,source="$(pwd)",target=/go/src/github.com/kuzzleio/sdk-go kuzzleio/sdk-cross:amd64 /build.sh`
+ - Build the SDK : `docker run --rm -it -v "$(pwd)":/go/src/github.com/kuzzleio/sdk-go kuzzleio/sdk-cross:amd64 /build.sh`
  - Run a Kuzzle stack : `sh .codepipeline/start_kuzzle.sh`
- - Build and run features : `docker run --rm -it --network codepipeline_default --link kuzzle -e KUZZLE_HOST=kuzzle --mount type=bind,source="$(pwd)",target=/go/src/github.com/kuzzleio/sdk-go  kuzzleio/sdk-cross:amd64 sh internal/wrappers/features/run_cpp.sh`
+ - Build and run features : `docker run --rm -it --network codepipeline_default --link kuzzle -e KUZZLE_HOST=kuzzle -v "$(pwd)":/go/src/github.com/kuzzleio/sdk-go  kuzzleio/sdk-cross:amd64 sh internal/wrappers/features/run_cpp.sh`
 `
 
 You can specify a single feature file to be run by passing it as argument to the `run_***.sh` script.  
-Run only the collection features : `docker run --rm -it --network codepipeline_default --link kuzzle -e KUZZLE_HOST=kuzzle --mount type=bind,source="$(pwd)",target=/go/src/github.com/kuzzleio/sdk-go  kuzzleio/sdk-cross:amd64 sh internal/wrappers/features/run_cpp.sh collection.feature`
+Run only the collection features : `docker run --rm -it --network codepipeline_default --link kuzzle -e KUZZLE_HOST=kuzzle -v "$(pwd)":/go/src/github.com/kuzzleio/sdk-go  kuzzleio/sdk-cross:amd64 sh internal/wrappers/features/run_cpp.sh collection.feature`
 
 # Contributing
 

--- a/internal/wrappers/cgo/kuzzle/kuzzle.go
+++ b/internal/wrappers/cgo/kuzzle/kuzzle.go
@@ -200,9 +200,9 @@ func kuzzle_flush_queue(k *C.kuzzle) {
 	(*kuzzle.Kuzzle)(k.instance).FlushQueue()
 }
 
-//export kuzzle_replay_queue
-func kuzzle_replay_queue(k *C.kuzzle) {
-	(*kuzzle.Kuzzle)(k.instance).ReplayQueue()
+//export kuzzle_play_queue
+func kuzzle_play_queue(k *C.kuzzle) {
+	(*kuzzle.Kuzzle)(k.instance).PlayQueue()
 }
 
 //export kuzzle_start_queuing

--- a/internal/wrappers/cpp/kuzzle.cpp
+++ b/internal/wrappers/cpp/kuzzle.cpp
@@ -36,7 +36,7 @@ namespace kuzzleio {
   Kuzzle::Kuzzle(const std::string& host, options *opts) {
     this->_kuzzle = new kuzzle();
     kuzzle_new_kuzzle(this->_kuzzle, const_cast<char*>(host.c_str()), (char*)"websocket", opts);
-    
+
     this->document = new Document(this, kuzzle_get_document_controller(_kuzzle));
     this->auth = new Auth(this, kuzzle_get_auth_controller(_kuzzle));
     this->index = new Index(this, kuzzle_get_index_controller(_kuzzle));
@@ -71,8 +71,8 @@ namespace kuzzleio {
     return r;
   }
 
-  Kuzzle* Kuzzle::replayQueue() {
-    kuzzle_replay_queue(_kuzzle);
+  Kuzzle* Kuzzle::playQueue() {
+    kuzzle_play_queue(_kuzzle);
     return this;
   }
 

--- a/internal/wrappers/headers/kuzzle.hpp
+++ b/internal/wrappers/headers/kuzzle.hpp
@@ -53,7 +53,7 @@ namespace kuzzleio {
       std::string getJwt();
       void disconnect();
       kuzzle_response* query(kuzzle_request* query, query_options* options=NULL) Kuz_Throw_KuzzleException;
-      Kuzzle* replayQueue();
+      Kuzzle* playQueue();
       Kuzzle* setAutoReplay(bool autoReplay);
       Kuzzle* setDefaultIndex(const std::string& index);
       Kuzzle* startQueuing();

--- a/internal/wrappers/templates/java/javadoc/kuzzle.i
+++ b/internal/wrappers/templates/java/javadoc/kuzzle.i
@@ -397,7 +397,7 @@
    */
   public";
 
-%javamethodmodifiers kuzzleio::Kuzzle::replayQueue() "
+%javamethodmodifiers kuzzleio::Kuzzle::playQueue() "
   /**
    * Replays the requests queued during offline mode.
    * Works only if the SDK is not in a disconnected state, and if the autoReplay option is set to false.
@@ -420,7 +420,7 @@
    * Set a new JWT and trigger the 'loginAttempt' event.
    *
    * @param jwt - New authentication JSON Web Token
-   * @return this 
+   * @return this
    */
   public";
 
@@ -501,7 +501,7 @@
 
 %javamethodmodifiers kuzzleio::Kuzzle::addListener(Event event, EventListener* listener) "
    /**
-   * Adds a listener to a Kuzzle global event. When an event is triggered, 
+   * Adds a listener to a Kuzzle global event. When an event is triggered,
    * listeners are called in the order of their insertion.
    *
    * @param event - Name of the global event to subscribe to

--- a/kuzzle/queue.go
+++ b/kuzzle/queue.go
@@ -19,10 +19,9 @@ func (k *Kuzzle) FlushQueue() {
 	k.socket.ClearQueue()
 }
 
-// ReplayQueue replays the requests queued during offline mode.
-// Works only if the SDK is not in a disconnected state, and if the autoReplay option is set to false.
-func (k *Kuzzle) ReplayQueue() {
-	k.socket.ReplayQueue()
+// PlayQueue replays the requests queued during offline mode. Works only if the SDK is not in a disconnected state, and if the autoReplay option is set to false.
+func (k *Kuzzle) PlayQueue() {
+	k.socket.PlayQueue()
 }
 
 // StartQueuing start the requests queuing.


### PR DESCRIPTION
## What does this PR do ?

The method `replayQueue` is deprecated in the version `6.x` of the [sdk-javascript](https://github.com/kuzzleio/sdk-javascript/blob/6.x/src/Kuzzle.js#L374).  
This PR rename the `ReplayQueue` method to `PlayQueue` in Go and in the wrappers.

### Boyscout

  - Use `-v` instead of `--mount` for Docker volumes