### PR TITLE
add a mapping argument to existing collection.create methods

### DIFF
--- a/.codepipeline/docker-compose.yml
+++ b/.codepipeline/docker-compose.yml
@@ -22,6 +22,8 @@ services:
 
   elasticsearch:
     image: kuzzleio/elasticsearch:5.4.1
+    ulimits:
+      nofile: 65536
     environment:
       - cluster.name=kuzzle
       - "ES_JAVA_OPTS=-Xms256m -Xmx256m"

--- a/.gitignore
+++ b/.gitignore
@@ -9,5 +9,6 @@ _build*/
 build/
 kcore_wrap.cxx
 kcore_wrap.h
+.gradle
 
 internal/wrappers/kcore_wrap\.o

--- a/README.md
+++ b/README.md
@@ -54,12 +54,12 @@ func main() {
 
 To run the tests you can simply execute the coverage.sh script
 ```sh
-./coverage.sh
+./test.sh
 ```
 
 You can also get html coverage by running
 ```sh
-./coverage.sh --html
+./test.sh --html
 ```
 ### e2e tests
 

--- a/collection/create.go
+++ b/collection/create.go
@@ -15,17 +15,22 @@
 package collection
 
 import (
+	"encoding/json"
 	"github.com/kuzzleio/sdk-go/types"
 )
 
 // Create creates a new empty data collection
-func (dc *Collection) Create(index string, collection string, options types.QueryOptions) error {
+func (dc *Collection) Create(index string, collection string, body json.RawMessage, options types.QueryOptions) error {
 	if index == "" {
 		return types.NewError("Collection.Create: index required", 400)
 	}
 
 	if collection == "" {
 		return types.NewError("Collection.Create: collection required", 400)
+	}
+
+	if body != nil && len(body) == 0 {
+		return types.NewError("Collection.Create: body is not a valid JSON", 400)
 	}
 
 	ch := make(chan *types.KuzzleResponse)
@@ -35,7 +40,9 @@ func (dc *Collection) Create(index string, collection string, options types.Quer
 		Index:      index,
 		Controller: "collection",
 		Action:     "create",
+		Body:       body,
 	}
+
 	go dc.Kuzzle.Query(query, options, ch)
 
 	res := <-ch

--- a/collection/create.go
+++ b/collection/create.go
@@ -29,8 +29,8 @@ func (dc *Collection) Create(index string, collection string, body json.RawMessa
 		return types.NewError("Collection.Create: collection required", 400)
 	}
 
-	if body != nil && len(body) == 0 {
-		return types.NewError("Collection.Create: body is not a valid JSON", 400)
+	if body != nil && !json.Valid(body) {
+		return types.NewError("Collection.Create: body is not a valid JSON object", 400)
 	}
 
 	ch := make(chan *types.KuzzleResponse)

--- a/collection/create_test.go
+++ b/collection/create_test.go
@@ -15,27 +15,34 @@
 package collection_test
 
 import (
+	"encoding/json"
 	"fmt"
-	"testing"
-
 	"github.com/kuzzleio/sdk-go/collection"
 	"github.com/kuzzleio/sdk-go/internal"
 	"github.com/kuzzleio/sdk-go/kuzzle"
 	"github.com/kuzzleio/sdk-go/types"
 	"github.com/stretchr/testify/assert"
+	"testing"
 )
 
 func TestCreateIndexNull(t *testing.T) {
 	k, _ := kuzzle.NewKuzzle(&internal.MockedConnection{}, nil)
 	nc := collection.NewCollection(k)
-	err := nc.Create("", "collection", nil)
+	err := nc.Create("", "collection", nil, nil)
 	assert.NotNil(t, err)
 }
 
 func TestCreateCollectionNull(t *testing.T) {
 	k, _ := kuzzle.NewKuzzle(&internal.MockedConnection{}, nil)
 	nc := collection.NewCollection(k)
-	err := nc.Create("index", "", nil)
+	err := nc.Create("index", "", nil, nil)
+	assert.NotNil(t, err)
+}
+
+func TestCreateBodyEmpty(t *testing.T) {
+	k, _ := kuzzle.NewKuzzle(&internal.MockedConnection{}, nil)
+	nc := collection.NewCollection(k)
+	err := nc.Create("index", "collection", json.RawMessage(``), nil)
 	assert.NotNil(t, err)
 }
 
@@ -48,7 +55,7 @@ func TestCreateError(t *testing.T) {
 	k, _ := kuzzle.NewKuzzle(c, nil)
 
 	nc := collection.NewCollection(k)
-	err := nc.Create("index", "collection", nil)
+	err := nc.Create("index", "collection", nil, nil)
 	assert.NotNil(t, err)
 	assert.Equal(t, "Unit test error", err.(types.KuzzleError).Message)
 }
@@ -64,7 +71,10 @@ func TestCreate(t *testing.T) {
 	k, _ := kuzzle.NewKuzzle(c, nil)
 
 	nc := collection.NewCollection(k)
-	err := nc.Create("index", "collection", nil)
+	err := nc.Create("index", "collection", nil, nil)
+	assert.Nil(t, err)
+
+	err = nc.Create("index", "collection", json.RawMessage(`{"properties":{}}`), nil)
 	assert.Nil(t, err)
 }
 
@@ -73,7 +83,7 @@ func ExampleCollection_Create() {
 	k, _ := kuzzle.NewKuzzle(c, nil)
 
 	nc := collection.NewCollection(k)
-	err := nc.Create("index", "collection", nil)
+	err := nc.Create("index", "collection", json.RawMessage(`{"properties":{"foo": {"type": "keyword"}}}`), nil)
 
 	if err != nil {
 		fmt.Println(err.Error())

--- a/internal/wrappers/cgo/kuzzle/collection.go
+++ b/internal/wrappers/cgo/kuzzle/collection.go
@@ -58,7 +58,13 @@ func kuzzle_new_collection(c *C.collection, k *C.kuzzle) {
 
 //export kuzzle_collection_create
 func kuzzle_collection_create(c *C.collection, index *C.char, col *C.char, body *C.char, options *C.query_options) *C.error_result {
-	err := (*collection.Collection)(c.instance).Create(C.GoString(index), C.GoString(col), json.RawMessage(C.GoString(body)), SetQueryOptions(options))
+	var rawBody json.RawMessage
+
+	if body != nil {
+		rawBody = json.RawMessage(C.GoString(body))
+	}
+
+	err := (*collection.Collection)(c.instance).Create(C.GoString(index), C.GoString(col), rawBody, SetQueryOptions(options))
 	return goToCErrorResult(err)
 }
 

--- a/internal/wrappers/cgo/kuzzle/collection.go
+++ b/internal/wrappers/cgo/kuzzle/collection.go
@@ -57,8 +57,8 @@ func kuzzle_new_collection(c *C.collection, k *C.kuzzle) {
 }
 
 //export kuzzle_collection_create
-func kuzzle_collection_create(c *C.collection, index *C.char, col *C.char, options *C.query_options) *C.error_result {
-	err := (*collection.Collection)(c.instance).Create(C.GoString(index), C.GoString(col), SetQueryOptions(options))
+func kuzzle_collection_create(c *C.collection, index *C.char, col *C.char, body *C.char, options *C.query_options) *C.error_result {
+	err := (*collection.Collection)(c.instance).Create(C.GoString(index), C.GoString(col), json.RawMessage(C.GoString(body)), SetQueryOptions(options))
 	return goToCErrorResult(err)
 }
 

--- a/internal/wrappers/cpp/collection.cpp
+++ b/internal/wrappers/cpp/collection.cpp
@@ -36,7 +36,7 @@ namespace kuzzleio {
             _collection,
             const_cast<char*>(index.c_str()),
             const_cast<char*>(collection.c_str()),
-            body ? const_cast<char*>(body->c_str()) : NULL,
+            body != NULL ? const_cast<char*>(body->c_str()) : NULL,
             options);
 
         if (r != NULL)

--- a/internal/wrappers/cpp/collection.cpp
+++ b/internal/wrappers/cpp/collection.cpp
@@ -31,10 +31,17 @@ namespace kuzzleio {
         delete(_collection);
     }
 
-    void Collection::create(const std::string& index, const std::string& collection, query_options *options) Kuz_Throw_KuzzleException {
-        error_result *r = kuzzle_collection_create(_collection, const_cast<char*>(index.c_str()), const_cast<char*>(collection.c_str()), options);
+    void Collection::create(const std::string& index, const std::string& collection, const std::string* body, query_options *options) Kuz_Throw_KuzzleException {
+        error_result *r = kuzzle_collection_create(
+            _collection,
+            const_cast<char*>(index.c_str()),
+            const_cast<char*>(collection.c_str()),
+            body ? const_cast<char*>(body->c_str()) : NULL,
+            options);
+
         if (r != NULL)
             throwExceptionFromStatus(r);
+
         kuzzle_free_error_result(r);
     }
 

--- a/internal/wrappers/features/collection.feature
+++ b/internal/wrappers/features/collection.feature
@@ -29,9 +29,16 @@ Feature: Collection management
     And the collection has a document with id 'my-document-id'
     And the collection has a document with id 'my-document-id2'
     When I truncate the collection 'test-collection'
-    Then the collection 'test-collection' shall be empty
+    Then the collection 'test-collection' should be empty
 
   Scenario: Create a collection with a custom mapping
+    Given Kuzzle Server is running
+    And there is an index 'test-index'
+    When I create a collection 'test-create-with-mapping' with a mapping
+    Then the collection 'test-create-with-mapping' should exists
+    And the mapping of 'test-create-with-mapping' should be updated
+
+  Scenario: Update a collection with a custom mapping
     Given Kuzzle Server is running
     And there is an index 'test-index'
     And it has a collection 'test-collection'

--- a/internal/wrappers/features/collection.feature
+++ b/internal/wrappers/features/collection.feature
@@ -4,7 +4,7 @@ Feature: Collection management
     Given Kuzzle Server is running
     And there is an index 'test-index'
     When I create a collection 'collection-test-collection'
-    Then the collection 'collection-test-collection' should exists
+    Then the collection 'collection-test-collection' should exist
 
   Scenario: Check if a collection exists
     Given Kuzzle Server is running
@@ -35,7 +35,7 @@ Feature: Collection management
     Given Kuzzle Server is running
     And there is an index 'test-index'
     When I create a collection 'test-create-with-mapping' with a mapping
-    Then the collection 'test-create-with-mapping' should exists
+    Then the collection 'test-create-with-mapping' should exist
     And the mapping of 'test-create-with-mapping' should be updated
 
   Scenario: Update a collection with a custom mapping

--- a/internal/wrappers/features/documents.feature
+++ b/internal/wrappers/features/documents.feature
@@ -186,7 +186,7 @@ Feature: Document management
     And it has a collection 'exist-test-collection'
     And the collection has a document with id 'exist-my-document-id'
     When I check if 'exist-my-document-id' exists
-    Then the document should exists
+    Then the document should exist
 
   Scenario: Check if a document does not exists
     Given Kuzzle Server is running

--- a/internal/wrappers/features/java/src/test/java/gradle/cucumber/Collectiondefs.java
+++ b/internal/wrappers/features/java/src/test/java/gradle/cucumber/Collectiondefs.java
@@ -32,7 +32,7 @@ public class Collectiondefs {
         world.collection = collection;
     }
 
-    @Then("^the collection \'([^\"]*)\' should exists$")
+    @Then("^the collection \'([^\"]*)\' should exist$")
     public void the_collection_should_exists(String collection) throws Exception {
         Assert.assertTrue(k.getCollection().exists(world.index, collection));
     }

--- a/internal/wrappers/features/java/src/test/java/gradle/cucumber/Collectiondefs.java
+++ b/internal/wrappers/features/java/src/test/java/gradle/cucumber/Collectiondefs.java
@@ -79,7 +79,7 @@ public class Collectiondefs {
         k.getCollection().truncate(world.index, collection, o);
     }
 
-    @Then("^the collection \'([^\"]*)\' shall be empty$")
+    @Then("^the collection \'([^\"]*)\' should be empty$")
     public void it_should_be_empty(String collection) throws Exception {
         SearchResult res = k.getDocument().search(world.index, collection, "{}");
         Assert.assertEquals("[]", res.getDocuments());
@@ -99,7 +99,8 @@ public class Collectiondefs {
     @Then("^the mapping of \'([^\"]*)\' should be updated$")
     public void the_mapping_should_be_updated(String collection) throws Exception {
         String mapping = k.getCollection().getMapping(world.index, collection);
-        Assert.assertEquals("{\"test-index\":{\"mappings\":{\"test-collection\":{\"properties\":{\"foo\":{\"type\":\"text\",\"fields\":{\"keyword\":{\"type\":\"keyword\",\"ignore_above\":256}}}}}}}}", mapping);
+        Assert.assertEquals(
+            "{\"" + world.index + "\":{\"mappings\":{\"" + collection + "\":{\"properties\":{\"foo\":{\"type\":\"text\",\"fields\":{\"keyword\":{\"type\":\"keyword\",\"ignore_above\":256}}}}}}}}", mapping);
     }
 
     @When("^I update the specifications of the collection \'([^\"]*)\'$")
@@ -143,4 +144,10 @@ public class Collectiondefs {
         Assert.assertTrue(notFound);
     }
 
+    @When("^I create a collection \'([^\"]*)\' with a mapping$")
+    public void i_create_a_collection_test_collection(String collection) throws Exception {
+        String mapping = "{\"properties\": {\"foo\": {\"type\": \"string\"}}}";
+        k.getCollection().create(world.index, collection, mapping);
+        world.collection = collection;
+    }
 }

--- a/internal/wrappers/features/java/src/test/java/gradle/cucumber/Collectiondefs.java
+++ b/internal/wrappers/features/java/src/test/java/gradle/cucumber/Collectiondefs.java
@@ -90,7 +90,8 @@ public class Collectiondefs {
         k.getCollection().updateMapping(world.index, collection, "{" +
                 "\"properties\": {" +
                 "    \"foo\": {" +
-                "      \"type\": \"string\"" +
+                "      \"type\": \"string\"," +
+                "      \"fields\": {\"keyword\":{\"type\":\"keyword\",\"ignore_above\":256}}" +
                 "    }" +
                 "}" +
                 "}");
@@ -146,7 +147,10 @@ public class Collectiondefs {
 
     @When("^I create a collection \'([^\"]*)\' with a mapping$")
     public void i_create_a_collection_test_collection_with_mapping(String collection) throws Exception {
-        String mapping = "{\"properties\": {\"foo\": {\"type\": \"string\"}}}";
+        String mapping = "{\"properties\": {\"foo\": {"
+            + "\"type\": \"string\", \"fields\": {"
+            + "\"keyword\":{\"type\":\"keyword\",\"ignore_above\":256}}"
+            + "}}}";
         k.getCollection().create(world.index, collection, mapping);
         world.collection = collection;
     }

--- a/internal/wrappers/features/java/src/test/java/gradle/cucumber/Collectiondefs.java
+++ b/internal/wrappers/features/java/src/test/java/gradle/cucumber/Collectiondefs.java
@@ -145,7 +145,7 @@ public class Collectiondefs {
     }
 
     @When("^I create a collection \'([^\"]*)\' with a mapping$")
-    public void i_create_a_collection_test_collection(String collection) throws Exception {
+    public void i_create_a_collection_test_collection_with_mapping(String collection) throws Exception {
         String mapping = "{\"properties\": {\"foo\": {\"type\": \"string\"}}}";
         k.getCollection().create(world.index, collection, mapping);
         world.collection = collection;

--- a/internal/wrappers/features/java/src/test/java/gradle/cucumber/Documentdefs.java
+++ b/internal/wrappers/features/java/src/test/java/gradle/cucumber/Documentdefs.java
@@ -347,7 +347,7 @@ public class Documentdefs {
         }
     }
 
-    @Then("^the document should exists$")
+    @Then("^the document should exist$")
     public void the_document_should_exists() throws Exception {
         Assert.assertNull(this.errorMessage);
         Assert.assertTrue(this.documentExists);

--- a/internal/wrappers/features/step_defs_cpp/collection-steps.cpp
+++ b/internal/wrappers/features/step_defs_cpp/collection-steps.cpp
@@ -96,7 +96,7 @@ namespace {
     ctx->kuzzle->collection->truncate(ctx->index, collection_id, &options);
   }
 
-  THEN("^the collection \'([^\"]*)\' shall be empty$")
+  THEN("^the collection \'([^\"]*)\' should be empty$")
   {
     REGEX_PARAM(string, collection_id);
 
@@ -199,5 +199,19 @@ namespace {
     ScenarioScope<KuzzleCtx> ctx;
 
     BOOST_CHECK(ctx->kuzzle->collection->getSpecifications(ctx->index, collection_id) == "");
+  }
+
+  WHEN("^I create a collection \'([^\"]*)\' with a mapping$")
+  {
+    REGEX_PARAM(string, collection_id);
+
+    ScenarioScope<KuzzleCtx> ctx;
+    string mapping = "{\"properties\": {\"gordon\": {\"type\": \"keyword\"}}}";
+
+    try {
+      ctx->kuzzle->collection->create(ctx->index, collection_id, &mapping);
+    } catch (KuzzleException e) {
+      BOOST_FAIL(e.getMessage());
+    }
   }
 }

--- a/internal/wrappers/features/step_defs_cpp/collection-steps.cpp
+++ b/internal/wrappers/features/step_defs_cpp/collection-steps.cpp
@@ -16,7 +16,7 @@ namespace {
     }
   }
 
-  THEN("^the collection \'([^\"]*)\' should exists$")
+  THEN("^the collection \'([^\"]*)\' should exist$")
   {
     REGEX_PARAM(string, collection_id);
 

--- a/internal/wrappers/headers/collection.hpp
+++ b/internal/wrappers/headers/collection.hpp
@@ -30,7 +30,7 @@ namespace kuzzleio {
             Collection(Kuzzle* kuzzle);
             Collection(Kuzzle* kuzzle, collection *collection);
             virtual ~Collection();
-            void create(const std::string& index, const std::string& collection, query_options *options=NULL) Kuz_Throw_KuzzleException;
+            void create(const std::string& index, const std::string& collection, const std::string* body=NULL, query_options *options=NULL) Kuz_Throw_KuzzleException;
             bool exists(const std::string& index, const std::string& collection, query_options *options=NULL) Kuz_Throw_KuzzleException;
             std::string list(const std::string& index, query_options *options=NULL) Kuz_Throw_KuzzleException;
             void truncate(const std::string& index, const std::string& collection, query_options *options=NULL) Kuz_Throw_KuzzleException;

--- a/internal/wrappers/templates/java/typemap.i
+++ b/internal/wrappers/templates/java/typemap.i
@@ -25,3 +25,23 @@
     return new java.util.Date(res);
   }
 %}
+
+%typemap(jni) std::string* "jobject"
+%typemap(jtype) std::string* "java.lang.String"
+%typemap(jstype) std::string* "java.lang.String"
+%typemap(javain) std::string* "$javainput"
+%typemap(in) std::string * (std::string strTemp) {
+  jobject oInput = $input;
+  if (oInput != NULL) {
+    jstring sInput = static_cast<jstring>( oInput );
+
+    const char * $1_pstr = (const char *)jenv->GetStringUTFChars(sInput, 0);
+    if (!$1_pstr) return $null;
+    strTemp.assign( $1_pstr );
+    jenv->ReleaseStringUTFChars( sInput, $1_pstr);
+    $1 = &strTemp;
+  } else {
+    $1 = NULL;
+  }
+}
+%apply std::string * { std::string* };


### PR DESCRIPTION
## What does this PR do ?

Allow `Collection.create` in Go, C++ and Java to handle a `mapping` argument, allowing to create new collections directly with a user-mapping specified.

Unit & functional tests have been added.

## Other changes

* Add a SWIG template for Java to make it handle pointers to std::string (@jenow)

## Boyscout

* Fix outdated test script name in the README file
* Fix a typo in functional test scenarios
* Add a `ulimit` configuration to elasticsearch's docker-compose, to allow it to run on computers with a number of opened files set with a low value