### PR TITLE
[KZL-372] Add namespace kuzzleio for C structs

### DIFF
--- a/internal/wrappers/Makefile
+++ b/internal/wrappers/Makefile
@@ -167,7 +167,7 @@ java: core_java swig_java wrapper_java java_object
 	cp build/java/io/kuzzle/sdk/$(LIB_PREFIX)kuzzle-wrapper-java.so build/io/kuzzle/sdk/resources
 	mkdir -p $(ROOTOUTDIR)/java/src/main/resources
 	mkdir -p $(ROOTOUTDIR)/java/src/main/java
-	mv build/java/io/kuzzle/sdk/$(LIB_PREFIX)kuzzle-wrapper-java.so $(ROOTOUTDIR)/java/src/main/resources/	
+	mv build/java/io/kuzzle/sdk/$(LIB_PREFIX)kuzzle-wrapper-java.so $(ROOTOUTDIR)/java/src/main/resources/
 	ln -sf $(ROOTOUTDIR)/java/io/kuzzle/sdk/* $(ROOTOUTDIR)/java/src/main/java/
 	cd build/java && sh gradlew sourcesJar jar javadocJar && cd -
 	cp -p $(GOTARGET) $(OUTDIR)
@@ -208,7 +208,7 @@ cpp: OUTDIR = $(ROOTOUTDIR)/cpp
 cpp: LANGUAGE = c++
 cpp: makedir core_cpp $(CPPSDK)
 		ar rvs $(OUTDIR)/libcpp$(STATICLIB) $(OUTDIR)/*.o
-		$(CPP) -shared -fPIC -o $(OUTDIR)/libcpp$(DYNLIB) -Wl,--whole-archive $(OUTDIR)/libcpp$(STATICLIB) build/c/$(LIB_PREFIX)kuzzlesdk$(STATICLIB) -Wl,--no-whole-archive
+		$(CXX) -shared -fPIC -o $(OUTDIR)/libcpp$(DYNLIB) -Wl,--whole-archive $(OUTDIR)/libcpp$(STATICLIB) build/c/$(LIB_PREFIX)kuzzlesdk$(STATICLIB) -Wl,--no-whole-archive
 
 clean:
 ifeq ($(OS),Windows_NT)

--- a/internal/wrappers/cgo/kuzzle/auth.go
+++ b/internal/wrappers/cgo/kuzzle/auth.go
@@ -54,7 +54,7 @@ func kuzzle_new_auth(a *C.auth, k *C.kuzzle) {
 
 	ptr := unsafe.Pointer(auth)
 	a.instance = ptr
-	a.kuzzle = k
+	a.k = k
 
 	registerAuth(a, ptr)
 }
@@ -109,7 +109,7 @@ func kuzzle_delete_my_credentials(a *C.auth, strategy *C.char, options *C.query_
 func kuzzle_get_current_user(a *C.auth) *C.user_result {
 	u, err := (*auth.Auth)(a.instance).GetCurrentUser()
 
-	return goToCUserResult(a.kuzzle, u, err)
+	return goToCUserResult(a.k, u, err)
 }
 
 //export kuzzle_get_my_credentials
@@ -175,7 +175,7 @@ func kuzzle_update_self(a *C.auth, data *C.char, options *C.query_options) *C.us
 		json.RawMessage(C.GoString(data)),
 		SetQueryOptions(options))
 
-	return goToCUserResult(a.kuzzle, res, err)
+	return goToCUserResult(a.k, res, err)
 }
 
 //export kuzzle_validate_my_credentials

--- a/internal/wrappers/cgo/kuzzle/c_to_go.go
+++ b/internal/wrappers/cgo/kuzzle/c_to_go.go
@@ -66,7 +66,7 @@ func cToGoKuzzleMeta(cMeta *C.meta) *types.Meta {
 }
 
 func cToGoCollection(c *C.collection) *collection.Collection {
-	return collection.NewCollection((*kuzzle.Kuzzle)(c.kuzzle.instance))
+	return collection.NewCollection((*kuzzle.Kuzzle)(c.k.instance))
 }
 
 func cToGoPolicyRestriction(r *C.policy_restriction) *types.PolicyRestriction {

--- a/internal/wrappers/cgo/kuzzle/collection.go
+++ b/internal/wrappers/cgo/kuzzle/collection.go
@@ -51,7 +51,7 @@ func kuzzle_new_collection(c *C.collection, k *C.kuzzle) {
 
 	ptr := unsafe.Pointer(col)
 	c.instance = ptr
-	c.kuzzle = k
+	c.k = k
 
 	registerCollection(c, ptr)
 }

--- a/internal/wrappers/cgo/kuzzle/destructors.go
+++ b/internal/wrappers/cgo/kuzzle/destructors.go
@@ -248,7 +248,7 @@ func kuzzle_free_user_data(st *C.user_data) {
 func kuzzle_free_collection(st *C.collection) {
 	if st != nil {
 		C.free(unsafe.Pointer(st.instance))
-		C.free(unsafe.Pointer(st.kuzzle))
+		C.free(unsafe.Pointer(st.k))
 		C.free(unsafe.Pointer(st))
 	}
 }
@@ -257,7 +257,7 @@ func kuzzle_free_collection(st *C.collection) {
 func kuzzle_free_document(st *C.document) {
 	if st != nil {
 		C.free(unsafe.Pointer(st.instance))
-		C.free(unsafe.Pointer(st.kuzzle))
+		C.free(unsafe.Pointer(st.k))
 		C.free(unsafe.Pointer(st))
 	}
 }
@@ -266,7 +266,7 @@ func kuzzle_free_document(st *C.document) {
 func kuzzle_free_notification_content(st *C.notification_content) {
 	if st != nil {
 		C.free(unsafe.Pointer(st.id))
-		kuzzle_free_meta(st.meta)
+		kuzzle_free_meta(st.m)
 		C.free(unsafe.Pointer(st.content))
 		C.free(unsafe.Pointer(st))
 	}
@@ -300,7 +300,7 @@ func kuzzle_free_notification_result(st *C.notification_result) {
 //export kuzzle_free_profile_result
 func kuzzle_free_profile_result(st *C.profile_result) {
 	if st != nil {
-		kuzzle_free_profile(st.profile)
+		kuzzle_free_profile(st.p)
 		C.free(unsafe.Pointer(st.error))
 		C.free(unsafe.Pointer(st.stack))
 		C.free(unsafe.Pointer(st))
@@ -329,7 +329,7 @@ func kuzzle_free_profiles_result(st *C.profiles_result) {
 //export kuzzle_free_role_result
 func kuzzle_free_role_result(st *C.role_result) {
 	if st != nil {
-		kuzzle_free_role(st.role)
+		kuzzle_free_role(st.r)
 		C.free(unsafe.Pointer(st.error))
 		C.free(unsafe.Pointer(st.stack))
 		C.free(unsafe.Pointer(st))

--- a/internal/wrappers/cgo/kuzzle/document.go
+++ b/internal/wrappers/cgo/kuzzle/document.go
@@ -50,7 +50,7 @@ func kuzzle_new_document(d *C.document, k *C.kuzzle) {
 
 	ptr := unsafe.Pointer(doc)
 	d.instance = ptr
-	d.kuzzle = k
+	d.k = k
 	registerDocument(doc, ptr)
 }
 

--- a/internal/wrappers/cgo/kuzzle/go_to_c.go
+++ b/internal/wrappers/cgo/kuzzle/go_to_c.go
@@ -33,7 +33,7 @@ import (
 func duplicateCollection(ptr *C.collection) *C.collection {
 	dest := (*C.collection)(C.calloc(1, C.sizeof_collection))
 
-	dest.kuzzle = ptr.kuzzle
+	dest.k = ptr.k
 
 	return dest
 }
@@ -73,7 +73,7 @@ func goToCShards(gShards *types.Shards) *C.shards {
 func goToCNotificationContent(gNotifContent *types.NotificationResult) *C.notification_content {
 	result := (*C.notification_content)(C.calloc(1, C.sizeof_notification_content))
 	result.id = C.CString(gNotifContent.Id)
-	result.meta = goToCMeta(gNotifContent.Meta)
+	result.m = goToCMeta(gNotifContent.Meta)
 	result.count = C.int(gNotifContent.Count)
 	marshalled, _ := json.Marshal(gNotifContent)
 	result.content = C.CString(string(marshalled))
@@ -293,7 +293,7 @@ func goToCProfile(k *C.kuzzle, profile *security.Profile, dest *C.profile) *C.pr
 
 	cprofile.id = C.CString(profile.Id)
 	cprofile.policies_length = C.size_t(len(profile.Policies))
-	cprofile.kuzzle = k
+	cprofile.k = k
 
 	if profile.Policies != nil {
 		cprofile.policies = (*C.policy)(C.calloc(C.size_t(len(profile.Policies)), C.sizeof_policy))
@@ -416,7 +416,7 @@ func goToCRole(k *C.kuzzle, role *security.Role, dest *C.role) *C.role {
 	}
 
 	crole.id = C.CString(role.Id)
-	crole.kuzzle = k
+	crole.k = k
 
 	if role.Controllers != nil {
 		ctrls, _ := json.Marshal(role.Controllers)
@@ -503,7 +503,7 @@ func goToCProfileResult(k *C.kuzzle, res *security.Profile, err error) *C.profil
 		return result
 	}
 
-	result.profile = goToCProfile(k, res, nil)
+	result.p = goToCProfile(k, res, nil)
 	return result
 }
 
@@ -549,7 +549,7 @@ func goToCUser(k *C.kuzzle, user *security.User, dest *C.kuzzle_user) (*C.kuzzle
 	}
 
 	cuser.id = C.CString(user.Id)
-	cuser.kuzzle = k
+	cuser.k = k
 
 	if user.Content != nil {
 		cnt, err := json.Marshal(user.Content)

--- a/internal/wrappers/cgo/kuzzle/index.go
+++ b/internal/wrappers/cgo/kuzzle/index.go
@@ -52,7 +52,7 @@ func kuzzle_new_index(i *C.kuzzle_index, k *C.kuzzle) {
 
 	ptr := unsafe.Pointer(index)
 	i.instance = ptr
-	i.kuzzle = k
+	i.k = k
 
 	registerIndex(i, ptr)
 }

--- a/internal/wrappers/cgo/kuzzle/kuzzle.go
+++ b/internal/wrappers/cgo/kuzzle/kuzzle.go
@@ -83,7 +83,7 @@ func kuzzle_get_document_controller(k *C.kuzzle) *C.document {
 	d := (*C.document)(C.calloc(1, C.sizeof_document))
 
 	d.instance = unsafe.Pointer(unsafe.Pointer((*kuzzle.Kuzzle)(k.instance).Document))
-	d.kuzzle = k
+	d.k = k
 	return d
 }
 
@@ -92,7 +92,7 @@ func kuzzle_get_auth_controller(k *C.kuzzle) *C.auth {
 	a := (*C.auth)(C.calloc(1, C.sizeof_auth))
 
 	a.instance = unsafe.Pointer(unsafe.Pointer((*kuzzle.Kuzzle)(k.instance).Auth))
-	a.kuzzle = k
+	a.k = k
 	return a
 }
 
@@ -101,7 +101,7 @@ func kuzzle_get_index_controller(k *C.kuzzle) *C.kuzzle_index {
 	i := (*C.kuzzle_index)(C.calloc(1, C.sizeof_kuzzle_index))
 
 	i.instance = unsafe.Pointer(unsafe.Pointer((*kuzzle.Kuzzle)(k.instance).Index))
-	i.kuzzle = k
+	i.k = k
 	return i
 }
 
@@ -115,7 +115,7 @@ func kuzzle_get_server_controller(k *C.kuzzle) *C.server {
 	s := (*C.server)(C.calloc(1, C.sizeof_server))
 
 	s.instance = unsafe.Pointer(unsafe.Pointer((*kuzzle.Kuzzle)(k.instance).Server))
-	s.kuzzle = k
+	s.k = k
 	return s
 }
 
@@ -124,7 +124,7 @@ func kuzzle_get_collection_controller(k *C.kuzzle) *C.collection {
 	c := (*C.collection)(C.calloc(1, C.sizeof_collection))
 
 	c.instance = unsafe.Pointer(unsafe.Pointer((*kuzzle.Kuzzle)(k.instance).Collection))
-	c.kuzzle = k
+	c.k = k
 	return c
 }
 
@@ -133,7 +133,7 @@ func kuzzle_get_realtime_controller(k *C.kuzzle) *C.realtime {
 	rt := (*C.realtime)(C.calloc(1, C.sizeof_realtime))
 
 	rt.instance = unsafe.Pointer(unsafe.Pointer((*kuzzle.Kuzzle)(k.instance).Realtime))
-	rt.kuzzle = k
+	rt.k = k
 	return rt
 }
 

--- a/internal/wrappers/cgo/kuzzle/realtime.go
+++ b/internal/wrappers/cgo/kuzzle/realtime.go
@@ -53,7 +53,7 @@ func kuzzle_new_realtime(rt *C.realtime, k *C.kuzzle) {
 
 	ptr := unsafe.Pointer(gort)
 	rt.instance = ptr
-	rt.kuzzle = k
+	rt.k = k
 
 	registerRealtime(rt, ptr)
 }

--- a/internal/wrappers/cgo/kuzzle/security.go
+++ b/internal/wrappers/cgo/kuzzle/security.go
@@ -40,7 +40,7 @@ func kuzzle_security_new_profile(k *C.kuzzle, id *C.char, policies *C.policy, po
 	cprofile.id = id
 	cprofile.policies = policies
 	cprofile.policies_length = policies_length
-	cprofile.kuzzle = k
+	cprofile.k = k
 
 	return cprofile
 }
@@ -82,7 +82,7 @@ func kuzzle_security_new_user(k *C.kuzzle, id *C.char, d *C.user_data) *C.kuzzle
 	cuser := (*C.kuzzle_user)(C.calloc(1, C.sizeof_kuzzle_user))
 
 	cuser.id = id
-	cuser.kuzzle = k
+	cuser.k = k
 
 	if d != nil {
 		cuser.content = d.content
@@ -125,7 +125,7 @@ func kuzzle_security_new_role(k *C.kuzzle, id *C.char, c C.controllers) *C.role 
 	crole := (*C.role)(C.calloc(1, C.sizeof_role))
 	crole.id = id
 	crole.controllers = C.CString(C.GoString(c))
-	crole.kuzzle = k
+	crole.k = k
 
 	return crole
 }
@@ -151,7 +151,7 @@ func kuzzle_security_get_profile(k *C.kuzzle, id *C.char, o *C.query_options) *C
 		return result
 	}
 
-	result.profile = goToCProfile(k, profile, nil)
+	result.p = goToCProfile(k, profile, nil)
 
 	return result
 }
@@ -183,7 +183,7 @@ func kuzzle_security_get_role(k *C.kuzzle, id *C.char, o *C.query_options) *C.ro
 		return result
 	}
 
-	result.role = goToCRole(k, role, nil)
+	result.r = goToCRole(k, role, nil)
 
 	return result
 }
@@ -317,7 +317,7 @@ func kuzzle_security_create_role(k *C.kuzzle, id, body *C.char, o *C.query_optio
 		return result
 	}
 
-	result.role = goToCRole(k, role, nil)
+	result.r = goToCRole(k, role, nil)
 
 	return result
 }
@@ -369,7 +369,7 @@ func kuzzle_security_create_or_replace_role(k *C.kuzzle, id, body *C.char, o *C.
 		return result
 	}
 
-	result.role = goToCRole(k, role, nil)
+	result.r = goToCRole(k, role, nil)
 
 	return result
 }
@@ -403,7 +403,7 @@ func kuzzle_security_update_profile(k *C.kuzzle, id *C.char, body *C.char, o *C.
 		return result
 	}
 
-	result.profile = goToCProfile(k, profile, nil)
+	result.p = goToCProfile(k, profile, nil)
 
 	return result
 }
@@ -426,7 +426,7 @@ func kuzzle_security_update_role(k *C.kuzzle, id *C.char, body *C.char, o *C.que
 		return result
 	}
 
-	result.role = goToCRole(k, role, nil)
+	result.r = goToCRole(k, role, nil)
 
 	return result
 }

--- a/internal/wrappers/cgo/kuzzle/server.go
+++ b/internal/wrappers/cgo/kuzzle/server.go
@@ -54,7 +54,7 @@ func kuzzle_new_server(s *C.server, k *C.kuzzle) {
 
 	ptr := unsafe.Pointer(server)
 	s.instance = ptr
-	s.kuzzle = k
+	s.k = k
 
 	registerServer(s, ptr)
 }

--- a/internal/wrappers/headers/kuzzlesdk.h
+++ b/internal/wrappers/headers/kuzzlesdk.h
@@ -54,9 +54,9 @@ enum Event {
 };
 
 enum is_action_allowed {
-    ALLOWED=0,
-    CONDITIONNAL=1,
-    DENIED=2
+    ALLOWED,
+    CONDITIONNAL,
+    DENIED
 };
 
 

--- a/internal/wrappers/headers/kuzzlesdk.h
+++ b/internal/wrappers/headers/kuzzlesdk.h
@@ -21,17 +21,23 @@
 #include <stdlib.h>
 #include <stdio.h>
 
-//query object used by query()
-typedef struct {
-    char *query;
-    unsigned long long timestamp;
-    char   *request_id;
-} query_object;
+enum Mode {AUTO, MANUAL};
+//options passed to the Kuzzle() fct
 
-typedef struct {
-    query_object **queries;
-    size_t queries_length;
-} offline_queue;
+#define KUZZLE_OPTIONS_DEFAULT { \
+    .queue_ttl = 120000, \
+    .queue_max_size = 500, \
+    .offline_mode = MANUAL,  \
+    .auto_queue = false,  \
+    .auto_reconnect = true,  \
+    .auto_replay = false, \
+    .auto_resubscribe = true, \
+    .reconnection_delay = 1000, \
+    .replay_interval = 10, \
+    .connect = AUTO, \
+    .refresh = NULL, \
+    .default_index = NULL  \
+}
 
 enum Event {
     CONNECTED,
@@ -46,6 +52,29 @@ enum Event {
     JWT_EXPIRED,
     ERROR
 };
+
+enum is_action_allowed {
+    ALLOWED=0,
+    CONDITIONNAL=1,
+    DENIED=2
+};
+
+
+# ifdef __cplusplus
+namespace kuzzleio {
+# endif
+
+//query object used by query()
+typedef struct {
+    char *query;
+    unsigned long long timestamp;
+    char   *request_id;
+} query_object;
+
+typedef struct {
+    query_object **queries;
+    size_t queries_length;
+} offline_queue;
 
 typedef void (*kuzzle_event_listener)(int, char*, void*);
 
@@ -110,7 +139,7 @@ typedef struct {
 
 typedef struct {
   void *instance;
-  kuzzle* kuzzle;
+  kuzzle* k;
 } realtime;
 
 typedef struct {
@@ -122,17 +151,17 @@ typedef struct {
 
 typedef struct auth {
   void *instance;
-  kuzzle *kuzzle;
+  kuzzle *k;
 } auth;
 
 typedef struct {
   void *instance;
-  kuzzle *kuzzle;
+  kuzzle *k;
 } kuzzle_index;
 
 typedef struct {
   void *instance;
-  kuzzle* kuzzle;
+  kuzzle* k;
 } server;
 
 typedef struct {
@@ -182,24 +211,6 @@ typedef struct {
     char *volatiles;
 } query_options;
 
-enum Mode {AUTO, MANUAL};
-//options passed to the Kuzzle() fct
-
-#define KUZZLE_OPTIONS_DEFAULT { \
-    .queue_ttl = 120000, \
-    .queue_max_size = 500, \
-    .offline_mode = MANUAL,  \
-    .auto_queue = false,  \
-    .auto_reconnect = true,  \
-    .auto_replay = false, \
-    .auto_resubscribe = true, \
-    .reconnection_delay = 1000, \
-    .replay_interval = 10, \
-    .connect = AUTO, \
-    .refresh = NULL, \
-    .default_index = NULL  \
-}
-
 typedef struct {
     unsigned queue_ttl;
     unsigned long queue_max_size;
@@ -245,13 +256,13 @@ typedef struct {
     char *id;
     policy *policies;
     size_t policies_length;
-    kuzzle *kuzzle;
+    kuzzle *k;
 } profile;
 
 typedef struct {
     char *id;
     char *controllers;
-    kuzzle *kuzzle;
+    kuzzle *k;
 } role;
 
 // kuzzle user
@@ -260,7 +271,7 @@ typedef struct {
     char *content;
     char **profile_ids;
     size_t profile_ids_length;
-    kuzzle *kuzzle;
+    kuzzle *k;
 } kuzzle_user;
 
 // user content passed to user constructor
@@ -280,17 +291,17 @@ typedef struct {
 
 typedef struct {
     void *instance;
-    kuzzle *kuzzle;
+    kuzzle *k;
 } collection;
 
 typedef struct {
     void *instance;
-    kuzzle *kuzzle;
+    kuzzle *k;
 } document;
 
 typedef struct {
     char *id;
-    meta *meta;
+    meta *m;
     char *content;
     int count;
 } notification_content;
@@ -316,7 +327,7 @@ typedef struct notification_result {
 } notification_result;
 
 typedef struct profile_result {
-    profile *profile;
+    profile *p;
     int status;
     char *error;
     char *stack;
@@ -331,7 +342,7 @@ typedef struct profiles_result {
 } profiles_result;
 
 typedef struct role_result {
-    role *role;
+    role *r;
     int status;
     char *error;
     char *stack;
@@ -367,12 +378,6 @@ typedef struct user_result {
     char *error;
     char *stack;
 } user_result;
-
-enum is_action_allowed {
-    ALLOWED=0,
-    CONDITIONNAL=1,
-    DENIED=2
-};
 
 //statistics
 typedef struct {
@@ -659,5 +664,9 @@ typedef struct collection_entry_result {
 
 typedef void (*kuzzle_notification_listener)(notification_result*, void*);
 typedef void (*kuzzle_subscribe_listener)(room_result*, void*);
+
+# ifdef __cplusplus
+}
+# endif
 
 #endif

--- a/internal/wrappers/headers/sdk_wrappers_internal.h
+++ b/internal/wrappers/headers/sdk_wrappers_internal.h
@@ -15,6 +15,10 @@
 #ifndef __SDK_WRAPPERS_INTERNAL
 #define __SDK_WRAPPERS_INTERNAL
 
+# ifdef __cplusplus
+using namespace kuzzleio;
+# endif
+
 typedef char *char_ptr;
 typedef policy *policy_ptr;
 typedef policy_restriction *policy_restriction_ptr;

--- a/internal/wrappers/templates/java/common.i
+++ b/internal/wrappers/templates/java/common.i
@@ -99,7 +99,6 @@
 %rename(delete) delete_;
 
 %ignore *::error;
-%ignore *::status;
 %ignore *::stack;
 
 %feature("director") NotificationListener;


### PR DESCRIPTION
## What does this PR do ?
Add namespace `kuzzleio` for SDK C++

### How should this be manually tested?

Build and test it using Docker.

### Other changes

Update in kuzzlesdk.h to have different type name and variable name:

before:
```c
typedef mystruct struct {
    kuzzle *kuzzle;
} mystruct; 
```

now:
```c
typedef mystruct struct {
    kuzzle *k;
} mystruct; 
```
Otherwise SWIG will parse type AND variable to give : 

```c
typedef mystruct struct {
    kuzzleio::kuzzle kuzzleio::*kuzzle;
} mystruct; 
```
instead of:
```c
typedef mystruct struct {
    kuzzleio::kuzzle *kuzzle;
} mystruct; 
```

## Boyscout

Rename CXX to CPP in Makefile