### PR TITLE
Add custom WebviewClient

### DIFF
--- a/internal/wrappers/cgo/kuzzle/kuzzle.go
+++ b/internal/wrappers/cgo/kuzzle/kuzzle.go
@@ -110,6 +110,11 @@ func kuzzle_get_jwt(k *C.kuzzle) *C.char {
 	return C.CString((*kuzzle.Kuzzle)(k.instance).Jwt())
 }
 
+//export kuzzle_set_jwt
+func kuzzle_set_jwt(k *C.kuzzle, jwt *C.char) {
+	(*kuzzle.Kuzzle)(k.instance).SetJwt(C.GoString(jwt))
+}
+
 //export kuzzle_get_server_controller
 func kuzzle_get_server_controller(k *C.kuzzle) *C.server {
 	s := (*C.server)(C.calloc(1, C.sizeof_server))
@@ -151,6 +156,11 @@ func kuzzle_connect(k *C.kuzzle) *C.char {
 //export kuzzle_disconnect
 func kuzzle_disconnect(k *C.kuzzle) {
 	(*kuzzle.Kuzzle)(k.instance).Disconnect()
+}
+
+//export kuzzle_emit_event
+func kuzzle_emit_event(k *C.kuzzle, event C.int, body *C.char) {
+	(*kuzzle.Kuzzle)(k.instance).EmitEvent(int(event), C.GoString(body))
 }
 
 //export kuzzle_get_default_index

--- a/internal/wrappers/cpp/auth.cpp
+++ b/internal/wrappers/cpp/auth.cpp
@@ -18,11 +18,13 @@
 namespace kuzzleio {
   Auth::Auth(Kuzzle *kuzzle) {
       _auth = new auth();
+      _kuzzle = kuzzle;
       kuzzle_new_auth(_auth, kuzzle->_kuzzle);
   }
 
   Auth::Auth(Kuzzle *kuzzle, auth *auth) {
     _auth = auth;
+    _kuzzle = kuzzle;
     kuzzle_new_auth(_auth, kuzzle->_kuzzle);
   }
 
@@ -121,6 +123,10 @@ namespace kuzzleio {
 
   void Auth::logout() {
     kuzzle_logout(_auth);
+  }
+
+  void Auth::setJwt(const std::string& jwt) {
+    kuzzle_set_jwt(_kuzzle->_kuzzle, const_cast<char*>(jwt.c_str()));
   }
 
   std::string Auth::updateMyCredentials(const std::string& strategy, const std::string& credentials, query_options *options) Kuz_Throw_KuzzleException {

--- a/internal/wrappers/cpp/kuzzle.cpp
+++ b/internal/wrappers/cpp/kuzzle.cpp
@@ -118,7 +118,7 @@ namespace kuzzleio {
     return _listener_instances;
   }
 
-  void Kuzzle::emitEvent(Event event, const std::string& body) {
+  void Kuzzle::emitEvent(Event& event, const std::string& body) {
     kuzzle_emit_event(_kuzzle, event, const_cast<char*>(body.c_str()));
   }
 

--- a/internal/wrappers/cpp/kuzzle.cpp
+++ b/internal/wrappers/cpp/kuzzle.cpp
@@ -123,6 +123,10 @@ namespace kuzzleio {
     return _listener_instances;
   }
 
+  void Kuzzle::emitEvent(Event event, const std::string& body) {
+    kuzzle_emit_event(_kuzzle, event, const_cast<char*>(body.c_str()));
+  }
+
   KuzzleEventEmitter* Kuzzle::addListener(Event event, EventListener* listener) {
     kuzzle_add_listener(_kuzzle, event, &trigger_event_listener, this);
     _listener_instances[event] = listener;

--- a/internal/wrappers/headers/auth.hpp
+++ b/internal/wrappers/headers/auth.hpp
@@ -27,6 +27,8 @@ namespace kuzzleio {
     Auth();
 
     public:
+      Kuzzle *_kuzzle;
+
       Auth(Kuzzle *kuzzle);
       Auth(Kuzzle *kuzzle, auth *auth);
       virtual ~Auth();
@@ -41,6 +43,7 @@ namespace kuzzleio {
       std::string login(const std::string& strategy, const std::string& credentials, int expiresIn) Kuz_Throw_KuzzleException;
       std::string login(const std::string& strategy, const std::string& credentials) Kuz_Throw_KuzzleException;
       void logout();
+      void setJwt(const std::string& jwt);
       std::string updateMyCredentials(const std::string& strategy, const std::string& credentials, query_options *options=NULL) Kuz_Throw_KuzzleException;      
       kuzzle_user* updateSelf(const std::string& content, query_options* options=NULL) Kuz_Throw_KuzzleException;      
       bool validateMyCredentials(const std::string& strategy, const std::string& credentials, query_options* options=NULL) Kuz_Throw_KuzzleException;

--- a/internal/wrappers/headers/kuzzle.hpp
+++ b/internal/wrappers/headers/kuzzle.hpp
@@ -61,7 +61,7 @@ namespace kuzzleio {
       std::string getVolatile();
       Kuzzle* setVolatile(const std::string& volatiles);
       std::map<int, EventListener*> getListeners();
-      void emitEvent(Event event, const std::string& body);
+      void emitEvent(Event& event, const std::string& body);
 
       virtual KuzzleEventEmitter* addListener(Event event, EventListener* listener);
       virtual KuzzleEventEmitter* removeListener(Event event, EventListener* listener);

--- a/internal/wrappers/headers/kuzzle.hpp
+++ b/internal/wrappers/headers/kuzzle.hpp
@@ -62,6 +62,7 @@ namespace kuzzleio {
       std::string getVolatile();
       Kuzzle* setVolatile(const std::string& volatiles);
       std::map<int, EventListener*> getListeners();
+      void emitEvent(Event event, const std::string& body);
 
       virtual KuzzleEventEmitter* addListener(Event event, EventListener* listener);
       virtual KuzzleEventEmitter* removeListener(Event event, EventListener* listener);

--- a/internal/wrappers/templates/android/core.i
+++ b/internal/wrappers/templates/android/core.i
@@ -49,6 +49,7 @@
 %include "../java/exceptions.i"
 %include "std_string.i"
 %include "typemap.i"
+%include "json_wrap/kuzzle.i"
 %include "json_wrap/document.i"
 %include "json_wrap/server.i"
 %include "json_wrap/collection.i"

--- a/internal/wrappers/templates/android/core.i
+++ b/internal/wrappers/templates/android/core.i
@@ -93,7 +93,7 @@ typedef long long time_t;
   }
 %}
 
-%extend options {
+%extend kuzzleio::options {
     options() {
         options *o = kuzzle_new_options();
         return o;

--- a/internal/wrappers/templates/android/json_wrap/auth.i
+++ b/internal/wrappers/templates/android/json_wrap/auth.i
@@ -15,8 +15,16 @@
 %javamethodmodifiers kuzzleio::Auth::validateMyCredentials(const std::string& strategy, const std::string& credentials, query_options *options) "private";
 %javamethodmodifiers kuzzleio::Auth::validateMyCredentials(const std::string& strategy, const std::string& credentials) "private";
 
+%typemap(javaimports) kuzzleio::Auth %{
+import android.webkit.WebView;
+import android.webkit.WebViewClient;
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.net.URI;
+%}
 %typemap(javacode) kuzzleio::Auth %{
-
   public org.json.JSONObject createMyCredentials(String strategy, org.json.JSONObject credentials, QueryOptions options) throws org.json.JSONException, KuzzleException {
     String res = createMyCredentials(strategy, credentials.toString(), options);
 
@@ -70,4 +78,58 @@
   public boolean validateMyCredentials(String strategy, org.json.JSONObject credentials) throws org.json.JSONException, KuzzleException {
     return validateMyCredentials(strategy, credentials, null);
   }
+
+  /**
+   * WebViewClient to forward kuzzle's jwt token after an OAuth authentication
+   */
+  protected class KuzzleWebViewClient extends WebViewClient {
+    @Override
+    public boolean shouldOverrideUrlLoading(WebView view, final String url) {
+      if (url.contains("code=")) {
+        new Thread(new Runnable() {
+          @Override
+          public void run() {
+            try {
+              HttpURLConnection conn = (HttpURLConnection) URI.create(url).toURL().openConnection();
+              conn.setRequestMethod("GET");
+              conn.setUseCaches(false);
+
+              BufferedReader br = new BufferedReader(new InputStreamReader(conn.getInputStream()));
+              StringBuilder sb = new StringBuilder();
+              String line;
+              while ((line = br.readLine()) != null) {
+                sb.append(line);
+              }
+              br.close();
+
+              org.json.JSONObject response = new org.json.JSONObject(sb.toString());
+              if (response.isNull("error")) {
+                Auth.this.setJwt(response.getString("jwt"));
+              } else {
+                Auth.this.get_kuzzle().emitEvent(Event.LOGIN_ATTEMPT, new org.json.JSONObject()
+                  .put("success", false)
+                  .put("error", response.getJSONObject("error")));
+              }
+            } catch (org.json.JSONException | IOException e) {
+              e.printStackTrace();
+            }
+          }
+        }).start();
+      } else {
+        view.loadUrl(url);
+      }
+      return true;
+    }
+  }
+
+  /**
+   * Gets kuzzle web view client.
+   *
+   * @return the kuzzle web view client
+   */
+  public KuzzleWebViewClient getKuzzleWebViewClient() {
+    return new KuzzleWebViewClient();
+  }
 %}
+
+

--- a/internal/wrappers/templates/android/json_wrap/kuzzle.i
+++ b/internal/wrappers/templates/android/json_wrap/kuzzle.i
@@ -1,4 +1,4 @@
-%rename (_emitEvent) kuzzleio::Server::getAllStats(Event& event, const std::string& body);
+%rename (_emitEvent) kuzzleio::Kuzzle::emitEvent(Event& event, const std::string& body);
 
 %typemap(javacode) kuzzleio::Kuzzle %{
   public void emitEvent(Event event, org.json.JSONObject body) throws org.json.JSONException {

--- a/internal/wrappers/templates/android/json_wrap/kuzzle.i
+++ b/internal/wrappers/templates/android/json_wrap/kuzzle.i
@@ -1,7 +1,7 @@
-%rename (_emitEvent) kuzzleio::Server::getAllStats(Event event, const std::string& body);
+%rename (_emitEvent) kuzzleio::Server::getAllStats(Event& event, const std::string& body);
 
 %typemap(javacode) kuzzleio::Kuzzle %{
   public void emitEvent(Event event, org.json.JSONObject body) throws org.json.JSONException {
-    emitEvent(event, body.toString());
+    _emitEvent(event, body.toString());
   }
 %}

--- a/internal/wrappers/templates/android/json_wrap/kuzzle.i
+++ b/internal/wrappers/templates/android/json_wrap/kuzzle.i
@@ -1,0 +1,7 @@
+%rename (_emitEvent) kuzzleio::Server::getAllStats(Event event, const std::string& body);
+
+%typemap(javacode) kuzzleio::Kuzzle %{
+  public void emitEvent(Event event, org.json.JSONObject body) throws org.json.JSONException {
+    emitEvent(event, body.toString());
+  }
+%}

--- a/internal/wrappers/templates/android/typemap.i
+++ b/internal/wrappers/templates/android/typemap.i
@@ -27,7 +27,6 @@
 %typemap(javain) Event& "$javainput"
 %typemap(in) Event& (Event tmp) {
   jmethodID swigValueMethod = jenv->GetMethodID(jenv->GetObjectClass($input), "swigValue", "()I");
-  const jclass clazz = JCALL1(FindClass, jenv, "io/kuzzle/sdk/Event");
   jint swigValue = jenv->CallIntMethod($input, swigValueMethod, 0);
 
   Event e = (Event)swigValue;

--- a/internal/wrappers/templates/android/typemap.i
+++ b/internal/wrappers/templates/android/typemap.i
@@ -1,3 +1,5 @@
+%include <typemaps.i> 
+
 %typemap(jni) std::string* "jobject"
 %typemap(jtype) std::string* "java.lang.String"
 %typemap(jstype) std::string* "java.lang.String"
@@ -17,3 +19,18 @@
   }
 }
 %apply std::string * { std::string* };
+
+
+%typemap(jni) Event& "jobject"
+%typemap(jtype) Event& "Event"
+%typemap(jstype) Event& "Event"
+%typemap(javain) Event& "$javainput"
+%typemap(in) Event& (Event tmp) {
+  jmethodID swigValueMethod = jenv->GetMethodID(jenv->GetObjectClass($input), "swigValue", "()I");
+  const jclass clazz = JCALL1(FindClass, jenv, "io/kuzzle/sdk/Event");
+  jint swigValue = jenv->CallIntMethod($input, swigValueMethod, 0);
+
+  Event e = (Event)swigValue;
+  $1 = &e;
+}
+%apply Event& event { Event& event };

--- a/internal/wrappers/templates/java/core.i
+++ b/internal/wrappers/templates/java/core.i
@@ -54,7 +54,7 @@ typedef long long time_t;
   }
 %}
 
-%extend options {
+%extend kuzzleio::options {
     options() {
         options *o = kuzzle_new_options();
         return o;


### PR DESCRIPTION
## What does this PR do ?

Add custom a custom WebviewClient called `KuzzleWebViewClient` to handle OAUTH login with Kuzzle.

### How should this be manually tested?

```sh
docker run --rm -it -v "$(pwd)":/go/src/github.com/kuzzleio/sdk-go android-x86 /custom_build.sh
```

## Other changes

- Expose setJwt and emitEvent from the Kuzzle class for the Auth class to be able to handle logins.
- Also wrap emitEvent for it to take JSONObject as a parameter.
- Extend the options struct wich is now in the kuzzleio namespace 