### PR TITLE
Remove autoconnect

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,8 @@ kcore_wrap.h
 .gradle
 
 internal/wrappers/kcore_wrap\.o
+
+# Build files
+*.o
+*.so
+*.a

--- a/internal/wrappers/cgo/kuzzle/destructors.go
+++ b/internal/wrappers/cgo/kuzzle/destructors.go
@@ -129,7 +129,6 @@ func kuzzle_free_room_options(st *C.room_options) {
 func kuzzle_free_options(st *C.options) {
 	if st != nil {
 		C.free(unsafe.Pointer(st.refresh))
-		C.free(unsafe.Pointer(st.default_index))
 		C.free(unsafe.Pointer(st))
 	}
 }

--- a/internal/wrappers/cgo/kuzzle/kuzzle.go
+++ b/internal/wrappers/cgo/kuzzle/kuzzle.go
@@ -153,21 +153,6 @@ func kuzzle_disconnect(k *C.kuzzle) {
 	(*kuzzle.Kuzzle)(k.instance).Disconnect()
 }
 
-//export kuzzle_get_default_index
-func kuzzle_get_default_index(k *C.kuzzle) *C.char {
-	return C.CString((*kuzzle.Kuzzle)(k.instance).DefaultIndex())
-}
-
-//export kuzzle_set_default_index
-func kuzzle_set_default_index(k *C.kuzzle, index *C.char) C.int {
-	err := (*kuzzle.Kuzzle)(k.instance).SetDefaultIndex(C.GoString(index))
-	if err != nil {
-		return C.int(C.EINVAL)
-	}
-
-	return 0
-}
-
 //export kuzzle_get_offline_queue
 func kuzzle_get_offline_queue(k *C.kuzzle) *C.offline_queue {
 	result := (*C.offline_queue)(C.calloc(1, C.sizeof_offline_queue))

--- a/internal/wrappers/cgo/kuzzle/options.go
+++ b/internal/wrappers/cgo/kuzzle/options.go
@@ -40,12 +40,6 @@ func kuzzle_new_options() *C.options {
 	copts.reconnection_delay = C.ulong(opts.ReconnectionDelay())
 	copts.replay_interval = C.ulong(opts.ReplayInterval())
 
-	if opts.Connect() == 1 {
-		copts.connect = C.MANUAL
-	} else {
-		copts.connect = C.AUTO
-	}
-
 	if opts.OfflineMode() == 1 {
 		copts.offline_mode = C.MANUAL
 	} else {
@@ -107,7 +101,6 @@ func SetOptions(options *C.options) (opts types.Options) {
 	opts.SetAutoResubscribe(bool(options.auto_resubscribe))
 	opts.SetReconnectionDelay(time.Duration(int(options.reconnection_delay)))
 	opts.SetReplayInterval(time.Duration(int(options.replay_interval)))
-	opts.SetConnect(int(options.connect))
 	opts.SetRefresh(C.GoString(options.refresh))
 	opts.SetDefaultIndex(C.GoString(options.default_index))
 

--- a/internal/wrappers/cgo/kuzzle/options.go
+++ b/internal/wrappers/cgo/kuzzle/options.go
@@ -51,11 +51,6 @@ func kuzzle_new_options() *C.options {
 		copts.refresh = C.CString(refresh)
 	}
 
-	defaultIndex := opts.DefaultIndex()
-	if len(defaultIndex) > 0 {
-		copts.default_index = C.CString(defaultIndex)
-	}
-
 	return copts
 }
 
@@ -102,7 +97,6 @@ func SetOptions(options *C.options) (opts types.Options) {
 	opts.SetReconnectionDelay(time.Duration(int(options.reconnection_delay)))
 	opts.SetReplayInterval(time.Duration(int(options.replay_interval)))
 	opts.SetRefresh(C.GoString(options.refresh))
-	opts.SetDefaultIndex(C.GoString(options.default_index))
 
 	return
 }

--- a/internal/wrappers/cpp/kuzzle.cpp
+++ b/internal/wrappers/cpp/kuzzle.cpp
@@ -82,11 +82,6 @@ namespace kuzzleio {
     return this;
   }
 
-  Kuzzle* Kuzzle::setDefaultIndex(const std::string& index) {
-    kuzzle_set_default_index(_kuzzle, const_cast<char*>(index.c_str()));
-    return this;
-  }
-
   Kuzzle* Kuzzle::startQueuing() {
     kuzzle_start_queuing(_kuzzle);
     return this;

--- a/internal/wrappers/features/java/src/test/java/gradle/cucumber/Documentdefs.java
+++ b/internal/wrappers/features/java/src/test/java/gradle/cucumber/Documentdefs.java
@@ -29,6 +29,8 @@ public class Documentdefs {
     @Given("^Kuzzle Server is running$")
     public void kuzzle_Server_is_running() throws Exception {
         k = KuzzleSingleton.getInstance();
+
+        k.connect();
     }
 
     @Given("^there is an index \'([^\"]*)\'$")

--- a/internal/wrappers/features/step_defs_cpp/kuzzle-sdk-steps.cpp
+++ b/internal/wrappers/features/step_defs_cpp/kuzzle-sdk-steps.cpp
@@ -98,7 +98,6 @@ namespace {
     K_LOG_I("Connecting to Kuzzle on 'localhost:7512'");
     ScenarioScope<KuzzleCtx> ctx;
     ctx->kuzzle_options         = KUZZLE_OPTIONS_DEFAULT;
-    ctx->kuzzle_options.connect = MANUAL;
     std::string hostname = "localhost";
 
     if (std::getenv("KUZZLE_HOST") != NULL) {

--- a/internal/wrappers/headers/kuzzle.hpp
+++ b/internal/wrappers/headers/kuzzle.hpp
@@ -55,7 +55,6 @@ namespace kuzzleio {
       kuzzle_response* query(kuzzle_request* query, query_options* options=NULL) throw(KUZZLE_ALL_EXCEPTIONS);
       Kuzzle* playQueue();
       Kuzzle* setAutoReplay(bool autoReplay);
-      Kuzzle* setDefaultIndex(const std::string& index);
       Kuzzle* startQueuing();
       Kuzzle* stopQueuing();
       Kuzzle* flushQueue();

--- a/internal/wrappers/headers/kuzzlesdk.h
+++ b/internal/wrappers/headers/kuzzlesdk.h
@@ -34,7 +34,6 @@ enum Mode {AUTO, MANUAL};
     .auto_resubscribe = true, \
     .reconnection_delay = 1000, \
     .replay_interval = 10, \
-    .connect = AUTO, \
     .refresh = NULL, \
     .default_index = NULL  \
 }
@@ -221,7 +220,6 @@ typedef struct {
     bool auto_resubscribe;
     unsigned long reconnection_delay;
     unsigned long replay_interval;
-    enum Mode connect;
     char *refresh;
     char *default_index;
 } options;

--- a/internal/wrappers/headers/kuzzlesdk.h
+++ b/internal/wrappers/headers/kuzzlesdk.h
@@ -30,7 +30,7 @@ enum Mode {AUTO, MANUAL};
     .offline_mode = MANUAL,  \
     .auto_queue = false,  \
     .auto_reconnect = true,  \
-    .auto_replay = false, \_
+    .auto_replay = false, \
     .auto_resubscribe = true, \
     .reconnection_delay = 1000, \
     .replay_interval = 10, \

--- a/internal/wrappers/headers/kuzzlesdk.h
+++ b/internal/wrappers/headers/kuzzlesdk.h
@@ -34,8 +34,7 @@ enum Mode {AUTO, MANUAL};
     .auto_resubscribe = true, \
     .reconnection_delay = 1000, \
     .replay_interval = 10, \
-    .refresh = NULL, \
-    .default_index = NULL  \
+    .refresh = NULL
 }
 
 enum Event {
@@ -221,7 +220,6 @@ typedef struct {
     unsigned long reconnection_delay;
     unsigned long replay_interval;
     const char *refresh;
-    const char *default_index;
 } options;
 
 //meta of a document

--- a/internal/wrappers/headers/kuzzlesdk.h
+++ b/internal/wrappers/headers/kuzzlesdk.h
@@ -30,11 +30,11 @@ enum Mode {AUTO, MANUAL};
     .offline_mode = MANUAL,  \
     .auto_queue = false,  \
     .auto_reconnect = true,  \
-    .auto_replay = false, \
+    .auto_replay = false, \_
     .auto_resubscribe = true, \
     .reconnection_delay = 1000, \
     .replay_interval = 10, \
-    .refresh = NULL
+    .refresh = NULL \
 }
 
 enum Event {

--- a/internal/wrappers/templates/java/common.i
+++ b/internal/wrappers/templates/java/common.i
@@ -64,7 +64,6 @@
 %rename(autoResubscribe) auto_resubscribe;
 %rename(reconnectionDelay) reconnection_delay;
 %rename(replayInterval) replay_interval;
-%rename(defaultIndex) default_index;
 
 // struct query_options
 %rename(scrollId) scroll_id;

--- a/internal/wrappers/templates/java/javadoc/kuzzle.i
+++ b/internal/wrappers/templates/java/javadoc/kuzzle.i
@@ -388,15 +388,6 @@
    */
   public";
 
-%javamethodmodifiers kuzzleio::Kuzzle::setDefaultIndex(const std::string& index) "
-  /**
-   * Default index setter
-   *
-   * @param index - New default index name
-   * @return this
-   */
-  public";
-
 %javamethodmodifiers kuzzleio::Kuzzle::playQueue() "
   /**
    * Replays the requests queued during offline mode.

--- a/kuzzle/kuzzle.go
+++ b/kuzzle/kuzzle.go
@@ -87,13 +87,7 @@ func NewKuzzle(c connection.Connection, options types.Options) (*Kuzzle, error) 
 	k.Document = document.NewDocument(k)
 	k.Index = index.NewIndex(k)
 
-	var err error
-
-	if options.Connect() == types.Auto {
-		err = k.Connect()
-	}
-
-	return k, err
+	return k, nil
 }
 
 // Connect connects to a Kuzzle instance using the provided host and port.

--- a/kuzzle/kuzzle.go
+++ b/kuzzle/kuzzle.go
@@ -40,7 +40,6 @@ type Kuzzle struct {
 	wasConnected   bool
 	lastUrl        string
 	message        chan []byte
-	defaultIndex   string
 	jwt            string
 	headers        map[string]interface{}
 	version        string
@@ -68,9 +67,8 @@ func NewKuzzle(c connection.Connection, options types.Options) (*Kuzzle, error) 
 	}
 
 	k := &Kuzzle{
-		socket:       c,
-		version:      version,
-		defaultIndex: options.DefaultIndex(),
+		socket:  c,
+		version: version,
 	}
 
 	k.RequestHistory = k.socket.RequestHistory()
@@ -81,7 +79,6 @@ func NewKuzzle(c connection.Connection, options types.Options) (*Kuzzle, error) 
 
 	k.RequestHistory = k.socket.RequestHistory()
 
-	k.defaultIndex = options.DefaultIndex()
 	k.Server = server.NewServer(k)
 	k.Collection = collection.NewCollection(k)
 	k.Document = document.NewDocument(k)
@@ -258,21 +255,6 @@ func (k *Kuzzle) SetQueueTTL(v time.Duration) {
 // SetReplayInterval sets the Kuzzle socket ReplayInterval field with the given value
 func (k *Kuzzle) SetReplayInterval(v time.Duration) {
 	k.socket.SetReplayInterval(v)
-}
-
-// DefaultIndex returns the Kuzzle default index name
-func (k *Kuzzle) DefaultIndex() string {
-	return k.defaultIndex
-}
-
-// SetDefaultIndex set the default data index. Has the same effect than the defaultIndex constructor option.
-func (k *Kuzzle) SetDefaultIndex(index string) error {
-	if index == "" {
-		return types.NewError("Kuzzle.SetDefaultIndex: index required", 400)
-	}
-
-	k.defaultIndex = index
-	return nil
 }
 
 func (k *Kuzzle) Volatile() types.VolatileData {

--- a/kuzzle/kuzzle_test.go
+++ b/kuzzle/kuzzle_test.go
@@ -106,33 +106,3 @@ func ExampleKuzzle_UnsetJwt() {
 	k.UnsetJwt()
 	fmt.Println(k.Jwt())
 }
-
-func TestSetDefaultIndexNullIndex(t *testing.T) {
-	k, _ := kuzzle.NewKuzzle(&internal.MockedConnection{}, nil)
-	assert.NotNil(t, k.SetDefaultIndex(""))
-}
-
-func TestSetDefaultIndex(t *testing.T) {
-	c := &internal.MockedConnection{
-		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
-			request := types.KuzzleRequest{}
-			json.Unmarshal(query, &request)
-			assert.Equal(t, "myindex", request.Index)
-			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "error"}}
-		},
-	}
-	k, _ := kuzzle.NewKuzzle(c, nil)
-	k.SetDefaultIndex("myindex")
-}
-
-func ExampleKuzzle_SetDefaultIndex() {
-	conn := websocket.NewWebSocket("localhost:7512", nil)
-	k, _ := kuzzle.NewKuzzle(conn, nil)
-
-	err := k.SetDefaultIndex("index")
-
-	if err != nil {
-		fmt.Println(err.Error())
-		return
-	}
-}

--- a/kuzzle/kuzzle_test.go
+++ b/kuzzle/kuzzle_test.go
@@ -28,7 +28,6 @@ import (
 
 func ExampleKuzzle_Connect() {
 	opts := types.NewOptions()
-	opts.SetConnect(types.Manual)
 
 	conn := websocket.NewWebSocket("localhost:7512", nil)
 	k, _ := kuzzle.NewKuzzle(conn, opts)

--- a/types/options.go
+++ b/types/options.go
@@ -43,8 +43,6 @@ type Options interface {
 	SetReconnectionDelay(time.Duration) *options
 	ReplayInterval() time.Duration
 	SetReplayInterval(time.Duration) *options
-	Connect() int
-	SetConnect(int) *options
 	Refresh() string
 	SetRefresh(string) *options
 	DefaultIndex() string
@@ -153,15 +151,6 @@ func (o *options) SetReplayInterval(replayInterval time.Duration) *options {
 	return o
 }
 
-func (o options) Connect() int {
-	return o.connect
-}
-
-func (o *options) SetConnect(connect int) *options {
-	o.connect = connect
-	return o
-}
-
 func (o options) Refresh() string {
 	return o.refresh
 }
@@ -210,7 +199,6 @@ func NewOptions() *options {
 		autoResubscribe:   true,
 		reconnectionDelay: 1000,
 		replayInterval:    10,
-		connect:           Auto,
 		port:              7512,
 		sslConnection:     false,
 	}

--- a/types/options.go
+++ b/types/options.go
@@ -45,8 +45,6 @@ type Options interface {
 	SetReplayInterval(time.Duration) *options
 	Refresh() string
 	SetRefresh(string) *options
-	DefaultIndex() string
-	SetDefaultIndex(string) *options
 	Port() int
 	SetPort(int) *options
 	SslConnection() bool
@@ -65,7 +63,6 @@ type options struct {
 	replayInterval    time.Duration
 	connect           int
 	refresh           string
-	defaultIndex      string
 	port              int
 	sslConnection     bool
 }
@@ -157,15 +154,6 @@ func (o options) Refresh() string {
 
 func (o *options) SetRefresh(refresh string) *options {
 	o.refresh = refresh
-	return o
-}
-
-func (o options) DefaultIndex() string {
-	return o.defaultIndex
-}
-
-func (o *options) SetDefaultIndex(defaultIndex string) *options {
-	o.defaultIndex = defaultIndex
 	return o
 }
 


### PR DESCRIPTION
## What does this PR do ?

This PR remove the connection mode options of the Kuzzle object.  
Before, it was possible to set this option to `auto` and the SDK would have connected automatically to Kuzzle after instantiation.  
Now you have to manually call `connect()` before making a request.

### How should this be manually tested?

  - Step 1 : Instantiate the Kuzzle sdk object in Go, Cpp or Java
  - Step 2 : You should not be able to make a request before a call to `connect()`

### Other changes

  - remove the obsolete `defaultIndex` property from the kuzzle constructor options