### PR TITLE
fix body set as string

### DIFF
--- a/document/deleteByQuery.go
+++ b/document/deleteByQuery.go
@@ -21,17 +21,17 @@ import (
 )
 
 // DeleteByQuery deletes all the documents from Kuzzle that match the given filter or query.
-func (d *Document) DeleteByQuery(index string, collection string, body string, options types.QueryOptions) ([]string, error) {
+func (d *Document) DeleteByQuery(index string, collection string, body json.RawMessage, options types.QueryOptions) ([]string, error) {
 	if index == "" {
-		return nil, types.NewError("Document.MCreate: index required", 400)
+		return nil, types.NewError("Document.DeleteByQuery: index required", 400)
 	}
 
 	if collection == "" {
-		return nil, types.NewError("Document.MCreate: collection required", 400)
+		return nil, types.NewError("Document.DeleteByQuery: collection required", 400)
 	}
 
-	if body == "" {
-		return nil, types.NewError("Document.MCreate: body required", 400)
+	if body == nil {
+		return nil, types.NewError("Document.DeleteByQuery: body required", 400)
 	}
 
 	ch := make(chan *types.KuzzleResponse)

--- a/document/deleteByQuery_test.go
+++ b/document/deleteByQuery_test.go
@@ -29,7 +29,7 @@ func TestDeleteByQueryIndexNull(t *testing.T) {
 	k, _ := kuzzle.NewKuzzle(&internal.MockedConnection{}, nil)
 	d := document.NewDocument(k)
 
-	_, err := d.DeleteByQuery("", "collection", "body", nil)
+	_, err := d.DeleteByQuery("", "collection", json.RawMessage(`{"foo": "bar"}`), nil)
 	assert.NotNil(t, err)
 }
 
@@ -37,7 +37,7 @@ func TestDeleteByQueryCollectionNull(t *testing.T) {
 	k, _ := kuzzle.NewKuzzle(&internal.MockedConnection{}, nil)
 	d := document.NewDocument(k)
 
-	_, err := d.DeleteByQuery("index", "", "body", nil)
+	_, err := d.DeleteByQuery("index", "", json.RawMessage(`{"foo": "bar"}`), nil)
 	assert.NotNil(t, err)
 }
 
@@ -45,7 +45,7 @@ func TestDeleteByQueryBodyNull(t *testing.T) {
 	k, _ := kuzzle.NewKuzzle(&internal.MockedConnection{}, nil)
 	d := document.NewDocument(k)
 
-	_, err := d.DeleteByQuery("index", "collection", "", nil)
+	_, err := d.DeleteByQuery("index", "collection", nil, nil)
 	assert.NotNil(t, err)
 }
 
@@ -58,7 +58,7 @@ func TestDeleteByQueryDocumentError(t *testing.T) {
 	k, _ := kuzzle.NewKuzzle(c, nil)
 	d := document.NewDocument(k)
 
-	_, err := d.DeleteByQuery("index", "collection", "body", nil)
+	_, err := d.DeleteByQuery("index", "collection", json.RawMessage(`{"foo": "bar"}`), nil)
 	assert.NotNil(t, err)
 	assert.Equal(t, "Unit test error", err.(types.KuzzleError).Message)
 }
@@ -85,6 +85,6 @@ func TestDeleteByQueryDocument(t *testing.T) {
 	k, _ := kuzzle.NewKuzzle(c, nil)
 	d := document.NewDocument(k)
 
-	_, err := d.DeleteByQuery("index", "collection", "body", nil)
+	_, err := d.DeleteByQuery("index", "collection", json.RawMessage(`{"foo": "bar"}`), nil)
 	assert.Nil(t, err)
 }

--- a/realtime/validate.go
+++ b/realtime/validate.go
@@ -21,8 +21,8 @@ import (
 )
 
 // Validate validates data against existing validation rules
-func (r *Realtime) Validate(index string, collection string, body string, options types.QueryOptions) (bool, error) {
-	if (index == "" || collection == "") || body == "" {
+func (r *Realtime) Validate(index string, collection string, body json.RawMessage, options types.QueryOptions) (bool, error) {
+	if index == "" || collection == "" || body == nil {
 		return false, types.NewError("Realtime.Validate: index, collection and body required", 400)
 	}
 

--- a/realtime/validate_test.go
+++ b/realtime/validate_test.go
@@ -29,7 +29,7 @@ func TestValidateIndexNull(t *testing.T) {
 	k, _ := kuzzle.NewKuzzle(&internal.MockedConnection{}, nil)
 	nr := realtime.NewRealtime(k)
 
-	_, err := nr.Validate("", "collection", "body", nil)
+	_, err := nr.Validate("", "collection", json.RawMessage(`{"foo": "bar"}`), nil)
 
 	assert.NotNil(t, err)
 }
@@ -38,7 +38,7 @@ func TestValidateCollectionNull(t *testing.T) {
 	k, _ := kuzzle.NewKuzzle(&internal.MockedConnection{}, nil)
 	nr := realtime.NewRealtime(k)
 
-	_, err := nr.Validate("index", "", "body", nil)
+	_, err := nr.Validate("index", "", json.RawMessage(`{"foo": "bar"}`), nil)
 
 	assert.NotNil(t, err)
 }
@@ -47,7 +47,7 @@ func TestValidateBodyNull(t *testing.T) {
 	k, _ := kuzzle.NewKuzzle(&internal.MockedConnection{}, nil)
 	nr := realtime.NewRealtime(k)
 
-	_, err := nr.Validate("index", "collection", "", nil)
+	_, err := nr.Validate("index", "collection", nil, nil)
 
 	assert.NotNil(t, err)
 }
@@ -61,7 +61,7 @@ func TestValidateError(t *testing.T) {
 	k, _ := kuzzle.NewKuzzle(c, nil)
 	nr := realtime.NewRealtime(k)
 
-	_, err := nr.Validate("index", "collection", "body", nil)
+	_, err := nr.Validate("index", "collection", json.RawMessage(`{"foo": "bar"}`), nil)
 	assert.NotNil(t, err)
 }
 
@@ -87,7 +87,7 @@ func TestValidate(t *testing.T) {
 
 	nr := realtime.NewRealtime(k)
 
-	res, err := nr.Validate("index", "collection", "body", nil)
+	res, err := nr.Validate("index", "collection", json.RawMessage(`{"foo": "bar"}`), nil)
 	assert.Nil(t, err)
 	assert.Equal(t, true, res)
 }


### PR DESCRIPTION
## What does this PR do?

This PR fixes `document.deleteByQuery` and `realtime.validate` which had their `body` attribute defined as string, which was sent as-is to Kuzzle.