### PR TITLE
document.mCreatexx - take an array of documents

### DIFF
--- a/document/mCreate.go
+++ b/document/mCreate.go
@@ -21,7 +21,7 @@ import (
 )
 
 // MCreate creates the provided documents.
-func (d *Document) MCreate(index string, collection string, body json.RawMessage, options types.QueryOptions) (json.RawMessage, error) {
+func (d *Document) MCreate(index string, collection string, documents json.RawMessage, options types.QueryOptions) (json.RawMessage, error) {
 	if index == "" {
 		return nil, types.NewError("Document.MCreate: index required", 400)
 	}
@@ -30,18 +30,22 @@ func (d *Document) MCreate(index string, collection string, body json.RawMessage
 		return nil, types.NewError("Document.MCreate: collection required", 400)
 	}
 
-	if body == nil {
+	if documents == nil {
 		return nil, types.NewError("Document.MCreate: body required", 400)
 	}
 
 	ch := make(chan *types.KuzzleResponse)
+
+	type body struct {
+		Documents json.RawMessage `json:"documents"`
+	}
 
 	query := &types.KuzzleRequest{
 		Index:      index,
 		Collection: collection,
 		Controller: "document",
 		Action:     "mCreate",
-		Body:       body,
+		Body:       &body{documents},
 	}
 
 	go d.Kuzzle.Query(query, options, ch)

--- a/document/mCreateOrReplace.go
+++ b/document/mCreateOrReplace.go
@@ -21,7 +21,7 @@ import (
 )
 
 // MCreateOrReplace creates or replaces the provided documents.
-func (d *Document) MCreateOrReplace(index string, collection string, body json.RawMessage, options types.QueryOptions) (json.RawMessage, error) {
+func (d *Document) MCreateOrReplace(index string, collection string, documents json.RawMessage, options types.QueryOptions) (json.RawMessage, error) {
 	if index == "" {
 		return nil, types.NewError("Document.MCreateOrReplace: index required", 400)
 	}
@@ -30,18 +30,22 @@ func (d *Document) MCreateOrReplace(index string, collection string, body json.R
 		return nil, types.NewError("Document.MCreateOrReplace: collection required", 400)
 	}
 
-	if body == nil {
+	if documents == nil {
 		return nil, types.NewError("Document.MCreateOrReplace: body required", 400)
 	}
 
 	ch := make(chan *types.KuzzleResponse)
+
+	type body struct {
+		Documents json.RawMessage `json:"documents"`
+	}
 
 	query := &types.KuzzleRequest{
 		Index:      index,
 		Collection: collection,
 		Controller: "document",
 		Action:     "mCreateOrReplace",
-		Body:       body,
+		Body:       &body{documents},
 	}
 
 	go d.Kuzzle.Query(query, options, ch)

--- a/document/mCreateOrReplace_test.go
+++ b/document/mCreateOrReplace_test.go
@@ -110,6 +110,6 @@ func TestMCreateOrReplaceDocument(t *testing.T) {
 	k, _ := kuzzle.NewKuzzle(c, nil)
 	d := document.NewDocument(k)
 
-	_, err := d.MCreateOrReplace("index", "collection", json.RawMessage(`{"foo":"bar"}`), nil)
+	_, err := d.MCreateOrReplace("index", "collection", json.RawMessage(`["foo","bar"]`), nil)
 	assert.Nil(t, err)
 }

--- a/document/mCreate_test.go
+++ b/document/mCreate_test.go
@@ -110,6 +110,6 @@ func TestMCreateDocument(t *testing.T) {
 	k, _ := kuzzle.NewKuzzle(c, nil)
 	d := document.NewDocument(k)
 
-	_, err := d.MCreate("index", "collection", json.RawMessage(`{"foo":"bar"}`), nil)
+	_, err := d.MCreate("index", "collection", json.RawMessage(`["foo", "bar"]`), nil)
 	assert.Nil(t, err)
 }


### PR DESCRIPTION
# What does this PR do?

This PR fixes an inconstistency btw the Javascript SDK and this one for `document.mCreate` and `document.mCreateOrReplace`.
These 2 methods now take a JSON representation of an array of documents instead of an object.

# How to test it?
cf attached script

[test.go.txt](https://github.com/kuzzleio/sdk-go/files/2441015/test.go.txt)