### PR TITLE
Document.m create/update array input

### DIFF
--- a/document/mReplace.go
+++ b/document/mReplace.go
@@ -21,7 +21,7 @@ import (
 )
 
 // MReplace replaces multiple documents at once.
-func (d *Document) MReplace(index string, collection string, body json.RawMessage, options types.QueryOptions) (json.RawMessage, error) {
+func (d *Document) MReplace(index string, collection string, documents json.RawMessage, options types.QueryOptions) (json.RawMessage, error) {
 	if index == "" {
 		return nil, types.NewError("Document.MReplace: index required", 400)
 	}
@@ -30,18 +30,22 @@ func (d *Document) MReplace(index string, collection string, body json.RawMessag
 		return nil, types.NewError("Document.MReplace: collection required", 400)
 	}
 
-	if body == nil {
+	if documents == nil {
 		return nil, types.NewError("Document.MReplace: body required", 400)
 	}
 
 	ch := make(chan *types.KuzzleResponse)
+
+	type body struct {
+		Documents json.RawMessage `json:"documents"`
+	}
 
 	query := &types.KuzzleRequest{
 		Collection: collection,
 		Index:      index,
 		Controller: "document",
 		Action:     "mReplace",
-		Body:       body,
+		Body:       &body{documents},
 	}
 
 	go d.Kuzzle.Query(query, options, ch)

--- a/document/mReplace_test.go
+++ b/document/mReplace_test.go
@@ -29,7 +29,7 @@ func TestMReplaceIndexNull(t *testing.T) {
 	k, _ := kuzzle.NewKuzzle(&internal.MockedConnection{}, nil)
 	d := document.NewDocument(k)
 
-	_, err := d.MReplace("", "collection", json.RawMessage(`{"foo":"bar"}`), nil)
+	_, err := d.MReplace("", "collection", json.RawMessage(`["foo", "bar"]`), nil)
 	assert.NotNil(t, err)
 }
 
@@ -37,7 +37,7 @@ func TestMReplaceCollectionNull(t *testing.T) {
 	k, _ := kuzzle.NewKuzzle(&internal.MockedConnection{}, nil)
 	d := document.NewDocument(k)
 
-	_, err := d.MReplace("index", "", json.RawMessage(`{"foo":"bar"}`), nil)
+	_, err := d.MReplace("index", "", json.RawMessage(`["foo", "bar"]`), nil)
 	assert.NotNil(t, err)
 }
 
@@ -58,7 +58,7 @@ func TestMReplaceDocumentError(t *testing.T) {
 	k, _ := kuzzle.NewKuzzle(c, nil)
 	d := document.NewDocument(k)
 
-	_, err := d.MReplace("index", "collection", json.RawMessage(`{"foo":"bar"}`), nil)
+	_, err := d.MReplace("index", "collection", json.RawMessage(`["foo", "bar"]`), nil)
 	assert.NotNil(t, err)
 	assert.Equal(t, "Unit test error", err.(types.KuzzleError).Message)
 }
@@ -111,6 +111,6 @@ func TestMReplaceDocument(t *testing.T) {
 	k, _ := kuzzle.NewKuzzle(c, nil)
 	d := document.NewDocument(k)
 
-	_, err := d.MReplace("index", "collection", json.RawMessage(`{"foo":"bar"}`), nil)
+	_, err := d.MReplace("index", "collection", json.RawMessage(`["foo", "bar"]`), nil)
 	assert.Nil(t, err)
 }

--- a/document/mUpdate.go
+++ b/document/mUpdate.go
@@ -21,7 +21,7 @@ import (
 )
 
 // MUpdate updates multiple documents at once
-func (d *Document) MUpdate(index string, collection string, body json.RawMessage, options types.QueryOptions) (json.RawMessage, error) {
+func (d *Document) MUpdate(index string, collection string, documents json.RawMessage, options types.QueryOptions) (json.RawMessage, error) {
 	if index == "" {
 		return nil, types.NewError("Document.MUpdate: index required", 400)
 	}
@@ -30,18 +30,22 @@ func (d *Document) MUpdate(index string, collection string, body json.RawMessage
 		return nil, types.NewError("Document.MUpdate: collection required", 400)
 	}
 
-	if body == nil {
+	if documents == nil {
 		return nil, types.NewError("Document.MUpdate: body required", 400)
 	}
 
 	ch := make(chan *types.KuzzleResponse)
+
+	type body struct {
+		Documents json.RawMessage `json:"documents"`
+	}
 
 	query := &types.KuzzleRequest{
 		Collection: collection,
 		Index:      index,
 		Controller: "document",
 		Action:     "mUpdate",
-		Body:       body,
+		Body:       &body{documents},
 	}
 
 	go d.Kuzzle.Query(query, options, ch)

--- a/document/mUpdate_test.go
+++ b/document/mUpdate_test.go
@@ -29,7 +29,7 @@ func TestMUpdateIndexNull(t *testing.T) {
 	k, _ := kuzzle.NewKuzzle(&internal.MockedConnection{}, nil)
 	d := document.NewDocument(k)
 
-	_, err := d.MUpdate("", "collection", json.RawMessage(`{"foo":"bar"}`), nil)
+	_, err := d.MUpdate("", "collection", json.RawMessage(`["foo", "bar"]`), nil)
 	assert.NotNil(t, err)
 }
 
@@ -37,7 +37,7 @@ func TestMUpdateCollectionNull(t *testing.T) {
 	k, _ := kuzzle.NewKuzzle(&internal.MockedConnection{}, nil)
 	d := document.NewDocument(k)
 
-	_, err := d.MUpdate("index", "", json.RawMessage(`{"foo":"bar"}`), nil)
+	_, err := d.MUpdate("index", "", json.RawMessage(`["foo", "bar"]`), nil)
 	assert.NotNil(t, err)
 }
 
@@ -58,7 +58,7 @@ func TestMUpdateDocumentError(t *testing.T) {
 	k, _ := kuzzle.NewKuzzle(c, nil)
 	d := document.NewDocument(k)
 
-	_, err := d.MUpdate("index", "collection", json.RawMessage(`{"foo":"bar"}`), nil)
+	_, err := d.MUpdate("index", "collection", json.RawMessage(`["foo", "bar"]`), nil)
 	assert.NotNil(t, err)
 	assert.Equal(t, "Unit test error", err.(types.KuzzleError).Message)
 }
@@ -111,6 +111,6 @@ func TestMUpdateDocument(t *testing.T) {
 	k, _ := kuzzle.NewKuzzle(c, nil)
 	d := document.NewDocument(k)
 
-	_, err := d.MUpdate("index", "collection", json.RawMessage(`{"foo":"bar"}`), nil)
+	_, err := d.MUpdate("index", "collection", json.RawMessage(`["foo", "bar"]`), nil)
 	assert.Nil(t, err)
 }


### PR DESCRIPTION
## What does this PR do?

This PR fixes a inconsistency between go & co and Javascript sdks for `document.Replace` and `document.Update` actions.

The input format for these methods is now an array of document instead of an object.