### PR TITLE
KZL-547 - Update validateSpecifications signature to take index and collection

### DIFF
--- a/collection/validate_specifications.go
+++ b/collection/validate_specifications.go
@@ -16,23 +16,43 @@ package collection
 
 import (
 	"encoding/json"
+	"fmt"
 
 	"github.com/kuzzleio/sdk-go/types"
 )
 
 // ValidateSpecifications validates the provided specifications.
-func (dc *Collection) ValidateSpecifications(body json.RawMessage, options types.QueryOptions) (*types.ValidationResponse, error) {
-	if body == nil {
-		return nil, types.NewError("Collection.ValidateSpecifications: body required", 400)
+func (dc *Collection) ValidateSpecifications(index string, collection string, specifications json.RawMessage, options types.QueryOptions) (*types.ValidationResponse, error) {
+	if index == "" {
+		return nil, types.NewError("Collection.ValidateSpecifications: index required", 400)
+	}
+
+	if collection == "" {
+		return nil, types.NewError("Collection.ValidateSpecifications: collection required", 400)
+	}
+
+	if specifications == nil {
+		return nil, types.NewError("Collection.ValidateSpecifications: specifications required", 400)
 	}
 
 	ch := make(chan *types.KuzzleResponse)
 
+	body := make(map[string]map[string]json.RawMessage)
+	body[index] = make(map[string]json.RawMessage)
+	body[index][collection] = specifications
+
+	jsonBody, err := json.Marshal(body)
+
+	if err != nil {
+		return nil, types.NewError(fmt.Sprintf("Unable to construct body: %s\n", err.Error()), 500)
+	}
+
 	query := &types.KuzzleRequest{
 		Controller: "collection",
 		Action:     "validateSpecifications",
-		Body:       body,
+		Body:       jsonBody,
 	}
+
 	go dc.Kuzzle.Query(query, options, ch)
 
 	res := <-ch

--- a/collection/validate_specifications_test.go
+++ b/collection/validate_specifications_test.go
@@ -28,10 +28,10 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestValidateSpecificationsBodyNull(t *testing.T) {
+func TestValidateSpecificationsSpecificationsNull(t *testing.T) {
 	k, _ := kuzzle.NewKuzzle(&internal.MockedConnection{}, nil)
 	nc := collection.NewCollection(k)
-	_, err := nc.ValidateSpecifications(nil, nil)
+	_, err := nc.ValidateSpecifications("index", "collection", nil, nil)
 	assert.NotNil(t, err)
 }
 
@@ -44,7 +44,7 @@ func TestValidateSpecificationsError(t *testing.T) {
 	k, _ := kuzzle.NewKuzzle(c, nil)
 
 	nc := collection.NewCollection(k)
-	_, err := nc.ValidateSpecifications(json.RawMessage(`{"body": "body"}`), nil)
+	_, err := nc.ValidateSpecifications("index", "collection", json.RawMessage(`{"body": "body"}`), nil)
 	assert.NotNil(t, err)
 }
 
@@ -62,7 +62,7 @@ func TestValidateSpecifications(t *testing.T) {
 	k, _ := kuzzle.NewKuzzle(c, nil)
 
 	nc := collection.NewCollection(k)
-	vr, err := nc.ValidateSpecifications(json.RawMessage(`{"body": "body"}`), nil)
+	vr, err := nc.ValidateSpecifications("index", "collection", json.RawMessage(`{"body": "body"}`), nil)
 	assert.Nil(t, err)
 	assert.NotNil(t, vr)
 	assert.Equal(t, true, vr.Valid)
@@ -73,7 +73,7 @@ func ExampleCollection_ValidateSpecifications() {
 	k, _ := kuzzle.NewKuzzle(c, nil)
 
 	nc := collection.NewCollection(k)
-	res, err := nc.ValidateSpecifications(json.RawMessage(`{"body": "body"}`), nil)
+	res, err := nc.ValidateSpecifications("index", "collection", json.RawMessage(`{"body": "body"}`), nil)
 
 	if err != nil {
 		fmt.Println(err.Error())


### PR DESCRIPTION
## What does this PR do?

Before the method `ValidateSpecifications` didn't take an index an a collection in parameters and could be used for any collection.  
This PR change the signature to match the rest of the collection controller. The method now take an index and a collection in addition to the specifications for this collection.

I also modify the `UpdateSpecifications` method. The method was taking an index and collection in parameter but it didn't scope the specifications to the collection. 

Related PR: https://github.com/kuzzleio/sdk-javascript/pull/318, https://github.com/kuzzleio/sdk-go/pull/211, https://github.com/kuzzleio/sdk-c/pull/13, https://github.com/kuzzleio/sdk-cpp/pull/11, https://github.com/kuzzleio/sdk-java/pull/13, https://github.com/kuzzleio/documentation-V2/pull/51
### How should this be manually tested?

  - Step 1: Run tests `./test.sh`