### PR TITLE
fixes #KZL-695 - SearchResult.Fetched

### DIFF
--- a/document/search_test.go
+++ b/document/search_test.go
@@ -77,7 +77,8 @@ func TestSearchDocument(t *testing.T) {
 
 			return &types.KuzzleResponse{Result: []byte(`
 			{
-				"hits": ["id1", "id2"]
+				"hits": ["id1", "id2"],
+				"total": 42
 			}`),
 			}
 		},
@@ -85,6 +86,8 @@ func TestSearchDocument(t *testing.T) {
 	k, _ := kuzzle.NewKuzzle(c, nil)
 	d := document.NewDocument(k)
 
-	_, err := d.Search("index", "collection", json.RawMessage(`{"foo":"bar"}`), nil)
+	response, err := d.Search("index", "collection", json.RawMessage(`{"foo":"bar"}`), nil)
 	assert.Nil(t, err)
+	assert.Equal(t, 2, response.Fetched)
+	assert.Equal(t, 42, response.Total)
 }

--- a/types/search_result.go
+++ b/types/search_result.go
@@ -46,12 +46,15 @@ func NewSearchResult(collection string, filters json.RawMessage, options QueryOp
 		return nil, NewError(fmt.Sprintf("Unable to parse response: %s\n%s", err.Error(), raw.Result), 500)
 	}
 
+	var docs []interface{}
+	json.Unmarshal(parsed.Documents, &docs)
+
 	sr := &SearchResult{
 		Collection:   collection,
 		Filters:      filters,
 		Documents:    parsed.Documents,
 		Total:        parsed.Total,
-		Fetched:      len(parsed.Documents),
+		Fetched:      len(docs),
 		Aggregations: parsed.Aggregations,
 		Options:      NewQueryOptions(),
 	}


### PR DESCRIPTION
This PR fixes the case where `SearchResult.Fetched` would return the length of the json string instead of the number of documents.

Ref: https://jira.kaliop.net/browse/KZL-695