### PR TITLE
Fix realtime count arguments

### DIFF
--- a/realtime/count.go
+++ b/realtime/count.go
@@ -21,16 +21,14 @@ import (
 )
 
 // Count returns the number of other subscriptions on that room.
-func (r *Realtime) Count(index, collection, roomID string, options types.QueryOptions) (int, error) {
-	if index == "" || collection == "" || roomID == "" {
-		return -1, types.NewError("Realtime.Count: index, collection and roomID required", 400)
+func (r *Realtime) Count(roomID string, options types.QueryOptions) (int, error) {
+	if roomID == "" {
+		return -1, types.NewError("Realtime.Count: roomID required", 400)
 	}
 
 	query := &types.KuzzleRequest{
 		Controller: "realtime",
 		Action:     "count",
-		Index:      index,
-		Collection: collection,
 		Body: struct {
 			RoomID string `json:"roomID"`
 		}{roomID},

--- a/realtime/count_test.go
+++ b/realtime/count_test.go
@@ -26,29 +26,11 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestCountIndexNull(t *testing.T) {
-	k, _ := kuzzle.NewKuzzle(&internal.MockedConnection{}, nil)
-	nr := realtime.NewRealtime(k)
-
-	_, err := nr.Count("", "collection", "roomID", nil)
-
-	assert.NotNil(t, err)
-}
-
-func TestCountCollectionNull(t *testing.T) {
-	k, _ := kuzzle.NewKuzzle(&internal.MockedConnection{}, nil)
-	nr := realtime.NewRealtime(k)
-
-	_, err := nr.Count("index", "", "roomID", nil)
-
-	assert.NotNil(t, err)
-}
-
 func TestCountRoomIDNull(t *testing.T) {
 	k, _ := kuzzle.NewKuzzle(&internal.MockedConnection{}, nil)
 	nr := realtime.NewRealtime(k)
 
-	_, err := nr.Count("index", "collection", "", nil)
+	_, err := nr.Count("", nil)
 
 	assert.NotNil(t, err)
 }
@@ -62,7 +44,7 @@ func TestCountError(t *testing.T) {
 	k, _ := kuzzle.NewKuzzle(c, nil)
 	realTime := realtime.NewRealtime(k)
 
-	_, err := realTime.Count("index", "collection", "42", nil)
+	_, err := realTime.Count("42", nil)
 	assert.NotNil(t, err)
 }
 
@@ -81,6 +63,6 @@ func TestCount(t *testing.T) {
 	k, _ := kuzzle.NewKuzzle(c, nil)
 	realTime := realtime.NewRealtime(k)
 
-	res, _ := realTime.Count("index", "collection", "42", nil)
+	res, _ := realTime.Count("42", nil)
 	assert.Equal(t, 10, res)
 }


### PR DESCRIPTION
## What does this PR do?

This PR remove the unused `index` and `collection` parameters for Realtime.Count

:large_blue_circle: https://github.com/kuzzleio/sdk-c/pull/21 :arrow_right: 