### PR TITLE
Fix realtime:count body argument

### DIFF
--- a/realtime/count.go
+++ b/realtime/count.go
@@ -30,7 +30,7 @@ func (r *Realtime) Count(roomID string, options types.QueryOptions) (int, error)
 		Controller: "realtime",
 		Action:     "count",
 		Body: struct {
-			RoomID string `json:"roomID"`
+			RoomID string `json:"roomId"`
 		}{roomID},
 	}
 


### PR DESCRIPTION
## What does this PR do?

`realtime:count` method take a `roomId` in the body. The argument was named `roomID` before this PR.

### How should this be manually tested?

Run this snippet:
```go
package main

import (
	"encoding/json"
	"fmt"
	"log"
	"os"

	"github.com/kuzzleio/sdk-go/kuzzle"
	"github.com/kuzzleio/sdk-go/protocol/websocket"
	"github.com/kuzzleio/sdk-go/types"
)

func main() {
	c := websocket.NewWebSocket("kuzzle", nil)
	kuzzle, _ := kuzzle.NewKuzzle(c, nil)

	connectErr := kuzzle.Connect()
	if connectErr != nil {
		log.Fatal(connectErr)
		os.Exit(1)
	}

	filters := json.RawMessage(`{}`)

	listener := make(chan types.KuzzleNotification)
	go func() {
		<-listener
	}()

	res, _ := kuzzle.Realtime.Subscribe("nyc-open-data", "yellow-taxi", filters, listener, nil)

	count, err := kuzzle.Realtime.Count(res.Room, nil)

	if err != nil {
		log.Fatal(err)
	} else {
		fmt.Printf("Currently %d active subscription\n", count)
	}
}
```