### PR TITLE
[kzl-842] document.count - Make body argument optional

### DIFF
--- a/document/count.go
+++ b/document/count.go
@@ -34,10 +34,6 @@ func (d *Document) Count(index string, collection string, body json.RawMessage, 
 		return 0, types.NewError("Document.Count: collection required", 400)
 	}
 
-	if body == nil {
-		return 0, types.NewError("Document.Count: body required", 400)
-	}
-
 	ch := make(chan *types.KuzzleResponse)
 
 	query := &types.KuzzleRequest{


### PR DESCRIPTION
**:warning: depends on https://github.com/kuzzleio/kuzzle/pull/1214**

## What does this PR do?

Following https://github.com/kuzzleio/kuzzle/pull/1214, makes `document.count` `body` attribute optional (can be set to `nil`)
