### PR TITLE
Kzl 832 document count body optional

### DIFF
--- a/document/count.go
+++ b/document/count.go
@@ -34,10 +34,6 @@ func (d *Document) Count(index string, collection string, body json.RawMessage, 
 		return 0, types.NewError("Document.Count: collection required", 400)
 	}
 
-	if body == nil {
-		return 0, types.NewError("Document.Count: body required", 400)
-	}
-
 	ch := make(chan *types.KuzzleResponse)
 
 	query := &types.KuzzleRequest{

--- a/document/count_test.go
+++ b/document/count_test.go
@@ -39,13 +39,6 @@ func TestCountCollectionNull(t *testing.T) {
 	assert.NotNil(t, err)
 }
 
-func TestCountBodyNull(t *testing.T) {
-	k, _ := kuzzle.NewKuzzle(&internal.MockedConnection{}, nil)
-	d := document.NewDocument(k)
-	_, err := d.Count("index", "collection", nil, nil)
-	assert.NotNil(t, err)
-}
-
 func TestCountDocumentError(t *testing.T) {
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {


### PR DESCRIPTION
**:warning: depends on https://github.com/kuzzleio/kuzzle/pull/1214**

## What does this PR do?

Following https://github.com/kuzzleio/kuzzle/pull/1214, makes `document.count` `body` property optional.

:large_blue_circle: :arrow_right: https://github.com/kuzzleio/sdk-c/pull/30