### PR TITLE
[fix] Wrong route called in server.GetStats()

### DIFF
--- a/server/getStats.go
+++ b/server/getStats.go
@@ -40,7 +40,7 @@ func (s *Server) GetStats(startTime *time.Time, stopTime *time.Time, options typ
 
 	query := &types.KuzzleRequest{
 		Controller: "server",
-		Action:     "getLastStats",
+		Action:     "getStats",
 		Body:       d,
 	}
 

--- a/server/getStats_test.go
+++ b/server/getStats_test.go
@@ -33,7 +33,7 @@ func TestGetStatsQueryError(t *testing.T) {
 			request := types.KuzzleRequest{}
 			json.Unmarshal(query, &request)
 			assert.Equal(t, "server", request.Controller)
-			assert.Equal(t, "getLastStats", request.Action)
+			assert.Equal(t, "getStats", request.Action)
 			return &types.KuzzleResponse{Error: types.KuzzleError{Message: "error"}}
 		},
 	}
@@ -48,7 +48,7 @@ func TestGetStats(t *testing.T) {
 			request := types.KuzzleRequest{}
 			json.Unmarshal(query, &request)
 			assert.Equal(t, "server", request.Controller)
-			assert.Equal(t, "getLastStats", request.Action)
+			assert.Equal(t, "getStats", request.Action)
 
 			return &types.KuzzleResponse{Result: json.RawMessage(`{"foo": "bar"}`)}
 		},


### PR DESCRIPTION
## What does this PR do?
Wrong route called in server.GetStats()
