### PR TITLE
[bugfix] Fix document.validate unmarshalling

### DIFF
--- a/document/validate.go
+++ b/document/validate.go
@@ -52,8 +52,10 @@ func (d *Document) Validate(index string, collection string, body json.RawMessag
 		return false, res.Error
 	}
 
-	var valid bool
+	var valid struct {
+		Valid bool `json:"valid"`
+	}
 	json.Unmarshal(res.Result, &valid)
 
-	return valid, nil
+	return valid.Valid, nil
 }

--- a/document/validate_test.go
+++ b/document/validate_test.go
@@ -71,11 +71,12 @@ func TestValidateDocument(t *testing.T) {
 			assert.Equal(t, "index", parsedQuery.Index)
 			assert.Equal(t, "collection", parsedQuery.Collection)
 
-			return &types.KuzzleResponse{Result: []byte(`true`)}
+			return &types.KuzzleResponse{Result: []byte(`{"valid": true}`)}
 		},
 	}
 	k, _ := kuzzle.NewKuzzle(c, nil)
 	d := document.NewDocument(k)
-	_, err := d.Validate("index", "collection", json.RawMessage(`{"foo":"bar"}`), nil)
+	response, err := d.Validate("index", "collection", json.RawMessage(`{"foo":"bar"}`), nil)
 	assert.Nil(t, err)
+	assert.True(t, response)
 }


### PR DESCRIPTION
This PR fixes the parsing of the return of `document.validate`.