### PR TITLE
Rename KuzzleNotification and NotificationResult

### DIFF
--- a/internal/mock_connection.go
+++ b/internal/mock_connection.go
@@ -84,7 +84,7 @@ func (c *MockedConnection) EmitEvent(event int, arg interface{}) {
 	}
 }
 
-func (c *MockedConnection) RegisterSub(channel, roomID string, filters json.RawMessage, subscribeToSelf bool, notifChan chan<- types.KuzzleNotification, onReconnectChan chan<- interface{}) {
+func (c *MockedConnection) RegisterSub(channel, roomID string, filters json.RawMessage, subscribeToSelf bool, notifChan chan<- types.NotificationResult, onReconnectChan chan<- interface{}) {
 }
 
 func (c *MockedConnection) CancelSubs() {}

--- a/internal/mock_room.go
+++ b/internal/mock_room.go
@@ -20,15 +20,15 @@ type MockedRoom struct {
 	MockedSubscribe func()
 }
 
-func (m MockedRoom) Subscribe(realtimeNotificationChannel chan<- *types.KuzzleNotification) {
+func (m MockedRoom) Subscribe(realtimeNotificationChannel chan<- *types.NotificationResult) {
 	m.MockedSubscribe()
 }
 func (m MockedRoom) Unsubscribe() error {
 	return nil
 }
 
-func (m MockedRoom) GetRealtimeChannel() chan<- *types.KuzzleNotification {
-	return make(chan<- *types.KuzzleNotification)
+func (m MockedRoom) GetRealtimeChannel() chan<- *types.NotificationResult {
+	return make(chan<- *types.NotificationResult)
 }
 
 func (m MockedRoom) GetResponseChannel() chan<- *types.SubscribeResponse {

--- a/kuzzle/kuzzle.go
+++ b/kuzzle/kuzzle.go
@@ -139,7 +139,7 @@ func (k *Kuzzle) UnsetJwt() {
 	k.socket.CancelSubs()
 }
 
-func (k *Kuzzle) RegisterSub(channel, roomId string, filters json.RawMessage, subscribeToSelf bool, notifChan chan<- types.KuzzleNotification, onReconnectChannel chan<- interface{}) {
+func (k *Kuzzle) RegisterSub(channel, roomId string, filters json.RawMessage, subscribeToSelf bool, notifChan chan<- types.NotificationResult, onReconnectChannel chan<- interface{}) {
 	k.socket.RegisterSub(channel, roomId, filters, subscribeToSelf, notifChan, onReconnectChannel)
 }
 

--- a/protocol/protocol.go
+++ b/protocol/protocol.go
@@ -33,7 +33,7 @@ type Protocol interface {
 	Close() error
 	State() int
 	EmitEvent(int, interface{})
-	RegisterSub(string, string, json.RawMessage, bool, chan<- types.KuzzleNotification, chan<- interface{})
+	RegisterSub(string, string, json.RawMessage, bool, chan<- types.NotificationResult, chan<- interface{})
 	UnregisterSub(string)
 	CancelSubs()
 	RequestHistory() map[string]time.Time

--- a/protocol/websocket/web_socket.go
+++ b/protocol/websocket/web_socket.go
@@ -37,7 +37,7 @@ type subscription struct {
 	roomID              string
 	channel             string
 	filters             json.RawMessage
-	notificationChannel chan<- types.KuzzleNotification
+	notificationChannel chan<- types.NotificationResult
 	onReconnectChannel  chan<- interface{}
 	subscribeToSelf     bool
 }
@@ -291,7 +291,7 @@ func (ws *WebSocket) cleanQueue() {
 	}
 }
 
-func (ws *WebSocket) RegisterSub(channel, roomID string, filters json.RawMessage, subscribeToSelf bool, notifChan chan<- types.KuzzleNotification, onReconnectChannel chan<- interface{}) {
+func (ws *WebSocket) RegisterSub(channel, roomID string, filters json.RawMessage, subscribeToSelf bool, notifChan chan<- types.NotificationResult, onReconnectChannel chan<- interface{}) {
 	subs, found := ws.subscriptions.Load(channel)
 
 	if !found {
@@ -343,7 +343,7 @@ func (ws *WebSocket) listen() {
 		json.Unmarshal(msg, &message)
 
 		if s, found := ws.subscriptions.Load(message.RoomId); found {
-			var notification types.KuzzleNotification
+			var notification types.NotificationResult
 			_, fromSelf := ws.requestHistory[message.RequestId]
 
 			json.Unmarshal(msg, &notification)

--- a/realtime/subscribe.go
+++ b/realtime/subscribe.go
@@ -21,7 +21,7 @@ import (
 )
 
 // Subscribe permits to join a previously created subscription
-func (r *Realtime) Subscribe(index, collection string, filters json.RawMessage, cb chan<- types.KuzzleNotification, options types.RoomOptions) (*types.SubscribeResult, error) {
+func (r *Realtime) Subscribe(index, collection string, filters json.RawMessage, cb chan<- types.NotificationResult, options types.RoomOptions) (*types.SubscribeResult, error) {
 	if (index == "" || collection == "") || (filters == nil || cb == nil) {
 		return nil, types.NewError("Realtime.Subscribe: index, collection, filters and notificationChannel required", 400)
 	}

--- a/realtime/subscribe_test.go
+++ b/realtime/subscribe_test.go
@@ -30,7 +30,7 @@ func TestSubscribeIndexNull(t *testing.T) {
 	k, _ := kuzzle.NewKuzzle(&internal.MockedConnection{}, nil)
 	nr := realtime.NewRealtime(k)
 
-	notifChan := make(chan<- types.KuzzleNotification)
+	notifChan := make(chan<- types.NotificationResult)
 	_, err := nr.Subscribe("", "collection", json.RawMessage(`{"filter": "filter"}`), notifChan, nil)
 
 	assert.NotNil(t, err)
@@ -40,7 +40,7 @@ func TestSubscribeCollectionNull(t *testing.T) {
 	k, _ := kuzzle.NewKuzzle(&internal.MockedConnection{}, nil)
 	nr := realtime.NewRealtime(k)
 
-	notifChan := make(chan<- types.KuzzleNotification)
+	notifChan := make(chan<- types.NotificationResult)
 	_, err := nr.Subscribe("index", "", json.RawMessage(`{"filter": "filter"}`), notifChan, nil)
 
 	assert.NotNil(t, err)
@@ -83,7 +83,7 @@ func TestSubscribeQueryError(t *testing.T) {
 	nr := realtime.NewRealtime(k)
 	c.SetState(state.Connected)
 
-	notifChan := make(chan<- types.KuzzleNotification)
+	notifChan := make(chan<- types.NotificationResult)
 	_, err := nr.Subscribe("index", "collection", json.RawMessage(`{"filter": "filter"}`), notifChan, nil)
 	assert.Equal(t, "ah!", err.Error())
 }
@@ -101,7 +101,7 @@ func TestRenewWithSubscribeToSelf(t *testing.T) {
 	nr := realtime.NewRealtime(k)
 	c.SetState(state.Connected)
 
-	notifChan := make(chan<- types.KuzzleNotification)
+	notifChan := make(chan<- types.NotificationResult)
 	res, err := nr.Subscribe("index", "collection", json.RawMessage(`{"filter": "filter"}`), notifChan, nil)
 	assert.Nil(t, err)
 	assert.NotNil(t, res)
@@ -121,7 +121,7 @@ func TestRoomSubscribe(t *testing.T) {
 	nr := realtime.NewRealtime(k)
 	c.SetState(state.Connected)
 
-	notifChan := make(chan<- types.KuzzleNotification)
+	notifChan := make(chan<- types.NotificationResult)
 	res, err := nr.Subscribe("index", "collection", json.RawMessage(`{"filter": "filter"}`), notifChan, nil)
 	assert.Nil(t, err)
 	assert.NotNil(t, res)
@@ -142,7 +142,7 @@ func TestRoomSubscribeNotConnected(t *testing.T) {
 	nr := realtime.NewRealtime(k)
 	c.SetState(state.Connected)
 
-	notifChan := make(chan<- types.KuzzleNotification)
+	notifChan := make(chan<- types.NotificationResult)
 	_, err := nr.Subscribe("collection", "index", json.RawMessage("{}"), notifChan, nil)
 	assert.NotNil(t, err)
 	assert.Equal(t, "Not Connected", err.Error())
@@ -159,6 +159,6 @@ func ExampleRealtime_Subscribe() {
 	nr := realtime.NewRealtime(k)
 	c.SetState(state.Connected)
 
-	notifChan := make(chan<- types.KuzzleNotification)
+	notifChan := make(chan<- types.NotificationResult)
 	nr.Subscribe("collection", "index", json.RawMessage(""), notifChan, nil)
 }

--- a/types/ikuzzle.go
+++ b/types/ikuzzle.go
@@ -22,7 +22,7 @@ type IKuzzle interface {
 	Query(query *KuzzleRequest, options QueryOptions, responseChannel chan<- *KuzzleResponse)
 	EmitEvent(int, interface{})
 	SetJwt(string)
-	RegisterSub(string, string, json.RawMessage, bool, chan<- KuzzleNotification, chan<- interface{})
+	RegisterSub(string, string, json.RawMessage, bool, chan<- NotificationResult, chan<- interface{})
 	UnregisterSub(string)
 	AddListener(event int, notifChan chan<- json.RawMessage)
 	AutoResubscribe() bool

--- a/types/kuzzle_response.go
+++ b/types/kuzzle_response.go
@@ -42,33 +42,33 @@ type (
 		Channel string `json:"channel"`
 	}
 
-	// NotificationResult contains
-	NotificationResult struct {
+	// NotificationContent contains
+	NotificationContent struct {
 		Id      string          `json:"_id"`
 		Meta    *Meta           `json:"_meta"`
 		Content json.RawMessage `json:"_source"`
 		Count   int             `json:"count"`
 	}
 
-	// KuzzleNotification is a notification from Kuzzle
-	KuzzleNotification struct {
-		RequestId  string              `json:"requestId"`
-		Result     *NotificationResult `json:"result"`
-		Volatile   json.RawMessage     `json:"volatile"`
-		Index      string              `json:"index"`
-		Collection string              `json:"collection"`
-		Controller string              `json:"controller"`
-		Action     string              `json:"action"`
-		Protocol   string              `json:"protocol"`
-		Scope      string              `json:"scope"`
-		State      string              `json:"state"`
-		User       string              `json:"user"`
-		Type       string              `json:"type"`
-		RoomId     string              `json:"room"`
-		Channel    string              `json:"channel"`
-		Timestamp  int                 `json:"timestamp"`
-		Status     int                 `json:"status"`
-		Error      KuzzleError         `json:"error"`
+	// NotificationResult is a notification from Kuzzle
+	NotificationResult struct {
+		RequestId  string               `json:"requestId"`
+		Result     *NotificationContent `json:"result"`
+		Volatile   json.RawMessage      `json:"volatile"`
+		Index      string               `json:"index"`
+		Collection string               `json:"collection"`
+		Controller string               `json:"controller"`
+		Action     string               `json:"action"`
+		Protocol   string               `json:"protocol"`
+		Scope      string               `json:"scope"`
+		State      string               `json:"state"`
+		User       string               `json:"user"`
+		Type       string               `json:"type"`
+		RoomId     string               `json:"room"`
+		Channel    string               `json:"channel"`
+		Timestamp  int                  `json:"timestamp"`
+		Status     int                  `json:"status"`
+		Error      KuzzleError          `json:"error"`
 	}
 
 	// KuzzleResponse is a response to a KuzzleRequest

--- a/types/query_object.go
+++ b/types/query_object.go
@@ -23,7 +23,7 @@ type QueryObject struct {
 	Query     []byte
 	Options   QueryOptions
 	ResChan   chan<- *KuzzleResponse
-	NotifChan chan<- *KuzzleNotification
+	NotifChan chan<- *NotificationResult
 	Timestamp time.Time
 	RequestId string
 }

--- a/types/room.go
+++ b/types/room.go
@@ -24,9 +24,9 @@ type SubscribeResponse struct {
 
 // IRoom provides functions to manage Room
 type IRoom interface {
-	Subscribe(realtimeNotificationChannel chan<- KuzzleNotification)
+	Subscribe(realtimeNotificationChannel chan<- NotificationResult)
 	Unsubscribe() error
-	RealtimeChannel() chan<- KuzzleNotification
+	RealtimeChannel() chan<- NotificationResult
 	ResponseChannel() chan SubscribeResponse
 	RoomId() string
 	Filters() interface{}


### PR DESCRIPTION
## What does this PR do?

Rename `KuzzleNotification` to `NotificationResult` and `NotificationResult` to `NotifcicationContent`

### How should this be manually tested?

See travis result.

:arrow_right: https://github.com/kuzzleio/sdk-c/pull/35