### PR TITLE
Add query parameter to collection.searchSpecifications

### DIFF
--- a/collection/search_specifications.go
+++ b/collection/search_specifications.go
@@ -15,16 +15,27 @@
 package collection
 
 import (
+	"encoding/json"
+
 	"github.com/kuzzleio/sdk-go/types"
 )
 
 // SearchSpecifications searches specifications across indexes/collections according to the provided filters.
-func (dc *Collection) SearchSpecifications(options types.QueryOptions) (*types.SearchResult, error) {
+func (dc *Collection) SearchSpecifications(body json.RawMessage, options types.QueryOptions) (*types.SearchResult, error) {
+	if body == nil {
+		return nil, types.NewError("Document.Search: body required", 400)
+	}
+
 	ch := make(chan *types.KuzzleResponse)
 
 	query := &types.KuzzleRequest{
 		Controller: "collection",
 		Action:     "searchSpecifications",
+		Body:       body,
+	}
+	if options != nil {
+		query.From = options.From()
+		query.Size = options.Size()
 	}
 
 	go dc.Kuzzle.Query(query, options, ch)

--- a/collection/search_specifications_test.go
+++ b/collection/search_specifications_test.go
@@ -144,7 +144,7 @@ func ExampleCollection_SearchSpecifications() {
 
 	nc := collection.NewCollection(k)
 
-	res, err := nc.SearchSpecifications(json.RawMessage("{}"), nil)
+	res, err := nc.SearchSpecifications(json.RawMessage( `{}`), nil)
 
 	if err != nil {
 		fmt.Println(err.Error())

--- a/collection/search_specifications_test.go
+++ b/collection/search_specifications_test.go
@@ -144,7 +144,7 @@ func ExampleCollection_SearchSpecifications() {
 
 	nc := collection.NewCollection(k)
 
-	res, err := nc.SearchSpecifications(json.RawMessage( `{}`), nil)
+	res, err := nc.SearchSpecifications(json.RawMessage(`{}`), nil)
 
 	if err != nil {
 		fmt.Println(err.Error())

--- a/collection/search_specifications_test.go
+++ b/collection/search_specifications_test.go
@@ -36,7 +36,7 @@ func TestSearchSpecificationsError(t *testing.T) {
 
 	nc := collection.NewCollection(k)
 
-	_, err := nc.SearchSpecifications(nil)
+	_, err := nc.SearchSpecifications(nil, nil)
 	assert.NotNil(t, err)
 }
 
@@ -79,7 +79,7 @@ func TestSearchSpecifications(t *testing.T) {
 
 	nc := collection.NewCollection(k)
 
-	res, err := nc.SearchSpecifications(nil)
+	res, err := nc.SearchSpecifications(json.RawMessage(`{"foo": "bar"}`), nil)
 	assert.Equal(t, 1, res.Total)
 	assert.Nil(t, err)
 }
@@ -108,7 +108,7 @@ func TestSearchSpecificationsNext(t *testing.T) {
 	options.SetFrom(0)
 	options.SetSize(2)
 
-	sr, err := k.Security.SearchUsers(json.RawMessage(`{}`), options)
+	sr, err := k.Collection.SearchSpecifications(json.RawMessage(`{}`), options)
 	assert.Nil(t, err)
 	assert.NotNil(t, sr)
 
@@ -144,7 +144,7 @@ func ExampleCollection_SearchSpecifications() {
 
 	nc := collection.NewCollection(k)
 
-	res, err := nc.SearchSpecifications(nil)
+	res, err := nc.SearchSpecifications(json.RawMessage("{}"), nil)
 
 	if err != nil {
 		fmt.Println(err.Error())


### PR DESCRIPTION
## What does this PR do?

This PR fixes `collection.searchSpecifications` by adding the missing `query` parameter.

:large_blue_circle: :arrow_right: https://github.com/kuzzleio/sdk-c/pull/37