### PR TITLE
Check if a channel is not nil before closing it in websocket

### DIFF
--- a/protocol/websocket/web_socket.go
+++ b/protocol/websocket/web_socket.go
@@ -314,8 +314,12 @@ func (ws *WebSocket) UnregisterSub(roomID string) {
 	ws.subscriptions.Range(func(k, v interface{}) bool {
 		for k, sub := range v.(map[string]subscription) {
 			if sub.roomID == roomID {
-				close(sub.onReconnectChannel)
-				close(sub.notificationChannel)
+				if sub.onReconnectChannel != nil {
+					close(sub.onReconnectChannel)
+				}
+				if sub.notificationChannel != nil {
+					close(sub.notificationChannel)
+				}
 				delete(v.(map[string]subscription), k)
 			}
 		}


### PR DESCRIPTION
## What does this PR do?

Since users are now able to write their own protocol implemetation we check if the notifications channel are not nil before closing them.

### How should this be manually tested?

See travis.

:arrow_right: https://github.com/kuzzleio/sdk-cpp