### PR TITLE
Fix cancelSubs

### DIFF
--- a/protocol/websocket/web_socket.go
+++ b/protocol/websocket/web_socket.go
@@ -330,7 +330,7 @@ func (ws *WebSocket) UnregisterSub(roomID string) {
 func (ws *WebSocket) CancelSubs() {
 	ws.subscriptions.Range(func(roomId, s interface{}) bool {
 		for _, sub := range s.(map[string]subscription) {
-			if sub.notificationChannel != nil {
+			if sub.onReconnectChannel != nil {
 				close(sub.onReconnectChannel)
 			}
 			ws.subscriptions.Delete(roomId)


### PR DESCRIPTION
## What does this PR do?

Fix `cancelSubs` which was checking if `notificationChannel` was null before closing `onReconnectChannel` ... Bad copy paste I guess :p
