### PR TITLE
[websocket] allow passing HTTP headers to the ctor

### DIFF
--- a/protocol/websocket/web_socket.go
+++ b/protocol/websocket/web_socket.go
@@ -17,15 +17,15 @@ package websocket
 import (
 	"encoding/json"
 	"fmt"
-	"net/url"
-	"sync"
-	"time"
-
 	"github.com/gorilla/websocket"
 	"github.com/kuzzleio/sdk-go/event"
 	"github.com/kuzzleio/sdk-go/protocol"
 	"github.com/kuzzleio/sdk-go/state"
 	"github.com/kuzzleio/sdk-go/types"
+	"net/http"
+	"net/url"
+	"sync"
+	"time"
 )
 
 const (
@@ -75,6 +75,7 @@ type WebSocket struct {
 	reconnectionDelay  time.Duration
 	replayInterval     time.Duration
 	ssl                bool
+	headers            *http.Header
 }
 
 var defaultQueueFilter protocol.QueueFilter
@@ -116,6 +117,7 @@ func NewWebSocket(host string, options types.Options) *WebSocket {
 		queueFilter:           defaultQueueFilter,
 		port:                  opts.Port(),
 		ssl:                   opts.SslConnection(),
+		headers:               opts.Headers(),
 	}
 	ws.host = host
 
@@ -158,7 +160,7 @@ func (ws *WebSocket) Connect() (bool, error) {
 	}
 
 	u := url.URL{Scheme: scheme, Host: addr}
-	socket, _, err := websocket.DefaultDialer.Dial(u.String(), nil)
+	socket, _, err := websocket.DefaultDialer.Dial(u.String(), *ws.headers)
 
 	if err != nil {
 		ws.state = state.Offline

--- a/types/options.go
+++ b/types/options.go
@@ -15,6 +15,7 @@
 package types
 
 import (
+	"net/http"
 	"time"
 )
 
@@ -49,6 +50,8 @@ type Options interface {
 	SetPort(int) *options
 	SslConnection() bool
 	SetSslConnection(bool) *options
+	Headers() *http.Header
+	SetHeaders(*http.Header) *options
 }
 
 type options struct {
@@ -65,6 +68,7 @@ type options struct {
 	refresh           string
 	port              int
 	sslConnection     bool
+	headers           *http.Header
 }
 
 func (o options) QueueTTL() time.Duration {
@@ -175,6 +179,15 @@ func (o *options) SetSslConnection(v bool) *options {
 	return o
 }
 
+func (o *options) Headers() *http.Header {
+	return o.headers
+}
+
+func (o *options) SetHeaders(h *http.Header) *options {
+	o.headers = h
+	return o
+}
+
 // NewOptions instanciates new Options with default values
 func NewOptions() *options {
 	return &options{
@@ -189,5 +202,6 @@ func NewOptions() *options {
 		replayInterval:    10,
 		port:              7512,
 		sslConnection:     false,
+		headers:           nil,
 	}
 }


### PR DESCRIPTION
# Description

Allow users to pass HTTP headers to new WebSocket instances. This is simply a matter of making accessible the full capabilities of [Gorilla's Websocket constructor](https://godoc.org/github.com/gorilla/websocket#Dialer.Dial)

To pass HTTP headers, simply use the new accessors in the `options` interface:
- getter: `func (o *options) Headers() *http.Header`
- setter: `func (o *options) SetHeaders(*http.Header) *options`
