### PR TITLE
Fix websocket closing 

### DIFF
--- a/protocol/websocket/web_socket.go
+++ b/protocol/websocket/web_socket.go
@@ -349,9 +349,7 @@ func (ws *WebSocket) CancelSubs() {
 }
 
 func (ws *WebSocket) listen() {
-	for {
-		msg := <-ws.listenChan
-
+	for msg := range ws.listenChan {
 		var message types.KuzzleResponse
 		json.Unmarshal(msg, &message)
 
@@ -539,12 +537,10 @@ func (ws *WebSocket) emitRequest(query *types.QueryObject) error {
 	return nil
 }
 
-func (ws *WebSocket) Close() error {
+func (ws *WebSocket) Close() {
 	ws.stopRetryingToConnect = true
 	ws.ws.WriteMessage(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""))
 	ws.state = state.Disconnected
-
-	return ws.ws.Close()
 }
 
 func (ws *WebSocket) isValidState() bool {

--- a/protocol/websocket/web_socket.go
+++ b/protocol/websocket/web_socket.go
@@ -537,10 +537,12 @@ func (ws *WebSocket) emitRequest(query *types.QueryObject) error {
 	return nil
 }
 
-func (ws *WebSocket) Close() {
+func (ws *WebSocket) Close() error {
 	ws.stopRetryingToConnect = true
 	ws.ws.WriteMessage(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""))
 	ws.state = state.Disconnected
+
+	return ws.ws.Close()
 }
 
 func (ws *WebSocket) isValidState() bool {


### PR DESCRIPTION
# Description

Upon receiving the close signal, the socket message listener correctly closes the message channel. But that channel's listener runs on an infinite loop, resulting in a massive resource leak when closing a socket (we're speaking of about an exponential amount of time taken for each socket closed/reopened on functional tests here)