### PR TITLE
Fix a crash occuring when closing a non-connected websocket

### DIFF
--- a/protocol/websocket/web_socket.go
+++ b/protocol/websocket/web_socket.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// 		http://www.apache.org/licenses/LICENSE-2.0
+//    http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -539,6 +539,11 @@ func (ws *WebSocket) emitRequest(query *types.QueryObject) error {
 
 func (ws *WebSocket) Close() error {
 	ws.stopRetryingToConnect = true
+
+	if ws.ws == nil {
+		return nil
+	}
+
 	ws.ws.WriteMessage(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""))
 	ws.state = state.Disconnected
 


### PR DESCRIPTION
# Description

This PR fixes a segfault case occuring when closing an unconnected WebSocket instance.

# How to test

Run this Go program:

```go
package main

import (
	"github.com/kuzzleio/sdk-go/protocol/websocket"
)

func main() {
	c := websocket.NewWebSocket("kuzzle", nil)
	c.Close()
}
```

Without this PR: segfault
With this PR: :+1: 