### PR TITLE
Fix previous connection detection and associated events

### DIFF
--- a/kuzzle/disconnect.go
+++ b/kuzzle/disconnect.go
@@ -14,7 +14,10 @@
 
 package kuzzle
 
-import "github.com/kuzzleio/sdk-go/types"
+import (
+	"github.com/kuzzleio/sdk-go/event"
+	"github.com/kuzzleio/sdk-go/types"
+)
 
 // Disconnect from Kuzzle and invalidate this instance.
 // Does not fire a disconnected event.
@@ -26,6 +29,7 @@ func (k *Kuzzle) Disconnect() error {
 		return types.NewError(err.Error())
 	}
 	k.wasConnected = false
+	k.EmitEvent(event.Disconnected, nil)
 
 	return nil
 }

--- a/kuzzle/kuzzle.go
+++ b/kuzzle/kuzzle.go
@@ -172,8 +172,9 @@ func (k *Kuzzle) Connect() error {
 				}
 				k.EmitEvent(event.Reconnected, nil)
 			}()
+		} else {
+			k.EmitEvent(event.Reconnected, nil)
 		}
-
 	} else {
 		k.EmitEvent(event.Connected, nil)
 	}

--- a/protocol/websocket/web_socket.go
+++ b/protocol/websocket/web_socket.go
@@ -102,10 +102,8 @@ func (ws *WebSocket) Connect() (bool, error) {
 
 	addr := fmt.Sprintf("%s:%d", ws.host, ws.port)
 
-	if ws.lastUrl != addr {
-		ws.wasConnected = false
-		ws.lastUrl = addr
-	}
+	ws.wasConnected = ws.lastUrl == addr
+	ws.lastUrl = addr
 
 	var scheme string
 
@@ -139,7 +137,6 @@ func (ws *WebSocket) Connect() (bool, error) {
 	if ws.wasConnected {
 		ws.EmitEvent(event.Reconnected, nil)
 	} else {
-		ws.wasConnected = true
 		ws.EmitEvent(event.Connected, nil)
 	}
 
@@ -324,7 +321,7 @@ func (ws *WebSocket) EmitEvent(event int, arg interface{}) {
 }
 
 func (ws *WebSocket) IsReady() bool {
-	return ws.state == state.Connected
+	return ws != nil && ws.state == state.Connected
 }
 
 func (ws *WebSocket) emitRequest(query *types.QueryObject) error {


### PR DESCRIPTION
# Description

The `protocol.Connect` method is supposed to return a boolean telling if this is a first connection, or a reconnection.
Problem is, that status is computed at the beginning of that Connect method, and then set to `true` if this is a first connection, meaning that the status detection flag cannot be used.

As a result, the `event.Connected` event is never triggered.

Also, the `event.Reconnected` event is never triggered if no jwt is set.