### PR TITLE
Add capabilty to inject custom fields in requests

### DIFF
--- a/kuzzle/query.go
+++ b/kuzzle/query.go
@@ -98,8 +98,8 @@ func (k *Kuzzle) Query(query *types.KuzzleRequest, options types.QueryOptions, r
 		out["jwt"] = jwt
 	}
 
-	if len(query.CustomFields) != 0 {
-		for k, v := range query.CustomFields {
+	if len(query.CustomArgs) != 0 {
+		for k, v := range query.CustomArgs {
 			out[k] = v
 		}
 	}

--- a/kuzzle/query.go
+++ b/kuzzle/query.go
@@ -98,6 +98,12 @@ func (k *Kuzzle) Query(query *types.KuzzleRequest, options types.QueryOptions, r
 		out["jwt"] = jwt
 	}
 
+	if len(query.CustomFields) != 0 {
+		for k, v := range query.CustomFields {
+			out[k] = v
+		}
+	}
+
 	finalRequest, err := json.Marshal(out)
 
 	if err != nil {

--- a/kuzzle/query_test.go
+++ b/kuzzle/query_test.go
@@ -87,8 +87,8 @@ func TestQueryWithOptions(t *testing.T) {
 	options.SetRefresh("wait_for")
 	options.SetRetryOnConflict(7)
 	query := types.KuzzleRequest{}
-	query.AddCustomField("cert", "cert")
-	query.AddCustomField("foo", "bar")
+	query.AddCustomArg("cert", "cert")
+	query.AddCustomArg("foo", "bar")
 
 	go k.Query(&query, options, ch)
 	<-ch

--- a/kuzzle/query_test.go
+++ b/kuzzle/query_test.go
@@ -86,8 +86,11 @@ func TestQueryWithOptions(t *testing.T) {
 	options.SetScrollId("f00b4r")
 	options.SetRefresh("wait_for")
 	options.SetRetryOnConflict(7)
+	query := types.KuzzleRequest{}
+	query.AddCustomField("cert", "cert")
+	query.AddCustomField("foo", "bar")
 
-	go k.Query(&types.KuzzleRequest{}, options, ch)
+	go k.Query(&query, options, ch)
 	<-ch
 }
 

--- a/types/kuzzle_request.go
+++ b/types/kuzzle_request.go
@@ -62,14 +62,14 @@ type KuzzleRequest struct {
 	Match        string                 `json:"match,omitempty"`
 	Reset        bool                   `json:"reset,omitempty"`
 	IncludeTrash bool                   `json:"includeTrash,omitempty"`
-	CustomFields map[string]interface{} `json:"-"`
+	CustomArgs   map[string]interface{} `json:"-"`
 }
 
-func (kr *KuzzleRequest) AddCustomField(k string, v interface{}) {
-	if kr.CustomFields == nil {
-		kr.CustomFields = make(map[string]interface{})
+func (kr *KuzzleRequest) AddCustomArg(k string, v interface{}) {
+	if kr.CustomArgs == nil {
+		kr.CustomArgs = make(map[string]interface{})
 	}
-	kr.CustomFields[k] = v
+	kr.CustomArgs[k] = v
 }
 
 type SubscribeQuery struct {

--- a/types/kuzzle_request.go
+++ b/types/kuzzle_request.go
@@ -17,51 +17,59 @@ package types
 import "encoding/json"
 
 type KuzzleRequest struct {
-	RequestId    string        `json:"requestId,omitempty"`
-	Controller   string        `json:"controller,omitempty"`
-	Action       string        `json:"action,omitempty"`
-	Index        string        `json:"index,omitempty"`
-	Collection   string        `json:"collection,omitempty"`
-	Body         interface{}   `json:"body"`
-	Id           string        `json:"_id,omitempty"`
-	From         int           `json:"from"`
-	Size         int           `json:"size"`
-	Scroll       string        `json:"scroll,omitempty"`
-	ScrollId     string        `json:"scrollId,omitempty"`
-	Strategy     string        `json:"strategy,omitempty"`
-	ExpiresIn    int           `json:"expiresIn,omitempty"`
-	Volatile     VolatileData  `json:"volatile"`
-	Scope        string        `json:"scope"`
-	State        string        `json:"state"`
-	Users        string        `json:"users"`
-	Start        int           `json:"start,omitempty"`
-	Stop         int           `json:"stop,omitempty"`
-	End          int           `json:"end,omitempty"`
-	Bit          int           `json:"bit,omitempty"`
-	Member       string        `json:"member,omitempty"`
-	Member1      string        `json:"member1,omitempty"`
-	Member2      string        `json:"member2,omitempty"`
-	Members      []string      `json:"members,omitempty"`
-	Lon          float64       `json:"lon,omitempty"`
-	Lat          float64       `json:"lat,omitempty"`
-	Distance     float64       `json:"distance,omitempty"`
-	Unit         string        `json:"unit,omitempty"`
-	Options      []interface{} `json:"options,omitempty"`
-	Keys         []string      `json:"keys,omitempty"`
-	Cursor       int           `json:"cursor,omitempty"`
-	Offset       int           `json:"offset,omitempty"`
-	Field        string        `json:"field,omitempty"`
-	Fields       []string      `json:"fields,omitempty"`
-	Subcommand   string        `json:"subcommand,omitempty"`
-	Pattern      string        `json:"pattern,omitempty"`
-	Idx          int           `json:"idx, omitempty"`
-	Min          string        `json:"min,omitempty"`
-	Max          string        `json:"max,omitempty"`
-	Limit        string        `json:"limit,omitempty"`
-	Count        int           `json:"count,omitempty"`
-	Match        string        `json:"match,omitempty"`
-	Reset        bool          `json:"reset,omitempty"`
-	IncludeTrash bool          `json:"includeTrash,omitempty"`
+	RequestId    string                 `json:"requestId,omitempty"`
+	Controller   string                 `json:"controller,omitempty"`
+	Action       string                 `json:"action,omitempty"`
+	Index        string                 `json:"index,omitempty"`
+	Collection   string                 `json:"collection,omitempty"`
+	Body         interface{}            `json:"body"`
+	Id           string                 `json:"_id,omitempty"`
+	From         int                    `json:"from"`
+	Size         int                    `json:"size"`
+	Scroll       string                 `json:"scroll,omitempty"`
+	ScrollId     string                 `json:"scrollId,omitempty"`
+	Strategy     string                 `json:"strategy,omitempty"`
+	ExpiresIn    int                    `json:"expiresIn,omitempty"`
+	Volatile     VolatileData           `json:"volatile"`
+	Scope        string                 `json:"scope"`
+	State        string                 `json:"state"`
+	Users        string                 `json:"users"`
+	Start        int                    `json:"start,omitempty"`
+	Stop         int                    `json:"stop,omitempty"`
+	End          int                    `json:"end,omitempty"`
+	Bit          int                    `json:"bit,omitempty"`
+	Member       string                 `json:"member,omitempty"`
+	Member1      string                 `json:"member1,omitempty"`
+	Member2      string                 `json:"member2,omitempty"`
+	Members      []string               `json:"members,omitempty"`
+	Lon          float64                `json:"lon,omitempty"`
+	Lat          float64                `json:"lat,omitempty"`
+	Distance     float64                `json:"distance,omitempty"`
+	Unit         string                 `json:"unit,omitempty"`
+	Options      []interface{}          `json:"options,omitempty"`
+	Keys         []string               `json:"keys,omitempty"`
+	Cursor       int                    `json:"cursor,omitempty"`
+	Offset       int                    `json:"offset,omitempty"`
+	Field        string                 `json:"field,omitempty"`
+	Fields       []string               `json:"fields,omitempty"`
+	Subcommand   string                 `json:"subcommand,omitempty"`
+	Pattern      string                 `json:"pattern,omitempty"`
+	Idx          int                    `json:"idx, omitempty"`
+	Min          string                 `json:"min,omitempty"`
+	Max          string                 `json:"max,omitempty"`
+	Limit        string                 `json:"limit,omitempty"`
+	Count        int                    `json:"count,omitempty"`
+	Match        string                 `json:"match,omitempty"`
+	Reset        bool                   `json:"reset,omitempty"`
+	IncludeTrash bool                   `json:"includeTrash,omitempty"`
+	CustomFields map[string]interface{} `json:"-"`
+}
+
+func (kr *KuzzleRequest) AddCustomField(k string, v interface{}) {
+	if kr.CustomFields == nil {
+		kr.CustomFields = make(map[string]interface{})
+	}
+	kr.CustomFields[k] = v
 }
 
 type SubscribeQuery struct {


### PR DESCRIPTION
## What does this PR do?
Add capabilty to inject custom fields in requests. According to #245  

### How should this be manually tested?

I used this little program to test this new feature:
```go
package main

import (
	"log"
	"os"

	"github.com/kuzzleio/sdk-go/kuzzle"
	"github.com/kuzzleio/sdk-go/protocol/websocket"
	"github.com/kuzzleio/sdk-go/types"
)

func main() {
	// Creates a WebSocket connection.
	// Replace "kuzzle" with
	// your Kuzzle hostname like "localhost"
	c := websocket.NewWebSocket("localhost", nil)
	// Instantiates a Kuzzle client
	kuzzle, _ := kuzzle.NewKuzzle(c, nil)
	// Connects to the server.
	err := kuzzle.Connect()
	if err != nil {
		log.Fatal(err)
		os.Exit(1)
	}
	ch := make(chan *types.KuzzleResponse)
	options := types.NewQueryOptions()

	query := types.KuzzleRequest{}
	query.AddCustomArg("cert", "cert")
	query.AddCustomArg("foo", "bar")

	go kuzzle.Query(&query, options, ch)
	<-ch

	// Disconnects the SDK
	kuzzle.Disconnect()
}
```

But it's very hard to check the WebSocket message so I used Wireshark:
![image](https://user-images.githubusercontent.com/7868838/61066383-baf63480-a405-11e9-8a95-204984b8c59b.png)

