### PR TITLE
[hotfix] Try to reconnect if the state is not errored

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,11 @@ env:
 
 jobs:
   include:
-  - name: Documentation test
-    language: go
-    go: 1.12.x
-    script:
-      - docker-compose -f .ci/doc/docker-compose.yml run doc-tests node index
+    - name: Documentation test
+      language: go
+      go: 1.12.x
+      script:
+        - docker-compose -f .ci/doc/docker-compose.yml run doc-tests node index
 
 # -----------------------------------------------
 # Linux amd64

--- a/kuzzle/kuzzle.go
+++ b/kuzzle/kuzzle.go
@@ -33,7 +33,7 @@ import (
 )
 
 const (
-	version           = "2.0.0"
+	version           = "2.0.1"
 	MAX_CONNECT_RETRY = 10
 )
 

--- a/kuzzle/query_test.go
+++ b/kuzzle/query_test.go
@@ -96,7 +96,7 @@ func TestQueryWithOptions(t *testing.T) {
 
 func TestQueryWithVolatile(t *testing.T) {
 	var k *kuzzle.Kuzzle
-	var volatileData = types.VolatileData(`{"modifiedBy":"awesome me","reason":"it needed to be modified","sdkVersion":"2.0.0"}`)
+	var volatileData = types.VolatileData(`{"modifiedBy":"awesome me","reason":"it needed to be modified","sdkVersion":"2.0.1"}`)
 
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {

--- a/protocol/websocket/web_socket.go
+++ b/protocol/websocket/web_socket.go
@@ -94,7 +94,7 @@ func NewWebSocket(host string, options types.Options) *WebSocket {
 
 //Connect connects to a kuzzle instance
 func (ws *WebSocket) Connect() (bool, error) {
-	if ws.state != state.Offline {
+	if ws.state != state.Offline && ws.state != state.Disconnected && ws.state != state.Error {
 		return false, nil
 	}
 


### PR DESCRIPTION
## What does this PR do?

Try to reconnect if the state is different than Offline and Disconnected and Error.

Before that, we would check only if the state was different than Offline but in the case of when Kuzzle go down and you catch the `Disconnected` event, then do a Disconnect() to clean and a Reconnect() to try and connect again to the Kuzzle instance, WebSocket would not try to reconnect because the state would be set as `Offline` which would then initialize some goroutine inside the Kuzzle instance as long as we try to reconnect to the Kuzzle instance and get a OnNetworkError. Once connected to the Kuzzle instance those go routine would still be alive.. for nothing. So if you try to to reconnect to Kuzzle in a loop you would have a serious memory leak.