### PR TITLE
Remove listener when NetworkError is catched

### DIFF
--- a/kuzzle/kuzzle.go
+++ b/kuzzle/kuzzle.go
@@ -196,9 +196,8 @@ func (k *Kuzzle) Connect() error {
 
 			k.EmitEvent(event.NetworkError, err)
 		}
-		k.protocol.RemoveListener(event.NetworkError, ee)
 	}()
-	k.protocol.AddListener(event.NetworkError, ee)
+	k.protocol.Once(event.NetworkError, ee)
 
 	return nil
 }

--- a/kuzzle/kuzzle.go
+++ b/kuzzle/kuzzle.go
@@ -33,7 +33,7 @@ import (
 )
 
 const (
-	version           = "2.0.1"
+	version           = "2.0.2"
 	MAX_CONNECT_RETRY = 10
 )
 
@@ -196,6 +196,7 @@ func (k *Kuzzle) Connect() error {
 
 			k.EmitEvent(event.NetworkError, err)
 		}
+		k.protocol.RemoveListener(event.NetworkError, ee)
 	}()
 	k.protocol.AddListener(event.NetworkError, ee)
 

--- a/kuzzle/query_test.go
+++ b/kuzzle/query_test.go
@@ -96,7 +96,7 @@ func TestQueryWithOptions(t *testing.T) {
 
 func TestQueryWithVolatile(t *testing.T) {
 	var k *kuzzle.Kuzzle
-	var volatileData = types.VolatileData(`{"modifiedBy":"awesome me","reason":"it needed to be modified","sdkVersion":"2.0.1"}`)
+	var volatileData = types.VolatileData(`{"modifiedBy":"awesome me","reason":"it needed to be modified","sdkVersion":"2.0.2"}`)
 
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {


### PR DESCRIPTION
What does this PR do?

Remove listener on `NetworkError` once we catched it before reconnecting, otherwise we will write in it but nothing will be listening to it and this will block the whole process of `Connect`