### PR TITLE
Allow connecting to Kuzzle v2

### DIFF
--- a/.doc/2/controllers/realtime/subscribe/snippets/user-notifications.go
+++ b/.doc/2/controllers/realtime/subscribe/snippets/user-notifications.go
@@ -8,7 +8,7 @@ go func() {
 
   if notification.Type == "user" {
     fmt.Printf("Volatile data: %s\n", notification.Volatile)
-    // Volatile data: {"sdkVersion":"1.0.0","username":"nina vkote"}
+    // Volatile data: {"sdkName":"go@1.0.0","username":"nina vkote"}
     fmt.Printf("Currently %d users in the room\n", notification.Result.Count)
   }
 }()

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,9 @@
+module github.com/kuzzleio/sdk-go
+
+go 1.14
+
+require (
+	github.com/gorilla/websocket v1.4.2
+	github.com/satori/go.uuid v1.2.0
+	github.com/stretchr/testify v1.6.1
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,16 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/gorilla/websocket v1.4.2 h1:+/TMaTYc4QFitKJxsQ7Yye35DkWvkdLcvGKqM+x0Ufc=
+github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/satori/go.uuid v1.2.0 h1:0uYX9dsZ2yD7q2RtLRtPSdGDWzjeM3TbMJP9utgA0ww=
+github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
+github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
+github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/kuzzle/kuzzle.go
+++ b/kuzzle/kuzzle.go
@@ -33,7 +33,7 @@ import (
 )
 
 const (
-	version           = "2.0.2"
+	version           = "go@2.0.2"
 	MAX_CONNECT_RETRY = 10
 )
 

--- a/kuzzle/kuzzle.go
+++ b/kuzzle/kuzzle.go
@@ -33,7 +33,7 @@ import (
 )
 
 const (
-	version           = "go@2.0.2"
+	version           = "go@3.0.0"
 	MAX_CONNECT_RETRY = 10
 )
 

--- a/kuzzle/query.go
+++ b/kuzzle/query.go
@@ -49,12 +49,12 @@ func (k *Kuzzle) Query(query *types.KuzzleRequest, options types.QueryOptions, r
 		mapped := make(map[string]interface{})
 		json.Unmarshal(query.Volatile, &mapped)
 
-		mapped["sdkVersion"] = version
+		mapped["sdkName"] = version
 
 		query.Volatile, _ = json.Marshal(mapped)
 
 	} else {
-		vol := fmt.Sprintf(`{"sdkVersion": "%s"}`, version)
+		vol := fmt.Sprintf(`{"sdkName": "%s"}`, version)
 		query.Volatile = types.VolatileData(vol)
 	}
 

--- a/kuzzle/query.go
+++ b/kuzzle/query.go
@@ -21,12 +21,12 @@ import (
 
 	"github.com/kuzzleio/sdk-go/event"
 	"github.com/kuzzleio/sdk-go/types"
-	"github.com/satori/go.uuid"
+	uuid "github.com/satori/go.uuid"
 )
 
 // Query this is a low-level method, exposed to allow advanced SDK users to bypass high-level methods.
 func (k *Kuzzle) Query(query *types.KuzzleRequest, options types.QueryOptions, responseChannel chan<- *types.KuzzleResponse) {
-	u, _ := uuid.NewV4()
+	u := uuid.NewV4()
 	requestId := u.String()
 
 	if query.RequestId == "" {

--- a/kuzzle/query_test.go
+++ b/kuzzle/query_test.go
@@ -96,7 +96,7 @@ func TestQueryWithOptions(t *testing.T) {
 
 func TestQueryWithVolatile(t *testing.T) {
 	var k *kuzzle.Kuzzle
-	var volatileData = types.VolatileData(`{"modifiedBy":"awesome me","reason":"it needed to be modified","sdkVersion":"2.0.2"}`)
+	var volatileData = types.VolatileData(`{"modifiedBy":"awesome me","reason":"it needed to be modified","sdkName":"go@2.0.2"}`)
 
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {

--- a/kuzzle/query_test.go
+++ b/kuzzle/query_test.go
@@ -96,7 +96,7 @@ func TestQueryWithOptions(t *testing.T) {
 
 func TestQueryWithVolatile(t *testing.T) {
 	var k *kuzzle.Kuzzle
-	var volatileData = types.VolatileData(`{"modifiedBy":"awesome me","reason":"it needed to be modified","sdkName":"go@2.0.2"}`)
+	var volatileData = types.VolatileData(`{"modifiedBy":"awesome me","reason":"it needed to be modified","sdkName":"go@3.0.0"}`)
 
 	c := &internal.MockedConnection{
 		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {


### PR DESCRIPTION
## What does this PR do?

This PR allows an application using this SDK to connect to a Kuzzle server running on the latest version.

Several changes had to be made:
- update the code creating UUIDs because of #259 
- update the JSON field used to send the SDK version to `sdkName`, because of https://github.com/kuzzleio/kuzzle/blob/a301d0af145d5c78ad4fc4c09140484d500b51ae/lib/api/funnel.js#L630
- update the version from `2.0.2` to `go@2.0.2` to match the new format
- update the version from `go@2.0.2` to `go@3.0.0` because `Your SDK version (2.0.2) does not match Kuzzle requirement (min: 3, max: none)`

### How should this be manually tested?

Follow the examples at https://docs.kuzzle.io/sdk/go/1/essentials/getting-started/ to connect to a Kuzzle server and create documents.

This should be tested in an environment that doesn't use a cached `github.com/satori/go.uuid`: either using Go Modules, or by updating/removing the dependency.

### Boyscout

Fixed the dependencies versions using Go Modules so dependency changes don't break things again.