### PR TITLE
[#261] Adapt document controller routes to be compliant with Kuzzle V2 API 

### DIFF
--- a/.doc/3/controllers/document/mCreate/index.md
+++ b/.doc/3/controllers/document/mCreate/index.md
@@ -41,7 +41,21 @@ Additional query options
 
 ## Return
 
-Returns an json.RawMessage containing the created documents.
+Returns a json.RawMessage containing two arrays, successes and errors.
+
+Each created document is an object of the `successes` array with the following properties:
+| Name       | Type                       | Description                                            |
+| ---------- | -------------------------- | ------------------------------------------------------ |
+| `_id`      | <pre>string</pre>          | Document ID                                            |
+| `_version` | <pre>int</pre>             | Version of the document in the persistent data storage |
+| `_source`  | <pre>json.RawMessage</pre> | Document content                                       |
+
+Each errored document is an object of the `errors` array with the following properties:
+| Name       | Type                       | Description                   |
+| ---------- | -------------------------- | ----------------------------- |
+| `document` | <pre>json.RawMessage</pre> | Document that cause the error |
+| `status`   | <pre>int</pre>             | HTTP error status             |
+| `reason`   | <pre>string</pre>          | Human readable reason         |
 
 ## Usage
 

--- a/.doc/3/controllers/document/mCreate/index.md
+++ b/.doc/3/controllers/document/mCreate/index.md
@@ -53,7 +53,7 @@ Each created document is an object of the `successes` array with the following p
 Each errored document is an object of the `errors` array with the following properties:
 | Name       | Type                       | Description                   |
 | ---------- | -------------------------- | ----------------------------- |
-| `document` | <pre>json.RawMessage</pre> | Document that cause the error |
+| `document` | <pre>json.RawMessage</pre> | Document that caused the error |
 | `status`   | <pre>int</pre>             | HTTP error status             |
 | `reason`   | <pre>string</pre>          | Human readable reason         |
 

--- a/.doc/3/controllers/document/mCreate/snippets/m-create.go
+++ b/.doc/3/controllers/document/mCreate/snippets/m-create.go
@@ -1,12 +1,12 @@
 documents := json.RawMessage(`[
-  {
-    "_id": "some-id",
-    "body": { "capacity": 4 }
-  },
-  {
-    "body": { "this": "document id is auto-computed" }
-  }
-]`)
+    {
+      "_id": "some-id",
+      "body": { "capacity": 4 }
+    },
+    {
+      "body": { "this": "document id is auto-computed" }
+    }
+  ]`)
 response, err := kuzzle.Document.MCreate(
 	"nyc-open-data",
 	"yellow-taxi",
@@ -18,58 +18,61 @@ if err != nil {
 } else {
   fmt.Println(string(response))
   /*
-  [
-    {
-      "_id":"some-id",
-      "_source":{
-          "_kuzzle_info":{
-            "active":true,
-            "author":"-1",
-            "updater":null,
-            "updatedAt":null,
-            "deletedAt":null,
-            "createdAt":1538484279484
-          },
-          "capacity":4
+  {
+    "successes": [
+      {
+        "_id":"some-id",
+        "_source":{
+            "_kuzzle_info":{
+              "active":true,
+              "author":"-1",
+              "updater":null,
+              "updatedAt":null,
+              "deletedAt":null,
+              "createdAt":1538484279484
+            },
+            "capacity":4
+        },
+        "_index":"nyc-open-data",
+        "_type":"yellow-taxi",
+        "_version":1,
+        "result":"created",
+        "_shards":{
+            "total":2,
+            "successful":1,
+            "failed":0
+        },
+        "created":true,
+        "status":201
       },
-      "_index":"nyc-open-data",
-      "_type":"yellow-taxi",
-      "_version":1,
-      "result":"created",
-      "_shards":{
-          "total":2,
-          "successful":1,
-          "failed":0
-      },
-      "created":true,
-      "status":201
-    },
-    {
-      "_id":"AWY0zxi_7XvER2v0e9xR",
-      "_source":{
-          "_kuzzle_info":{
-            "active":true,
-            "author":"-1",
-            "updater":null,
-            "updatedAt":null,
-            "deletedAt":null,
-            "createdAt":1538484279484
-          },
-          "this":"document id is auto-computed"
-      },
-      "_index":"nyc-open-data",
-      "_type":"yellow-taxi",
-      "_version":1,
-      "result":"created",
-      "_shards":{
-          "total":2,
-          "successful":1,
-          "failed":0
-      },
-      "created":true,
-      "status":201
-    }
-  ]
+      {
+        "_id":"AWY0zxi_7XvER2v0e9xR",
+        "_source":{
+            "_kuzzle_info":{
+              "active":true,
+              "author":"-1",
+              "updater":null,
+              "updatedAt":null,
+              "deletedAt":null,
+              "createdAt":1538484279484
+            },
+            "this":"document id is auto-computed"
+        },
+        "_index":"nyc-open-data",
+        "_type":"yellow-taxi",
+        "_version":1,
+        "result":"created",
+        "_shards":{
+            "total":2,
+            "successful":1,
+            "failed":0
+        },
+        "created":true,
+        "status":201
+      }
+    ],
+    errors: []
+  }
   */
   fmt.Println("Success")
 }

--- a/.doc/3/controllers/document/mCreateOrReplace/index.md
+++ b/.doc/3/controllers/document/mCreateOrReplace/index.md
@@ -54,7 +54,7 @@ Each created or replaced document is an object of the `successes` array with the
 Each errored document is an object of the `errors` array with the following properties:
 | Name       | Type                       | Description                   |
 | ---------- | -------------------------- | ----------------------------- |
-| `document` | <pre>json.RawMessage</pre> | Document that cause the error |
+| `document` | <pre>json.RawMessage</pre> | Document that caused the error |
 | `status`   | <pre>int</pre>             | HTTP error status             |
 | `reason`   | <pre>string</pre>          | Human readable reason         |
 

--- a/.doc/3/controllers/document/mCreateOrReplace/index.md
+++ b/.doc/3/controllers/document/mCreateOrReplace/index.md
@@ -41,7 +41,22 @@ Additional query options
 
 ## Return
 
-Returns an json.RawMessage containing the created documents.
+Returns a json.RawMessage containing two arrays, successes and errors.
+
+Each created or replaced document is an object of the `successes` array with the following properties:
+| Name       | Type                       | Description                                            |
+| ---------- | -------------------------- | ------------------------------------------------------ |
+| `_id`      | <pre>string</pre>          | Document ID                                            |
+| `_version` | <pre>int</pre>             | Version of the document in the persistent data storage |
+| `_source`  | <pre>json.RawMessage</pre> | Document content                                       |
+| `created`  | <pre>bool</pre>            | True if the document was created                       |
+
+Each errored document is an object of the `errors` array with the following properties:
+| Name       | Type                       | Description                   |
+| ---------- | -------------------------- | ----------------------------- |
+| `document` | <pre>json.RawMessage</pre> | Document that cause the error |
+| `status`   | <pre>int</pre>             | HTTP error status             |
+| `reason`   | <pre>string</pre>          | Human readable reason         |
 
 ## Usage
 

--- a/.doc/3/controllers/document/mCreateOrReplace/snippets/m-create-or-replace.go
+++ b/.doc/3/controllers/document/mCreateOrReplace/snippets/m-create-or-replace.go
@@ -1,13 +1,13 @@
 body := json.RawMessage(`[
-  {
-    "_id": "some-id",
-    "body": { "capacity": 4 }
-  },
-  {
-    "_id": "some-other-id",
-    "body": { "capacity": 4 }
-  }
-]`)
+    {
+      "_id": "some-id",
+      "body": { "capacity": 4 }
+    },
+    {
+      "_id": "some-other-id",
+      "body": { "capacity": 4 }
+    }
+  ]`)
 response, err := kuzzle.Document.MCreateOrReplace(
 	"nyc-open-data",
 	"yellow-taxi",
@@ -19,74 +19,77 @@ if err != nil {
 } else {
   fmt.Println(string(response))
   /*
-  [
-    {
-      "_id":"some-id",
-      "_source":{
-        "_kuzzle_info":{
+  {
+    "successes": [
+      {
+        "_id":"some-id",
+        "_source":{
+          "_kuzzle_info":{
+            "active":true,
+            "author":"-1",
+            "updater":null,
+            "updatedAt":null,
+            "deletedAt":null,
+            "createdAt":1538552685790
+          },
+          "capacity":4
+        },
+        "_index":"nyc-open-data",
+        "_type":"yellow-taxi",
+        "_version":1,
+        "result":"created",
+        "_shards":{
+          "total":2,
+          "successful":1,
+          "failed":0
+        },
+        "created":true,
+        "status":201,
+        "_meta":{
           "active":true,
           "author":"-1",
           "updater":null,
           "updatedAt":null,
           "deletedAt":null,
           "createdAt":1538552685790
+        }
+      },
+      {
+        "_id":"some-other-id",
+        "_source":{
+          "_kuzzle_info":{
+            "active":true,
+            "author":"-1",
+            "updater":null,
+            "updatedAt":null,
+            "deletedAt":null,
+            "createdAt":1538552685790
+          },
+          "capacity":4
         },
-        "capacity":4
-      },
-      "_index":"nyc-open-data",
-      "_type":"yellow-taxi",
-      "_version":1,
-      "result":"created",
-      "_shards":{
-        "total":2,
-        "successful":1,
-        "failed":0
-      },
-      "created":true,
-      "status":201,
-      "_meta":{
-        "active":true,
-        "author":"-1",
-        "updater":null,
-        "updatedAt":null,
-        "deletedAt":null,
-        "createdAt":1538552685790
-      }
-    },
-    {
-      "_id":"some-other-id",
-      "_source":{
-        "_kuzzle_info":{
+        "_index":"nyc-open-data",
+        "_type":"yellow-taxi",
+        "_version":1,
+        "result":"created",
+        "_shards":{
+          "total":2,
+          "successful":1,
+          "failed":0
+        },
+        "created":true,
+        "status":201,
+        "_meta":{
           "active":true,
           "author":"-1",
           "updater":null,
           "updatedAt":null,
           "deletedAt":null,
           "createdAt":1538552685790
-        },
-        "capacity":4
-      },
-      "_index":"nyc-open-data",
-      "_type":"yellow-taxi",
-      "_version":1,
-      "result":"created",
-      "_shards":{
-        "total":2,
-        "successful":1,
-        "failed":0
-      },
-      "created":true,
-      "status":201,
-      "_meta":{
-        "active":true,
-        "author":"-1",
-        "updater":null,
-        "updatedAt":null,
-        "deletedAt":null,
-        "createdAt":1538552685790
+        }
       }
-    }
-  ]
+    ],
+    "errors": []
+  }
   */
   fmt.Println("Success")
 }

--- a/.doc/3/controllers/document/mDelete/index.md
+++ b/.doc/3/controllers/document/mDelete/index.md
@@ -43,7 +43,16 @@ Additional query options
 
 ## Return
 
-Returns an array of strings containing the ids of the deleted documents.
+Returns a json.RawMessage containing two arrays, successes and errors.
+
+The `successes` array contain the successfuly deleted document IDs.
+
+Each deletion error is an object of the `errors` array with the following properties:
+| Name     | Type              | Description           |
+| -------- | ----------------- | --------------------- |
+| `_id`    | <pre>string</pre> | Document ID           |
+| `reason` | <pre>string</pre> | Human readable reason |
+
 
 ## Usage
 

--- a/.doc/3/controllers/document/mGet/index.md
+++ b/.doc/3/controllers/document/mGet/index.md
@@ -40,7 +40,18 @@ Additional query options
 
 ## Return
 
-Returns a json.RawMessage containing the retrieved documents.
+Returns a json.RawMessage containing two arrays, successes and errors.
+
+The `successes` array contain the list of retrieved documents.
+
+Each document have the the following properties:
+| Name       | Type                       | Description                                            |
+| ---------- | -------------------------- | ------------------------------------------------------ |
+| `_id`      | <pre>string</pre>          | Document ID                                            |
+| `_version` | <pre>int</pre>             | Version of the document in the persistent data storage |
+| `_source`  | <pre>json.RawMessage</pre> | Document content                                       |
+
+The `errors` array contain the IDs of not found documents.
 
 ## Usage
 

--- a/.doc/3/controllers/document/mReplace/index.md
+++ b/.doc/3/controllers/document/mReplace/index.md
@@ -53,7 +53,7 @@ Each replaced document is an object of the `successes` array with the following 
 Each errored document is an object of the `errors` array with the following properties:
 | Name       | Type                       | Description                   |
 | ---------- | -------------------------- | ----------------------------- |
-| `document` | <pre>json.RawMessage</pre> | Document that cause the error |
+| `document` | <pre>json.RawMessage</pre> | Document that caused the error |
 | `status`   | <pre>int</pre>             | HTTP error status             |
 | `reason`   | <pre>string</pre>          | Human readable reason         |
 

--- a/.doc/3/controllers/document/mReplace/index.md
+++ b/.doc/3/controllers/document/mReplace/index.md
@@ -41,7 +41,21 @@ Additional query options
 
 ## Return
 
-Returns a json.RawMessage containing the updated documents.
+Returns a json.RawMessage containing two arrays, successes and errors.
+
+Each replaced document is an object of the `successes` array with the following properties:
+| Name       | Type                       | Description                                            |
+| ---------- | -------------------------- | ------------------------------------------------------ |
+| `_id`      | <pre>string</pre>          | Document ID                                            |
+| `_version` | <pre>int</pre>             | Version of the document in the persistent data storage |
+| `_source`  | <pre>json.RawMessage</pre> | Document content                                       |
+
+Each errored document is an object of the `errors` array with the following properties:
+| Name       | Type                       | Description                   |
+| ---------- | -------------------------- | ----------------------------- |
+| `document` | <pre>json.RawMessage</pre> | Document that cause the error |
+| `status`   | <pre>int</pre>             | HTTP error status             |
+| `reason`   | <pre>string</pre>          | Human readable reason         |
 
 ## Usage
 

--- a/.doc/3/controllers/document/mUpdate/index.md
+++ b/.doc/3/controllers/document/mUpdate/index.md
@@ -58,7 +58,7 @@ Each updated document is an object of the `successes` array with the following p
 Each errored document is an object of the `errors` array with the following properties:
 | Name       | Type                       | Description                   |
 | ---------- | -------------------------- | ----------------------------- |
-| `document` | <pre>json.RawMessage</pre> | Document that cause the error |
+| `document` | <pre>json.RawMessage</pre> | Document that caused the error |
 | `status`   | <pre>int</pre>             | HTTP error status             |
 | `reason`   | <pre>string</pre>          | Human readable reason         |
 

--- a/.doc/3/controllers/document/mUpdate/index.md
+++ b/.doc/3/controllers/document/mUpdate/index.md
@@ -46,7 +46,21 @@ Additional query options
 
 ## Return
 
-Returns a json.RawMessage containing the update documetns.
+Returns a json.RawMessage containing two arrays, successes and errors.
+
+Each updated document is an object of the `successes` array with the following properties:
+| Name       | Type                       | Description                                            |
+| ---------- | -------------------------- | ------------------------------------------------------ |
+| `_id`      | <pre>string</pre>          | Document ID                                            |
+| `_version` | <pre>int</pre>             | Version of the document in the persistent data storage |
+| `_source`  | <pre>json.RawMessage</pre> | Document content                                       |
+
+Each errored document is an object of the `errors` array with the following properties:
+| Name       | Type                       | Description                   |
+| ---------- | -------------------------- | ----------------------------- |
+| `document` | <pre>json.RawMessage</pre> | Document that cause the error |
+| `status`   | <pre>int</pre>             | HTTP error status             |
+| `reason`   | <pre>string</pre>          | Human readable reason         |
 
 ## Usage
 

--- a/document/mCreate.go
+++ b/document/mCreate.go
@@ -56,11 +56,5 @@ func (d *Document) MCreate(index string, collection string, documents json.RawMe
 		return nil, res.Error
 	}
 
-	type r struct {
-		Hits json.RawMessage `json:"hits"`
-	}
-	var docs r
-	json.Unmarshal(res.Result, &docs)
-
-	return docs.Hits, nil
+	return res.Result, nil
 }

--- a/document/mCreateOrReplace.go
+++ b/document/mCreateOrReplace.go
@@ -56,11 +56,5 @@ func (d *Document) MCreateOrReplace(index string, collection string, documents j
 		return nil, res.Error
 	}
 
-	type r struct {
-		Hits json.RawMessage `json:"hits"`
-	}
-	var docs r
-	json.Unmarshal(res.Result, &docs)
-
-	return docs.Hits, nil
+	return res.Result, nil
 }

--- a/document/mCreateOrReplace_test.go
+++ b/document/mCreateOrReplace_test.go
@@ -76,7 +76,7 @@ func TestMCreateOrReplaceDocument(t *testing.T) {
 			assert.Equal(t, "collection", parsedQuery.Collection)
 
 			return &types.KuzzleResponse{Result: []byte(`{
-				"hits": [
+				"successes": [
 					{
 						"_id": "id1",
 						"_index": "index",
@@ -102,7 +102,7 @@ func TestMCreateOrReplaceDocument(t *testing.T) {
 						"result": "created"
 					}
 				],
-				"total": "1"
+				"errors": []
 			}`),
 			}
 		},

--- a/document/mCreate_test.go
+++ b/document/mCreate_test.go
@@ -76,7 +76,7 @@ func TestMCreateDocument(t *testing.T) {
 			assert.Equal(t, "collection", parsedQuery.Collection)
 
 			return &types.KuzzleResponse{Result: []byte(`{
-				"hits": [
+				"successes": [
 					{
 						"_id": "id1",
 						"_index": "index",
@@ -102,7 +102,7 @@ func TestMCreateDocument(t *testing.T) {
 						"result": "created"
 					}
 				],
-				"total": "1"
+				"errors": []
 			}`),
 			}
 		},

--- a/document/mDelete.go
+++ b/document/mDelete.go
@@ -21,7 +21,7 @@ import (
 )
 
 // MDelete deletes multiple documents at once
-func (d *Document) MDelete(index string, collection string, ids []string, options types.QueryOptions) ([]string, error) {
+func (d *Document) MDelete(index string, collection string, ids []string, options types.QueryOptions) (json.RawMessage, error) {
 	if index == "" {
 		return nil, types.NewError("Document.MDelete: index required", 400)
 	}
@@ -56,8 +56,5 @@ func (d *Document) MDelete(index string, collection string, ids []string, option
 		return nil, res.Error
 	}
 
-	var mDeleted []string
-	json.Unmarshal(res.Result, &mDeleted)
-
-	return mDeleted, nil
+	return res.Result, nil
 }

--- a/document/mDelete_test.go
+++ b/document/mDelete_test.go
@@ -84,7 +84,8 @@ func TestMDeleteDocument(t *testing.T) {
 
 			return &types.KuzzleResponse{Result: []byte(`
 			{
-				"ids": ["id1", "id2"]
+				"successes": ["id1", "id2"],
+				errors: []
 			}`),
 			}
 		},

--- a/document/mDelete_test.go
+++ b/document/mDelete_test.go
@@ -85,7 +85,7 @@ func TestMDeleteDocument(t *testing.T) {
 			return &types.KuzzleResponse{Result: []byte(`
 			{
 				"successes": ["id1", "id2"],
-				errors: []
+				"errors": []
 			}`),
 			}
 		},

--- a/document/mGet.go
+++ b/document/mGet.go
@@ -59,11 +59,5 @@ func (d *Document) MGet(index string, collection string, ids []string, options t
 		return nil, res.Error
 	}
 
-	type r struct {
-		Hits json.RawMessage `json:"hits"`
-	}
-	var docs r
-	json.Unmarshal(res.Result, &docs)
-
-	return docs.Hits, nil
+	return res.Result, nil
 }

--- a/document/mGet_test.go
+++ b/document/mGet_test.go
@@ -80,7 +80,7 @@ func TestMGetDocument(t *testing.T) {
 
 			return &types.KuzzleResponse{Result: []byte(`
 			{
-				"hits": [
+				"successes": [
 					{
 						"_id": "id1",
 						"_index": "index",
@@ -106,7 +106,7 @@ func TestMGetDocument(t *testing.T) {
 						"result": "created"
 					}
 				],
-				"total": "1"
+				"errors": []
 			}`),
 			}
 		},

--- a/document/mReplace.go
+++ b/document/mReplace.go
@@ -56,11 +56,5 @@ func (d *Document) MReplace(index string, collection string, documents json.RawM
 		return nil, res.Error
 	}
 
-	type r struct {
-		Hits json.RawMessage `json:"hits"`
-	}
-	var docs r
-	json.Unmarshal(res.Result, &docs)
-
-	return docs.Hits, nil
+	return res.Result, nil
 }

--- a/document/mReplace_test.go
+++ b/document/mReplace_test.go
@@ -77,7 +77,7 @@ func TestMReplaceDocument(t *testing.T) {
 
 			return &types.KuzzleResponse{Result: []byte(`
 			{
-				"hits": [
+				"successes": [
 					{
 						"_id": "id1",
 						"_index": "index",
@@ -103,7 +103,7 @@ func TestMReplaceDocument(t *testing.T) {
 						"result": "created"
 					}
 				],
-				"total": "1"
+				"errors": []
 			}`),
 			}
 		},

--- a/document/mUpdate.go
+++ b/document/mUpdate.go
@@ -56,11 +56,5 @@ func (d *Document) MUpdate(index string, collection string, documents json.RawMe
 		return nil, res.Error
 	}
 
-	type r struct {
-		Hits json.RawMessage `json:"hits"`
-	}
-	var docs r
-	json.Unmarshal(res.Result, &docs)
-
-	return docs.Hits, nil
+	return res.Result, nil
 }

--- a/document/mUpdate_test.go
+++ b/document/mUpdate_test.go
@@ -77,7 +77,7 @@ func TestMUpdateDocument(t *testing.T) {
 
 			return &types.KuzzleResponse{Result: []byte(`
 			{
-				"hits": [
+				"successes": [
 					{
 						"_id": "id1",
 						"_index": "index",
@@ -103,7 +103,7 @@ func TestMUpdateDocument(t *testing.T) {
 						"result": "created"
 					}
 				],
-				"total": "1"
+				"errors": []
 			}`),
 			}
 		},


### PR DESCRIPTION
<!--
  This template is optional.
  It simply serves to provide a guide to allow a better review of pull requests.
-->

<!--
  IMPORTANT
  Don't forget to add the corresponding "changelog:xxx" label to your PR.
  This is part of our release process in order to generate the change log.
-->


## What does this PR do?
This PR modifies the following document controller routes and their documentation to be compliant with Kuzzle V2 API:
- mCreate
- mCreateOrReplace
- mDelete
- mGet
- mUpdate
- mReplace

Fix #261 