### PR TITLE
Fix CI, travis version, documentation version and snippets on 3-dev

### DIFF
--- a/.ci/doc/config.yml
+++ b/.ci/doc/config.yml
@@ -2,7 +2,7 @@
 
 snippets:
   mount: /mnt
-  path: '.doc/**/*.test.yml'
+  path: '.doc/**/snippets/*.test.yml'
   templates: /mnt/.ci/doc/templates
 
 runners:

--- a/.ci/doc/docker-compose.yml
+++ b/.ci/doc/docker-compose.yml
@@ -45,6 +45,7 @@ services:
     image: golang:alpine
     volumes:
       - ../..:/mnt
+      - ../..:/go/src/github.com/kuzzleio/sdk-go
       - snippets:/var/snippets
     command: >
       ash -c '
@@ -56,7 +57,6 @@ services:
          github.com/gorilla/websocket \
          golang.org/x/tools/cmd/goimports \
          golang.org/x/lint/golint;
-        go get github.com/kuzzleio/sdk-go;
         touch /tmp/runner_ready_to_lint;
         touch /tmp/runner_is_ready;
         tail -f /dev/null

--- a/.ci/doc/docker-compose.yml
+++ b/.ci/doc/docker-compose.yml
@@ -2,10 +2,9 @@ version: '3'
 
 services:
   kuzzle:
-    image: kuzzleio/kuzzle:1
+    image: kuzzleio/kuzzle:2
     ports:
       - '7512:7512'
-      - '1883:1883'
     cap_add:
       - SYS_PTRACE
     depends_on:
@@ -13,21 +12,19 @@ services:
       - elasticsearch
     container_name: kuzzle
     environment:
-      - kuzzle_services__db__client__host=http://elasticsearch:9200
+      - kuzzle_services__storageEngine__client__node=http://elasticsearch:9200
       - kuzzle_services__internalCache__node__host=redis
       - kuzzle_services__memoryStorage__node__host=redis
-      - NODE_END=production
+      - kuzzle_services__storageEngine__commonMapping__dynamic=true
+      - NODE_ENV=production
 
   redis:
     image: redis:5
 
   elasticsearch:
-    image: kuzzleio/elasticsearch:5.6.10
+    image: kuzzleio/elasticsearch:7
     ulimits:
       nofile: 65536
-    environment:
-      - cluster.name=kuzzle
-      - 'ES_JAVA_OPTS=-Xms256m -Xmx256m'
 
   doc-tests:
     image: kuzzleio/snippets-tests

--- a/.doc/3/controllers/auth/check-token/snippets/check-token.test.yml
+++ b/.doc/3/controllers/auth/check-token/snippets/check-token.test.yml
@@ -7,4 +7,4 @@ template: default
 expected: Success
 
 sdk: go
-version: 1
+version: 3

--- a/.doc/3/controllers/auth/create-my-credentials/snippets/create-my-credentials.test.yml
+++ b/.doc/3/controllers/auth/create-my-credentials/snippets/create-my-credentials.test.yml
@@ -7,4 +7,4 @@ template: default
 expected: Success
 
 sdk: go
-version: 1
+version: 3

--- a/.doc/3/controllers/auth/credentials-exist/snippets/credentials-exist.test.yml
+++ b/.doc/3/controllers/auth/credentials-exist/snippets/credentials-exist.test.yml
@@ -7,4 +7,4 @@ template: default
 expected: Success
 
 sdk: go
-version: 1
+version: 3

--- a/.doc/3/controllers/auth/delete-my-credentials/snippets/delete-my-credentials.test.yml
+++ b/.doc/3/controllers/auth/delete-my-credentials/snippets/delete-my-credentials.test.yml
@@ -6,4 +6,4 @@ hooks:
 template: default
 expected: Success
 sdk: go
-version: 1
+version: 3

--- a/.doc/3/controllers/auth/get-current-user/snippets/get-current-user.test.yml
+++ b/.doc/3/controllers/auth/get-current-user/snippets/get-current-user.test.yml
@@ -7,4 +7,4 @@ template: default
 expected: Success
 
 sdk: go
-version: 1
+version: 3

--- a/.doc/3/controllers/auth/get-my-credentials/snippets/get-my-credentials.test.yml
+++ b/.doc/3/controllers/auth/get-my-credentials/snippets/get-my-credentials.test.yml
@@ -7,4 +7,4 @@ template: default
 expected: Success
 
 sdk: go
-version: 1
+version: 3

--- a/.doc/3/controllers/auth/get-my-rights/snippets/get-my-rights.test.yml
+++ b/.doc/3/controllers/auth/get-my-rights/snippets/get-my-rights.test.yml
@@ -7,4 +7,4 @@ template: default
 expected: Success
 
 sdk: go
-version: 1
+version: 3

--- a/.doc/3/controllers/auth/get-strategies/snippets/get-strategies.test.yml
+++ b/.doc/3/controllers/auth/get-strategies/snippets/get-strategies.test.yml
@@ -7,4 +7,4 @@ template: default
 expected: Success
 
 sdk: go
-version: 1
+version: 3

--- a/.doc/3/controllers/auth/login/snippets/login.test.yml
+++ b/.doc/3/controllers/auth/login/snippets/login.test.yml
@@ -8,4 +8,4 @@ template: default
 expected: Success
 
 sdk: go
-version: 1
+version: 3

--- a/.doc/3/controllers/auth/logout/snippets/logout.test.yml
+++ b/.doc/3/controllers/auth/logout/snippets/logout.test.yml
@@ -7,4 +7,4 @@ template: default
 expected: Success
 
 sdk: go
-version: 1
+version: 3

--- a/.doc/3/controllers/auth/update-my-credentials/snippets/update-my-credentials.test.yml
+++ b/.doc/3/controllers/auth/update-my-credentials/snippets/update-my-credentials.test.yml
@@ -7,4 +7,4 @@ template: default
 expected: Success
 
 sdk: go
-version: 1
+version: 3

--- a/.doc/3/controllers/auth/update-self/snippets/update-self.test.yml
+++ b/.doc/3/controllers/auth/update-self/snippets/update-self.test.yml
@@ -7,4 +7,4 @@ template: default
 expected: Success
 
 sdk: go
-version: 1
+version: 3

--- a/.doc/3/controllers/auth/validate-my-credentials/snippets/validate-my-credentials.test.yml
+++ b/.doc/3/controllers/auth/validate-my-credentials/snippets/validate-my-credentials.test.yml
@@ -7,4 +7,4 @@ template: default
 expected: Success
 
 sdk: go
-version: 1
+version: 3

--- a/.doc/3/controllers/collection/create/snippets/create.test.yml
+++ b/.doc/3/controllers/collection/create/snippets/create.test.yml
@@ -7,4 +7,4 @@ template: default
 expected: Success
 
 sdk: go
-version: 1
+version: 3

--- a/.doc/3/controllers/collection/delete-specifications/snippets/delete-specifications.test.yml
+++ b/.doc/3/controllers/collection/delete-specifications/snippets/delete-specifications.test.yml
@@ -7,4 +7,4 @@ template: default
 expected: Success
 
 sdk: go
-version: 1
+version: 3

--- a/.doc/3/controllers/collection/exists/snippets/exists.test.yml
+++ b/.doc/3/controllers/collection/exists/snippets/exists.test.yml
@@ -7,4 +7,4 @@ template: default
 expected: Success
 
 sdk: go
-version: 1
+version: 3

--- a/.doc/3/controllers/collection/get-mapping/snippets/get-mapping.test.yml
+++ b/.doc/3/controllers/collection/get-mapping/snippets/get-mapping.test.yml
@@ -7,4 +7,4 @@ template: default
 expected: Success
 
 sdk: go
-version: 1
+version: 3

--- a/.doc/3/controllers/collection/get-specifications/snippets/get-specifications.test.yml
+++ b/.doc/3/controllers/collection/get-specifications/snippets/get-specifications.test.yml
@@ -1,10 +1,14 @@
 name: collection#getSpecifications
 description: Returns the validation specifications
 hooks:
-  before: "curl -X POST kuzzle:7512/nyc-open-data/_create && curl -X PUT kuzzle:7512/nyc-open-data/yellow-taxi && curl -X PUT -H \"Content-Type: application/json\" -d '{\"nyc-open-data\": {\"yellow-taxi\": {\"strict\": false,\"fields\": {\"license\": {\"type\": \"string\"}}}}}' kuzzle:7512/_specifications"
+  before: |
+    curl -X DELETE kuzzle:7512/nyc-open-data
+    curl -X POST kuzzle:7512/nyc-open-data/_create
+    curl -X PUT kuzzle:7512/nyc-open-data/yellow-taxi
+    curl -X PUT -H "Content-Type: application/json" -d '{"strict": false, "fields": {"license": {"type": "string"} } }' kuzzle:7512/nyc-open-data/yellow-taxi/_specifications
   after:
 template: default
 expected: Success
 
 sdk: go
-version: 1
+version: 3

--- a/.doc/3/controllers/collection/list/snippets/list.test.yml
+++ b/.doc/3/controllers/collection/list/snippets/list.test.yml
@@ -7,4 +7,4 @@ template: default
 expected: Success
 
 sdk: go
-version: 1
+version: 3

--- a/.doc/3/controllers/collection/refresh/index.md
+++ b/.doc/3/controllers/collection/refresh/index.md
@@ -1,0 +1,40 @@
+---
+code: true
+type: page
+title: refresh
+description: Forces an Elasticsearch search index update
+---
+
+# refresh
+
+Refreshes a collection to reindex the written and deleted documents so they are available in search results.
+
+:::info
+A refresh operation comes with some performance costs.
+
+From the [Elasticsearch documentation](https://www.elastic.co/guide/en/elasticsearch/reference/7.3/docs-refresh.html):
+> "While a refresh is much lighter than a commit, it still has a performance cost. A manual refresh can be useful when writing tests, but don’t do a manual refresh every time you index a document in production; it will hurt your performance. Instead, your application needs to be aware of the near real-time nature of Elasticsearch and make allowances for it."
+
+:::
+
+<br/>
+
+## Arguments
+
+```go
+Refresh(index string, collection string, options types.QueryOptions) error
+```
+
+| Arguments    | Type            | Description
+| ------------ | --------------- | -------------------------------------- |
+| `index`      | <pre>string</pre>          | Index name                             |
+| `collection` | <pre>string</pre>          | Collection name                        |
+| `options`    | <pre>QueryOptions</pre>    | Query options                          |
+
+## Resolves
+
+Resolves when the refresh has been done.
+
+## Usage
+
+<<< ./snippets/refresh.go

--- a/.doc/3/controllers/collection/refresh/snippets/refresh.go
+++ b/.doc/3/controllers/collection/refresh/snippets/refresh.go
@@ -1,4 +1,4 @@
-_, err := kuzzle.Server.GetAllStats(nil)
+err := kuzzle.Collection.Refresh("nyc-open-data", "yellow-taxi", nil)
 
 if err != nil {
   log.Fatal(err)

--- a/.doc/3/controllers/collection/refresh/snippets/refresh.test.yml
+++ b/.doc/3/controllers/collection/refresh/snippets/refresh.test.yml
@@ -1,0 +1,12 @@
+name: collection#refresh
+description: Refresh a collection
+hooks:
+  before: |
+    curl -X POST kuzzle:7512/nyc-open-data/_create
+    curl -X PUT kuzzle:7512/nyc-open-data/yellow-taxi
+  after:
+template: default
+expected: Success
+
+sdk: go
+version: 3

--- a/.doc/3/controllers/collection/search-specifications/snippets/search-specifications.test.yml
+++ b/.doc/3/controllers/collection/search-specifications/snippets/search-specifications.test.yml
@@ -21,4 +21,4 @@ hooks:
 template: default
 expected: Successfully retrieved 1 specifications
 sdk: go
-version: 1
+version: 3

--- a/.doc/3/controllers/collection/truncate/snippets/truncate.test.yml
+++ b/.doc/3/controllers/collection/truncate/snippets/truncate.test.yml
@@ -7,4 +7,4 @@ template: default
 expected: Success
 
 sdk: go
-version: 1
+version: 3

--- a/.doc/3/controllers/collection/update-mapping/snippets/update-mapping.test.yml
+++ b/.doc/3/controllers/collection/update-mapping/snippets/update-mapping.test.yml
@@ -7,4 +7,4 @@ template: default
 expected: Success
 
 sdk: go
-version: 1
+version: 3

--- a/.doc/3/controllers/collection/update-specifications/snippets/update-specifications.test.yml
+++ b/.doc/3/controllers/collection/update-specifications/snippets/update-specifications.test.yml
@@ -1,10 +1,13 @@
 name: collection#updateSpecifications
 description: Update the validation specifications
 hooks:
-  before: curl -X POST kuzzle:7512/nyc-open-data/_create && curl -X PUT kuzzle:7512/nyc-open-data/green-taxi
+  before: |
+    curl -X DELETE kuzzle:7512:/nyc-open-data
+    curl -X POST kuzzle:7512/nyc-open-data/_create
+    curl -X PUT kuzzle:7512/nyc-open-data/green-taxi
   after: curl -X DELETE kuzzle:7512/nyc-open-data/yellow-taxi/_specifications
 template: default
 expected: Success
 
 sdk: go
-version: 1
+version: 3

--- a/.doc/3/controllers/collection/validate-specifications/snippets/validate-specifications.test.yml
+++ b/.doc/3/controllers/collection/validate-specifications/snippets/validate-specifications.test.yml
@@ -7,4 +7,4 @@ template: default
 expected: Success
 
 sdk: go
-version: 1
+version: 3

--- a/.doc/3/controllers/document/count/snippets/count.test.yml
+++ b/.doc/3/controllers/document/count/snippets/count.test.yml
@@ -19,4 +19,4 @@ template: default
 expected: Found 5 documents matching licence:valid
 
 sdk: go
-version: 1
+version: 3

--- a/.doc/3/controllers/document/count/snippets/count.test.yml
+++ b/.doc/3/controllers/document/count/snippets/count.test.yml
@@ -12,7 +12,7 @@ hooks:
     for i in 1 2 3 4 5; do
       curl -H "Content-type: application/json" -d '{}' kuzzle:7512/nyc-open-data/yellow-taxi/_create
     done
-    curl -XPOST kuzzle:7512/nyc-open-data/_refresh
+    curl -X POST kuzzle:7512/nyc-open-data/yellow-taxi/_refresh
   after: |
     curl -XDELETE kuzzle:7512/nyc-open-data
 template: default

--- a/.doc/3/controllers/document/create/snippets/create.test.yml
+++ b/.doc/3/controllers/document/create/snippets/create.test.yml
@@ -11,4 +11,4 @@ template: default
 expected: Success
 
 sdk: go
-version: 1
+version: 3

--- a/.doc/3/controllers/document/createOrReplace/snippets/create-or-replace.test.yml
+++ b/.doc/3/controllers/document/createOrReplace/snippets/create-or-replace.test.yml
@@ -11,4 +11,4 @@ template: default
 expected: Success
 
 sdk: go
-version: 1
+version: 3

--- a/.doc/3/controllers/document/delete/snippets/delete.test.yml
+++ b/.doc/3/controllers/document/delete/snippets/delete.test.yml
@@ -12,4 +12,4 @@ template: default
 expected: Success
 
 sdk: go
-version: 1
+version: 3

--- a/.doc/3/controllers/document/deleteByQuery/snippets/delete-by-query.test.yml
+++ b/.doc/3/controllers/document/deleteByQuery/snippets/delete-by-query.test.yml
@@ -14,7 +14,7 @@ hooks:
       curl -H "Content-type: application/json" -d '{"capacity": 7}' kuzzle:7512/nyc-open-data/yellow-taxi/_create
     done
 
-    curl -XPOST kuzzle:7512/nyc-open-data/_refresh
+    curl -XPOST kuzzle:7512/nyc-open-data/yellow-taxi/_refresh
   after: |
     curl -XDELETE kuzzle:7512/nyc-open-data
 template: default

--- a/.doc/3/controllers/document/deleteByQuery/snippets/delete-by-query.test.yml
+++ b/.doc/3/controllers/document/deleteByQuery/snippets/delete-by-query.test.yml
@@ -21,4 +21,4 @@ template: default
 expected: Successfully deleted 5 documents
 
 sdk: go
-version: 1
+version: 3

--- a/.doc/3/controllers/document/get/snippets/get.test.yml
+++ b/.doc/3/controllers/document/get/snippets/get.test.yml
@@ -11,4 +11,4 @@ template: default
 expected: Success
 
 sdk: go
-version: 1
+version: 3

--- a/.doc/3/controllers/document/mCreate/snippets/m-create.test.yml
+++ b/.doc/3/controllers/document/mCreate/snippets/m-create.test.yml
@@ -11,4 +11,4 @@ template: default
 expected: Success
 
 sdk: go
-version: 1
+version: 3

--- a/.doc/3/controllers/document/mCreateOrReplace/snippets/m-create-or-replace.test.yml
+++ b/.doc/3/controllers/document/mCreateOrReplace/snippets/m-create-or-replace.test.yml
@@ -11,4 +11,4 @@ template: default
 expected: Success
 
 sdk: go
-version: 1
+version: 3

--- a/.doc/3/controllers/document/mDelete/snippets/m-delete.go
+++ b/.doc/3/controllers/document/mDelete/snippets/m-delete.go
@@ -14,10 +14,17 @@ kuzzle.Document.Create(
 	json.RawMessage(`{}`),
 	nil)
 
-deleted, err := kuzzle.Document.MDelete("nyc-open-data", "yellow-taxi", ids, nil)
+	
+deletedJSON, err := kuzzle.Document.MDelete("nyc-open-data", "yellow-taxi", ids, nil)
 
 if err != nil {
   log.Fatal(err)
 } else {
-  fmt.Printf("Successfully deleted %d documents", len(deleted))
+	type deletedResult struct {
+		Successes []json.RawMessage `json:"successes"`
+		Errors 	  []json.RawMessage `json:"errors"`
+	}
+	var deleted deletedResult
+	json.Unmarshal(deletedJSON, &deleted)
+  	fmt.Printf("Successfully deleted %d documents", len(deleted.Successes))
 }

--- a/.doc/3/controllers/document/mDelete/snippets/m-delete.test.yml
+++ b/.doc/3/controllers/document/mDelete/snippets/m-delete.test.yml
@@ -11,4 +11,4 @@ template: default
 expected: Successfully deleted 2 documents
 
 sdk: go
-version: 1
+version: 3

--- a/.doc/3/controllers/document/mGet/snippets/m-get.test.yml
+++ b/.doc/3/controllers/document/mGet/snippets/m-get.test.yml
@@ -11,4 +11,4 @@ template: default
 expected: Success
 
 sdk: go
-version: 1
+version: 3

--- a/.doc/3/controllers/document/mReplace/snippets/m-replace.test.yml
+++ b/.doc/3/controllers/document/mReplace/snippets/m-replace.test.yml
@@ -11,4 +11,4 @@ template: default
 expected: Success
 
 sdk: go
-version: 1
+version: 3

--- a/.doc/3/controllers/document/mUpdate/snippets/m-update.test.yml
+++ b/.doc/3/controllers/document/mUpdate/snippets/m-update.test.yml
@@ -11,4 +11,4 @@ template: default
 expected: Success
 
 sdk: go
-version: 1
+version: 3

--- a/.doc/3/controllers/document/replace/snippets/replace.test.yml
+++ b/.doc/3/controllers/document/replace/snippets/replace.test.yml
@@ -10,4 +10,4 @@ template: default
 expected: Success
 
 sdk: go
-version: 1
+version: 3

--- a/.doc/3/controllers/document/search/snippets/search.go
+++ b/.doc/3/controllers/document/search/snippets/search.go
@@ -8,7 +8,7 @@ for i := 5; i < 15; i++ {
     "category": "limousine"
   }`), nil)
 }
-kuzzle.Index.Refresh("nyc-open-data", nil)
+kuzzle.Collection.Refresh("nyc-open-data", "yellow-taxi", nil)
 
 options := types.NewQueryOptions()
 options.SetFrom(0)

--- a/.doc/3/controllers/document/search/snippets/search.test.yml
+++ b/.doc/3/controllers/document/search/snippets/search.test.yml
@@ -2,13 +2,13 @@ name: document#search
 description: Search documents
 hooks:
   before: |
-    curl -XDELETE kuzzle:7512/nyc-open-data
-    curl -XPOST kuzzle:7512/nyc-open-data/_create
-    curl -XPUT kuzzle:7512/nyc-open-data/yellow-taxi
+    curl -X DELETE kuzzle:7512/nyc-open-data
+    curl -X POST kuzzle:7512/nyc-open-data/_create
+    curl -X PUT kuzzle:7512/nyc-open-data/yellow-taxi
   after: |
     curl -XDELETE kuzzle:7512/nyc-open-data
 template: default
 expected: ^Successfully retrieved 5 documents$
 
 sdk: go
-version: 1
+version: 3

--- a/.doc/3/controllers/document/update/snippets/update.test.yml
+++ b/.doc/3/controllers/document/update/snippets/update.test.yml
@@ -8,7 +8,7 @@ hooks:
   after: |
     curl -XDELETE kuzzle:7512/nyc-open-data
 template: default
-expected: '{"_index":"nyc-open-data","_type":"yellow-taxi","_id":"some-id","_version":2,"result":"updated","'
+expected: {"_id":"some-id","_source":{.*}, "_version":2}
 
 sdk: go
-version: 1
+version: 3

--- a/.doc/3/controllers/document/validate/snippets/validate.test.yml
+++ b/.doc/3/controllers/document/validate/snippets/validate.test.yml
@@ -11,4 +11,4 @@ template: default
 expected: Success
 
 sdk: go
-version: 1
+version: 3

--- a/.doc/3/controllers/index/create/snippets/create.test.yml
+++ b/.doc/3/controllers/index/create/snippets/create.test.yml
@@ -8,4 +8,4 @@ template: default
 expected: index created
 
 sdk: go
-version: 1
+version: 3

--- a/.doc/3/controllers/index/delete/snippets/delete.test.yml
+++ b/.doc/3/controllers/index/delete/snippets/delete.test.yml
@@ -8,4 +8,4 @@ template: default
 expected: index deleted
 
 sdk: go
-version: 1
+version: 3

--- a/.doc/3/controllers/index/exists/snippets/exists.test.yml
+++ b/.doc/3/controllers/index/exists/snippets/exists.test.yml
@@ -8,4 +8,4 @@ template: default
 expected: index exists
 
 sdk: go
-version: 1
+version: 3

--- a/.doc/3/controllers/index/list/snippets/list.test.yml
+++ b/.doc/3/controllers/index/list/snippets/list.test.yml
@@ -8,4 +8,4 @@ template: default
 expected: Kuzzle contains 1 indexes
 
 sdk: go
-version: 1
+version: 3

--- a/.doc/3/controllers/index/m-delete/snippets/mDelete.test.yml
+++ b/.doc/3/controllers/index/m-delete/snippets/mDelete.test.yml
@@ -2,10 +2,12 @@
 name: index#mDelete
 description: Delete multiple indexes
 hooks:
-  before: curl -X POST kuzzle:7512/nyc-open-data/_create ; curl -X POST kuzzle:7512/mtp-open-data/_create
+  before: |
+    curl -X POST kuzzle:7512/nyc-open-data/_create
+    curl -X POST kuzzle:7512/mtp-open-data/_create
   after: 
 template: default
 expected: Successfully deleted 2 indexes
 
 sdk: go
-version: 1
+version: 3

--- a/.doc/3/controllers/realtime/count/snippets/count.test.yml
+++ b/.doc/3/controllers/realtime/count/snippets/count.test.yml
@@ -7,4 +7,4 @@ template: default
 expected: Currently 1 active subscription
 
 sdk: go
-version: 1
+version: 3

--- a/.doc/3/controllers/realtime/publish/snippets/publish.test.yml
+++ b/.doc/3/controllers/realtime/publish/snippets/publish.test.yml
@@ -7,4 +7,4 @@ template: default
 expected: Success
 
 sdk: go
-version: 1
+version: 3

--- a/.doc/3/controllers/realtime/subscribe/snippets/document-notifications-leave-scope.test.yml
+++ b/.doc/3/controllers/realtime/subscribe/snippets/document-notifications-leave-scope.test.yml
@@ -7,4 +7,4 @@ template: realtime
 expected: Document moved out from the scope
 
 sdk: go
-version: 1
+version: 3

--- a/.doc/3/controllers/realtime/subscribe/snippets/document-notifications.test.yml
+++ b/.doc/3/controllers/realtime/subscribe/snippets/document-notifications.test.yml
@@ -7,4 +7,4 @@ template: realtime
 expected: Document nina-vkote enter the scope
 
 sdk: go
-version: 1
+version: 3

--- a/.doc/3/controllers/realtime/subscribe/snippets/message-notifications.test.yml
+++ b/.doc/3/controllers/realtime/subscribe/snippets/message-notifications.test.yml
@@ -7,4 +7,4 @@ template: realtime
 expected: Message notification received
 
 sdk: go
-version: 1
+version: 3

--- a/.doc/3/controllers/realtime/subscribe/snippets/user-notifications.test.yml
+++ b/.doc/3/controllers/realtime/subscribe/snippets/user-notifications.test.yml
@@ -6,4 +6,4 @@ hooks:
 template: realtime
 expected: "\"username\":\"nina vkote\""
 sdk: go
-version: 1
+version: 3

--- a/.doc/3/controllers/realtime/unsubscribe/snippets/unsubscribe.test.yml
+++ b/.doc/3/controllers/realtime/unsubscribe/snippets/unsubscribe.test.yml
@@ -7,4 +7,4 @@ template: default
 expected: Success
 
 sdk: go
-version: 1
+version: 3

--- a/.doc/3/controllers/server/admin-exists/snippets/admin-exists.test.yml
+++ b/.doc/3/controllers/server/admin-exists/snippets/admin-exists.test.yml
@@ -7,4 +7,4 @@ template: default
 expected: ^(Admin exists\?) (true|false)$
 
 sdk: go
-version: 1
+version: 3

--- a/.doc/3/controllers/server/get-all-stats/snippets/get-all-stats.test.yml
+++ b/.doc/3/controllers/server/get-all-stats/snippets/get-all-stats.test.yml
@@ -4,7 +4,7 @@ hooks:
   before:
   after:
 template: default
-expected: ^(All Kuzzle Stats as JSON string:) {"hits":\[({"connections":{.*},"ongoingRequests":{.*},"completedRequests":{.*},"failedRequests":{.*},"timestamp":[0-9]{13}}(,)*\]),"total":[0-9]+}$
+expected: Success
 
 sdk: go
-version: 1
+version: 3

--- a/.doc/3/controllers/server/get-config/snippets/get-config.test.yml
+++ b/.doc/3/controllers/server/get-config/snippets/get-config.test.yml
@@ -4,7 +4,6 @@ hooks:
   before:
   after:
 template: default
-expected: ^Kuzzle Server configuration as JSON string: .*$
-
+expected: ^(Kuzzle Server configuration as JSON string:) .*$
 sdk: go
 version: 1

--- a/.doc/3/controllers/server/get-config/snippets/get-config.test.yml
+++ b/.doc/3/controllers/server/get-config/snippets/get-config.test.yml
@@ -6,4 +6,4 @@ hooks:
 template: default
 expected: ^(Kuzzle Server configuration as JSON string:) .*$
 sdk: go
-version: 1
+version: 3

--- a/.doc/3/controllers/server/get-last-stats/snippets/get-last-stats.test.yml
+++ b/.doc/3/controllers/server/get-last-stats/snippets/get-last-stats.test.yml
@@ -4,7 +4,7 @@ hooks:
   before:
   after:
 template: default
-expected: ^(Last Kuzzle Stats as JSON string:) {("connections":{.*}),("ongoingRequests":{.*}),("completedRequests":{.*}),("failedRequests":{.*}),("timestamp":[0-9]{13})}$
+expected: ^(Last Kuzzle Stats as JSON string:) {.*}$
 
 sdk: go
-version: 1
+version: 3

--- a/.doc/3/controllers/server/get-stats/snippets/get-stats.test.yml
+++ b/.doc/3/controllers/server/get-stats/snippets/get-stats.test.yml
@@ -4,7 +4,7 @@ hooks:
   before:
   after:
 template: default
-expected: ^(Kuzzle Stats as JSON string:) {"hits":\[({"connections":{.*},"ongoingRequests":{.*},"completedRequests":{.*},"failedRequests":{.*},"timestamp":[0-9]{13}}(,)*)*\],"total":[0-9]+}$
+expected: ^(Kuzzle Stats as JSON string:) {"hits":\[.*],"total":[0-9]+}$
 
 sdk: go
-version: 1
+version: 3

--- a/.doc/3/controllers/server/info/snippets/info.test.yml
+++ b/.doc/3/controllers/server/info/snippets/info.test.yml
@@ -4,6 +4,6 @@ hooks:
   before:
   after:
 template: default
-expected: "^Kuzzle Server information as JSON string: {\"serverInfo\":{\"kuzzle\":{\"version\":\"[0-9]\\.[0-9]\\.[0-9]\",\"api\":{.*"
+expected: 'Kuzzle Server information as JSON string: {"serverInfo":{"kuzzle":{.*}}}'
 sdk: go
-version: 1
+version: 3

--- a/.doc/3/controllers/server/now/snippets/now.test.yml
+++ b/.doc/3/controllers/server/now/snippets/now.test.yml
@@ -7,4 +7,4 @@ template: default
 expected: ^(Epoch-millis timestamp:) [0-9]{13}$
 
 sdk: go
-version: 1
+version: 3

--- a/.doc/3/core-structs/kuzzle-event-emitter/add-listener/snippets/add-listener.test.yml
+++ b/.doc/3/core-structs/kuzzle-event-emitter/add-listener/snippets/add-listener.test.yml
@@ -6,4 +6,4 @@ hooks:
 template: before-connect
 expected: "Connected to Kuzzle"
 sdk: go
-version: 1
+version: 3

--- a/.doc/3/core-structs/kuzzle-event-emitter/once/snippets/once.test.yml
+++ b/.doc/3/core-structs/kuzzle-event-emitter/once/snippets/once.test.yml
@@ -6,4 +6,4 @@ hooks:
 template: before-connect
 expected: "Connected to Kuzzle"
 sdk: go
-version: 1
+version: 3

--- a/.doc/3/core-structs/kuzzle-event-emitter/remove-all-listener/snippets/remove-all-listeners.test.yml
+++ b/.doc/3/core-structs/kuzzle-event-emitter/remove-all-listener/snippets/remove-all-listeners.test.yml
@@ -6,4 +6,4 @@ hooks:
 template: before-connect
 expected: Stopped listening
 sdk: go
-version: 1
+version: 3

--- a/.doc/3/core-structs/kuzzle-event-emitter/remove-listener/snippets/remove-listener.test.yml
+++ b/.doc/3/core-structs/kuzzle-event-emitter/remove-listener/snippets/remove-listener.test.yml
@@ -6,4 +6,4 @@ hooks:
 template: before-connect
 expected: Stopped listening
 sdk: go
-version: 1
+version: 3

--- a/.doc/3/core-structs/kuzzle/connect/snippets/connect.test.yml
+++ b/.doc/3/core-structs/kuzzle/connect/snippets/connect.test.yml
@@ -8,4 +8,4 @@ template: without-connect
 expected: Successfully connected
 
 sdk: go
-version: 1
+version: 3

--- a/.doc/3/core-structs/kuzzle/constructor/snippets/constructor.test.yml
+++ b/.doc/3/core-structs/kuzzle/constructor/snippets/constructor.test.yml
@@ -8,4 +8,4 @@ template: blank
 expected: Everything is ok
 
 sdk: go
-version: 1
+version: 3

--- a/.doc/3/core-structs/kuzzle/disconnect/snippets/disconnect.test.yml
+++ b/.doc/3/core-structs/kuzzle/disconnect/snippets/disconnect.test.yml
@@ -8,4 +8,4 @@ template: default
 expected: Success
 
 sdk: go
-version: 1
+version: 3

--- a/.doc/3/core-structs/kuzzle/flush-queue/snippets/flush-queue.test.yml
+++ b/.doc/3/core-structs/kuzzle/flush-queue/snippets/flush-queue.test.yml
@@ -8,4 +8,4 @@ template: without-connect
 expected: Success
 
 sdk: go
-version: 1
+version: 3

--- a/.doc/3/core-structs/kuzzle/play-queue/snippets/play-queue.test.yml
+++ b/.doc/3/core-structs/kuzzle/play-queue/snippets/play-queue.test.yml
@@ -8,4 +8,4 @@ template: without-connect
 expected: Success
 
 sdk: go
-version: 1
+version: 3

--- a/.doc/3/core-structs/kuzzle/query/snippets/query.test.yml
+++ b/.doc/3/core-structs/kuzzle/query/snippets/query.test.yml
@@ -9,4 +9,4 @@ template: default
 expected: Document created
 
 sdk: go
-version: 1
+version: 3

--- a/.doc/3/core-structs/kuzzle/start-queuing/snippets/start-queuing.test.yml
+++ b/.doc/3/core-structs/kuzzle/start-queuing/snippets/start-queuing.test.yml
@@ -8,4 +8,4 @@ template: without-connect
 expected: Success
 
 sdk: go
-version: 1
+version: 3

--- a/.doc/3/core-structs/kuzzle/stop-queuing/snippets/stop-queuing.test.yml
+++ b/.doc/3/core-structs/kuzzle/stop-queuing/snippets/stop-queuing.test.yml
@@ -8,4 +8,4 @@ template: without-connect
 expected: Success
 
 sdk: go
-version: 1
+version: 3

--- a/.doc/3/core-structs/search-result/snippets/search-result.go
+++ b/.doc/3/core-structs/search-result/snippets/search-result.go
@@ -8,11 +8,11 @@ for i := 5; i < 15; i++ {
     "category": "limousine"
   }`), nil)
 }
-kuzzle.Index.Refresh("nyc-open-data", nil)
+kuzzle.Collection.Refresh("nyc-open-data", "yellow-taxi", nil)
 
 options := types.NewQueryOptions()
 options.SetScroll("1m")
-options.SetSize(2)
+options.SetSize(4)
 
 response, err := kuzzle.Document.Search("nyc-open-data", "yellow-taxi", json.RawMessage(`{
   "query": {

--- a/.doc/3/core-structs/search-result/snippets/search-result.test.yml
+++ b/.doc/3/core-structs/search-result/snippets/search-result.test.yml
@@ -10,4 +10,4 @@ hooks:
 template: default
 expected: Successfully retrieved 4 documents
 sdk: go
-version: 1
+version: 3

--- a/.doc/3/essentials/error-handling/snippets/error-handling.go
+++ b/.doc/3/essentials/error-handling/snippets/error-handling.go
@@ -4,7 +4,7 @@ if err != nil {
   fmt.Println(err.Error())
 
   // Type assertion of error to KuzzleError
-  if err.(types.KuzzleError).Status == 400 {
+  if err.(types.KuzzleError).Status == 412 {
     fmt.Println("Try with another name!")
   }
 }

--- a/.doc/3/essentials/error-handling/snippets/error-handling.test.yml
+++ b/.doc/3/essentials/error-handling/snippets/error-handling.test.yml
@@ -1,10 +1,12 @@
 name: essentials#errorHandling
 description: How to handle SDK errors
 hooks:
-  before: curl -X POST kuzzle:7512/nyc-open-data/_create
+  before: |
+    curl -X DELETE kuzzle:7512/nyc-open-data
+    curl -X POST kuzzle:7512/nyc-open-data/_create
   after:
 template: default
 expected: Try with another name!
 
 sdk: go
-version: 1
+version: 3

--- a/.doc/3/essentials/getting-started/snippets/document.test.yml
+++ b/.doc/3/essentials/getting-started/snippets/document.test.yml
@@ -9,5 +9,5 @@ expected:
 - New document added to the yellow-taxi collection!
 
 sdk: go
-version: 1
+version: 3
 

--- a/.doc/3/essentials/getting-started/snippets/init.test.yml
+++ b/.doc/3/essentials/getting-started/snippets/init.test.yml
@@ -10,5 +10,5 @@ expected:
 - Collection yellow-taxi created!
 
 sdk: go
-version: 1
+version: 3
 

--- a/.doc/3/essentials/getting-started/snippets/realtime.test.yml
+++ b/.doc/3/essentials/getting-started/snippets/realtime.test.yml
@@ -10,5 +10,5 @@ expected:
 - Driver John born on 1995-11-27 got a B license.
 
 sdk: go
-version: 1
+version: 3
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ jobs:
   include:
     - name: Documentation test
       language: go
-      go: 1.14.x
+      go: 1.15.x
       script:
         - docker-compose -f .ci/doc/docker-compose.yml run doc-tests node index
 
@@ -16,12 +16,12 @@ jobs:
 # Linux amd64
 # -----------------------------------------------
 
-    - name: Linux amd64 - Go 1.14.x (with coverage)
+    - name: Linux amd64 - Go 1.15.x (with coverage)
       os: linux
       dist: xenial
       sudo: true
       language: go
-      go: 1.14.x
+      go: 1.15.x
       cache:
         directories:
         - "$HOME/.cache/go-build"
@@ -37,12 +37,12 @@ jobs:
 # Linux i386
 # -----------------------------------------------
 
-    - name: Linux i386 - Go 1.14.x
+    - name: Linux i386 - Go 1.15.x
       os: linux
       dist: xenial
       sudo: true
       language: go
-      go: 1.14.x
+      go: 1.15.x
       cache:
         directories:
         - "$HOME/.cache/go-build"
@@ -88,7 +88,7 @@ jobs:
 # Linux arm64
 # -----------------------------------------------
 
-    - name: Linux arm64 - Go 1.14.x
+    - name: Linux arm64 - Go 1.15.x
       os: linux
       dist: xenial
       sudo: true
@@ -97,7 +97,7 @@ jobs:
           packages:
           - qemu-user-static
       language: go
-      go: 1.14.x
+      go: 1.15.x
       cache:
         directories:
         - "$HOME/.cache/go-build"
@@ -131,7 +131,7 @@ jobs:
 # Linux armhf
 # -----------------------------------------------
 
-    - name: Linux armhf - Go 1.14.x
+    - name: Linux armhf - Go 1.15.x
       os: linux
       dist: xenial
       sudo: true
@@ -140,7 +140,7 @@ jobs:
           packages:
           - qemu-user-static
       language: go
-      go: 1.14.x
+      go: 1.15.x
       cache:
         directories:
         - "$HOME/.cache/go-build"
@@ -200,11 +200,11 @@ jobs:
 # MacOS amd64
 # -----------------------------------------------
 
-    - name: MacOS amd64 - Go 1.14.x
+    - name: MacOS amd64 - Go 1.15.x
       if: type = cron OR branch = master
       os: osx
       language: go
-      go: 1.14.x
+      go: 1.15.x
       cache:
         directories:
         - "$HOME/Library/Caches/go-build"
@@ -246,11 +246,11 @@ jobs:
 # MacOS i386
 # -----------------------------------------------
 
-    - name: MacOS i386 - Go 1.14.x
+    - name: MacOS i386 - Go 1.15.x
       if: type = cron OR branch = master
       os: osx
       language: go
-      go: 1.14.x
+      go: 1.15.x
       cache:
         directories:
         - "$HOME/Library/Caches/go-build"
@@ -292,11 +292,11 @@ jobs:
 # Windows amd64
 # -----------------------------------------------
 
-    - name: Windows amd64 - Go 1.14.x
+    - name: Windows amd64 - Go 1.15.x
       if: type = cron OR branch = master
       os: windows
       language: go
-      go: 1.14.x
+      go: 1.15.x
       script:
       - GOOS=windows
       - GOARCH=amd64
@@ -315,11 +315,11 @@ jobs:
 # Windows i386
 # -----------------------------------------------
 
-    - name: Windows i386 - Go 1.14.x
+    - name: Windows i386 - Go 1.15.x
       if: type = cron OR branch = master
       os: windows
       language: go
-      go: 1.14.x
+      go: 1.15.x
       script:
       - GOOS=windows
       - GOARCH=386
@@ -368,7 +368,7 @@ jobs:
     - stage: Tests
       name: Documentation test
       language: go
-      go: 1.14.x
+      go: 1.15.x
       script:
         - docker-compose -f .ci/doc/docker-compose.yml run doc-tests node index
 

--- a/collection/refresh.go
+++ b/collection/refresh.go
@@ -15,33 +15,26 @@
 package collection
 
 import (
-	"encoding/json"
-
 	"github.com/kuzzleio/sdk-go/types"
 )
 
-// ValidateSpecifications validates the provided specifications.
-func (dc *Collection) ValidateSpecifications(index string, collection string, specifications json.RawMessage, options types.QueryOptions) (*types.ValidationResponse, error) {
+// Create creates a new empty data collection
+func (dc *Collection) Refresh(index string, collection string, options types.QueryOptions) error {
 	if index == "" {
-		return nil, types.NewError("Collection.ValidateSpecifications: index required", 400)
+		return types.NewError("Collection.Create: index required", 400)
 	}
 
 	if collection == "" {
-		return nil, types.NewError("Collection.ValidateSpecifications: collection required", 400)
-	}
-
-	if specifications == nil {
-		return nil, types.NewError("Collection.ValidateSpecifications: specifications required", 400)
+		return types.NewError("Collection.Create: collection required", 400)
 	}
 
 	ch := make(chan *types.KuzzleResponse)
 
 	query := &types.KuzzleRequest{
-		Controller: "collection",
-		Action:     "validateSpecifications",
-		Index:      index,
 		Collection: collection,
-		Body:       specifications,
+		Index:      index,
+		Controller: "collection",
+		Action:     "refresh",
 	}
 
 	go dc.Kuzzle.Query(query, options, ch)
@@ -49,14 +42,8 @@ func (dc *Collection) ValidateSpecifications(index string, collection string, sp
 	res := <-ch
 
 	if res.Error.Error() != "" {
-		return nil, res.Error
+		return res.Error
 	}
 
-	vr, err := types.NewValidationResponse(res.Result)
-
-	if err != nil {
-		return nil, err
-	}
-
-	return vr, nil
+	return nil
 }

--- a/collection/refresh_test.go
+++ b/collection/refresh_test.go
@@ -1,0 +1,72 @@
+// Copyright 2015-2018 Kuzzle
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 		http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package collection_test
+
+import (
+	"testing"
+
+	"github.com/kuzzleio/sdk-go/collection"
+	"github.com/kuzzleio/sdk-go/internal"
+	"github.com/kuzzleio/sdk-go/kuzzle"
+	"github.com/kuzzleio/sdk-go/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRefreshIndexNull(t *testing.T) {
+	k, _ := kuzzle.NewKuzzle(&internal.MockedConnection{}, nil)
+	nc := collection.NewCollection(k)
+	err := nc.Refresh("", "collection", nil)
+	assert.NotNil(t, err)
+}
+
+func TestRefreshCollectionNull(t *testing.T) {
+	k, _ := kuzzle.NewKuzzle(&internal.MockedConnection{}, nil)
+	nc := collection.NewCollection(k)
+	err := nc.Refresh("index", "", nil)
+	assert.NotNil(t, err)
+}
+func TestRefreshError(t *testing.T) {
+	c := &internal.MockedConnection{
+		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
+			return &types.KuzzleResponse{Error: types.NewError("Unit test error")}
+		},
+	}
+	k, _ := kuzzle.NewKuzzle(c, nil)
+
+	nc := collection.NewCollection(k)
+	err := nc.Refresh("index", "collection", nil)
+	assert.NotNil(t, err)
+	assert.Equal(t, "Unit test error", err.(types.KuzzleError).Message)
+}
+
+func TestRefresh(t *testing.T) {
+	c := &internal.MockedConnection{
+		MockSend: func(query []byte, options types.QueryOptions) *types.KuzzleResponse {
+			return &types.KuzzleResponse{Result: []byte(`{
+				"status":200,
+				"error": null,
+				"index": "index",
+				"collection": "collection",
+				"action": "refresh",
+				"result": null
+			}`)}
+		},
+	}
+	k, _ := kuzzle.NewKuzzle(c, nil)
+
+	nc := collection.NewCollection(k)
+	err := nc.Refresh("index", "collection", nil)
+	assert.Nil(t, err)
+}

--- a/collection/update_specifications.go
+++ b/collection/update_specifications.go
@@ -16,7 +16,6 @@ package collection
 
 import (
 	"encoding/json"
-	"fmt"
 
 	"github.com/kuzzleio/sdk-go/types"
 )
@@ -37,20 +36,12 @@ func (dc *Collection) UpdateSpecifications(index string, collection string, spec
 
 	ch := make(chan *types.KuzzleResponse)
 
-	body := make(map[string]map[string]json.RawMessage)
-	body[index] = make(map[string]json.RawMessage)
-	body[index][collection] = specifications
-
-	jsonBody, err := json.Marshal(body)
-
-	if err != nil {
-		return nil, types.NewError(fmt.Sprintf("Unable to construct body: %s\n", err.Error()), 500)
-	}
-
 	query := &types.KuzzleRequest{
 		Controller: "collection",
 		Action:     "updateSpecifications",
-		Body:       json.RawMessage(jsonBody),
+		Index:      index,
+		Collection: collection,
+		Body:       specifications,
 	}
 
 	go dc.Kuzzle.Query(query, options, ch)

--- a/document/update.go
+++ b/document/update.go
@@ -23,7 +23,7 @@ import (
 // Update updates a document in Kuzzle.
 func (d *Document) Update(index string, collection string, id string, body json.RawMessage, options types.QueryOptions) (json.RawMessage, error) {
 	if id == "" {
-		return nil, types.NewError("Document.update: id required", 400)
+		return nil, types.NewError("Document.Update: id required", 400)
 	}
 
 	if index == "" {

--- a/index/mDelete.go
+++ b/index/mDelete.go
@@ -47,9 +47,11 @@ func (i *Index) MDelete(indexes []string, options types.QueryOptions) ([]string,
 	}
 
 	var deletedIndexes struct {
-		Deleted []string
+		Deleted []string `json:"deleted"`
 	}
-
+	data, _ := json.Marshal(&body{indexes})
+	fmt.Printf("|%s|\n", data)
+	fmt.Printf("|%s|\n", res.Result)
 	err := json.Unmarshal(res.Result, &deletedIndexes)
 	if err != nil {
 		return nil, types.NewError(fmt.Sprintf("Unable to parse response: %s\n%s", err.Error(), res.Result), 500)


### PR DESCRIPTION
<!--
  This template is optional.
  It simply serves to provide a guide to allow a better review of pull requests.
-->

<!--
  IMPORTANT
  Don't forget to add the corresponding "changelog:xxx" label to your PR.
  This is part of our release process in order to generate the change log.
-->


## What does this PR do?
<!-- Please fill this section -->
- Fix CI docker-compose that was working with Kuzzle V1 and not Kuzzle V2
- Update doc snippets version from 1 to 3
- Fix snippets that were broken, and not detected because of a bug in the CI docker-compose
- Update travis version from 1.14.x to 1.15.x
