### PR TITLE
[CI] Fix issue while deploying dev-docs with GA

### DIFF
--- a/.github/actions/doc-deploy/action.yml
+++ b/.github/actions/doc-deploy/action.yml
@@ -38,7 +38,7 @@ runs:
         npm run doc-build
       env:
         NODE_ENV: production
-        BRANCH: ${{ inputs.FRAMEWORK_BRANCH }}
+        FRAMEWORK_BRANCH: ${{ inputs.FRAMEWORK_BRANCH }}
       shell: bash
     - name: Deploy documentation
       run: |

--- a/.github/workflows/push_dev.workflow.yml
+++ b/.github/workflows/push_dev.workflow.yml
@@ -157,7 +157,7 @@ jobs:
             ${{ runner.os }}-
       - uses: actions/setup-node@v1
         with:
-          node-version: "10"
+          node-version: "12"
       - uses: ./.github/actions/doc-deploy
         with:
           REGION: us-west-2


### PR DESCRIPTION
This PR try to fix an issue related to The step deploy-doc of this https://github.com/kuzzleio/sdk-go/actions/runs/503248406


Changes

* Correct wrongly named Key `BRANCH` instead of `FRAMEWORK_BRANCH`
* Use Node 12 instead of Node 10 for the related deploy-doc job